### PR TITLE
Handle wasm-pack installation when using Webpack

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -21,12 +21,16 @@ pub fn build(cache: &Cache, project_type: &ProjectType) -> Result<(), failure::E
             commands::run(command, &command_name)?;
         }
         ProjectType::Webpack => {
+            let wasm_pack_path =
+                install::install("wasm-pack", "rustwasm", cache)?.binary("wasm-pack")?;
+
             if !wranglerjs::is_installed() {
                 println!("missing deps; installing...");
                 wranglerjs::install().expect("could not install wranglerjs");
             }
 
-            let wranglerjs_output = wranglerjs::run_build().expect("could not run wranglerjs");
+            let wranglerjs_output =
+                wranglerjs::run_build(wasm_pack_path).expect("could not run wranglerjs");
             let bundle = wranglerjs::Bundle::new();
             let out = wranglerjs_output.compiler_output();
 

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -93,12 +93,13 @@ fn executable_path() -> PathBuf {
         .join("wrangler-js")
 }
 
-pub fn run_build() -> Result<WrangerjsOutput, failure::Error> {
+pub fn run_build(wasm_pack_path: PathBuf) -> Result<WrangerjsOutput, failure::Error> {
     if !Path::new(BUNDLE_OUT).exists() {
         fs::create_dir(BUNDLE_OUT)?;
     }
 
     let output = Command::new(executable_path())
+        .env("WASM_PACK_PATH", wasm_pack_path)
         .output()
         .expect("failed to execute process");
     println!("{}", String::from_utf8_lossy(&output.stderr));

--- a/wrangler-js/index.js
+++ b/wrangler-js/index.js
@@ -6,7 +6,7 @@ const config = require(join(process.cwd(), "./webpack.config.js"));
 
 let compilerOutput = "";
 const oldConsoleLog = console.log;
-console.log = msg => compilerOutput += msg;
+console.log = (...msg) => compilerOutput += msg.join(" ");
 
 const compiler = webpack(config);
 


### PR DESCRIPTION
Since https://github.com/wasm-tool/wasm-pack-plugin/commit/708ff859b563f34c4832874c8ad64497ba39a349,
we can pass the {wasm-pack} binary path in the environment.