### PR TITLE
Use existing get_wrangler_cache function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,18 @@
 use std::str::FromStr;
 
-use binary_install::Cache;
+use cache::get_wrangler_cache;
 use clap::{App, Arg, SubCommand};
 use commands::HTTPMethod;
 use settings::Settings;
 
+mod cache;
 mod commands;
 mod install;
 mod settings;
 
 fn main() -> Result<(), failure::Error> {
     env_logger::init();
-    let cache = Cache::new("wrangler")?;
+    let cache = get_wrangler_cache()?;
 
     let matches = App::new("👷‍♀️🧡☁️ ✨ wrangler")
         .version("0.1.0")


### PR DESCRIPTION
Looking through the source (and learninf from it), I found the unused function `get_wrangler_cache`.

This PR uses it from within main. It should be no breaking change, because internally it creates the same `Cache` as `main` did, if the env `WRANGLER_CACHE` is not found.