### PR TITLE
fix(generate): Fix generate process on windows

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -24,7 +24,6 @@ pub fn command(cmd: &str, name: &str) -> Command {
 
     if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");
-        c.arg(cmd);
         c.args(&["/C", cmd]);
         c
     } else {


### PR DESCRIPTION
Hey there, I found just one more problem on when executing `wrangler generate` on a windows machine.
It would call the subcommand as `cmd cargo-generate ... /C cargo-generate ...` and this message would appear:

```
[2019-04-07T16:44:44Z INFO  wrangler::commands] Running "cmd" "C:\\Users\\jayson\\AppData\\Local\\.wrangler\\cargo-generate-3d90bda9894e61ab\\cargo-generate.exe generate --git https://github.com/cloudflare/rustwasm-worker-template --name wasm-worker" "/C" "C:\\Users
\\jayson\\AppData\\Local\\.wrangler\\cargo-generate-3d90bda9894e61ab\\cargo-generate.exe generate --git https://github.com/cloudflare/rustwasm-worker-template --name wasm-worker"
'loudflare' is not recognized as an internal or external command,
operable program or batch file.
Error: ErrorMessage { msg: "failed to execute `C:\\Users\\jayson\\AppData\\Local\\.wrangler\\cargo-generate-3d90bda9894e61ab\\cargo-generate.exe generate --git https://github.com/cloudflare/rustwasm-worker-template --name wasm-worker`: exited with exit code: 1" }
wrangler master *% > $ 
```