### PR TITLE
fix(gen): don't rename to match rust conventions

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -8,7 +8,7 @@ pub fn generate(name: &str, template: &str, cache: &Cache) -> Result<(), failure
     let tool_name = "cargo-generate";
     let binary_path = install::install(tool_name, "ashleygwilliams", cache)?.binary(tool_name)?;
 
-    let args = ["generate", "--git", template, "--name", name];
+    let args = ["generate", "--git", template, "--name", name, "--force"];
 
     let project_type = project_type(template);
     let command = command(name, binary_path, &args, &project_type);


### PR DESCRIPTION
fixes #100 

there's still a bit of a bug, though it's more messaging than functional. it's upstream in cargo-generate and i'll be fixing it before launch. https://github.com/ashleygwilliams/cargo-generate/issues/158