### PR TITLE
DRY version number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), failure::Error> {
     let cache = Cache::new("wrangler")?;
 
     let matches = App::new("👷‍♀️🧡☁️ ✨ wrangler")
-        .version("0.1.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("ashley g williams <ashley666ashley@gmail.com>")
         .subcommand(
             SubCommand::with_name("generate")


### PR DESCRIPTION
Current version prints `👷‍♀️🧡☁️ ✨ wrangler 0.1.0` to the console even if `Cargo.toml` and current git tag say it should be at `0.1.1`.

This PR tries to fix this by reading the current version through `env!("CARGO_PKG_VERSION")`. This is 100% Stackoverflow "Knowledge" (https://stackoverflow.com/a/27841363) and I'm a rust newbie so if there is a better way to do it, please let me know.