### PR TITLE
Improve error for package.main

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -2,6 +2,7 @@ use crate::user::settings::ProjectType;
 use crate::wranglerjs;
 use crate::{commands, install};
 use binary_install::Cache;
+use log::info;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -29,7 +30,7 @@ pub fn build(cache: &Cache, project_type: &ProjectType) -> Result<(), failure::E
             wranglerjs::run_npm_install().expect("could not run `npm install`");
 
             if !wranglerjs::is_installed() {
-                println!("missing deps; installing...");
+                info!("missing deps; installing...");
                 wranglerjs::install().expect("could not install wranglerjs");
             }
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -88,7 +88,7 @@ fn publish_script(user: &User, name: &str) -> Result<(), failure::Error> {
 
 fn build_js_script() -> Result<String, failure::Error> {
     let package = Package::new("./")?;
-    Ok(fs::read_to_string(package.main)?)
+    Ok(fs::read_to_string(package.main()?)?)
 }
 
 fn build_multipart_script() -> Result<Form, failure::Error> {

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -5,7 +5,19 @@ use serde::{self, Deserialize};
 
 #[derive(Debug, Deserialize)]
 pub struct Package {
-    pub main: String,
+    #[serde(default)]
+    main: String,
+}
+impl Package {
+    pub fn main(&self) -> Result<String, failure::Error> {
+        if self.main == "" {
+            failure::bail!(
+                "The `main` key in your `package.json` file is required; please specified the entrypoint of your Worker.",
+            )
+        } else {
+            Ok(self.main.clone())
+        }
+    }
 }
 
 impl Package {

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -140,7 +140,11 @@ pub fn run_build(
     if !bundle.has_webpack_config() {
         let package = Package::new("./")?;
         let current_dir = env::current_dir()?;
-        let package_main = current_dir.join(package.main).to_str().unwrap().to_string();
+        let package_main = current_dir
+            .join(package.main()?)
+            .to_str()
+            .unwrap()
+            .to_string();
         command.arg("--no-webpack-config=1");
         command.arg(format!("--use-entry={}", package_main));
     }


### PR DESCRIPTION
Add an error when the main key in not present in the package.json file.
This logic is used for project of types: Webpack and JavaScript.

Closes https://github.com/cloudflare/wrangler/issues/122