### PR TITLE
Make dist_to_clean optional and remove wasm_name

### DIFF
--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -14,12 +14,11 @@ use std::process::Command;
 #[derive(Deserialize, Debug)]
 pub struct WranglerjsOutput {
     wasm: Option<String>,
-    wasm_name: String,
     script: String,
     // {wrangler-js} will send us the path to the {dist} directory that {Webpack}
     // used; it's tedious to remove a directory with content in JavaScript so
     // let's do it in Rust!
-    dist_to_clean: String,
+    dist_to_clean: Option<String>,
 }
 
 impl WranglerjsOutput {}
@@ -54,9 +53,11 @@ impl Bundle {
 
         script_file.write_all(script.as_bytes())?;
 
-        // cleanup {Webpack} dist.
-        info!("Remove {}", wranglerjs_output.dist_to_clean);
-        fs::remove_dir_all(wranglerjs_output.dist_to_clean).expect("could not clean Webpack dist.");
+        // cleanup {Webpack} dist, if specified.
+        if let Some(dist_to_clean) = wranglerjs_output.dist_to_clean {
+            info!("Remove {}", dist_to_clean);
+            fs::remove_dir_all(dist_to_clean).expect("could not clean Webpack dist.");
+        }
 
         Ok(())
     }

--- a/wrangler-js/index.js
+++ b/wrangler-js/index.js
@@ -62,8 +62,7 @@ compiler.run((err, stats) => {
   const assets = stats.compilation.assets;
   const bundle = {
     wasm: null,
-    wasm_name: "",
-    script: null,
+    script: "",
     dist_to_clean: fullConfig.output.path
   };
 
@@ -78,7 +77,6 @@ compiler.run((err, stats) => {
 
   if (hasWasmModule === true) {
     bundle.wasm = Buffer.from(assets[wasmModuleAsset].source()).toString();
-    bundle.wasm_name = wasmModuleAsset;
   }
 
   writeFileSync(args["output-file"], JSON.stringify(bundle));


### PR DESCRIPTION
Optional {dist_to_clean} is used in the tests, wranglerjs will always
send back Webpack's dist directory.

{wasm_name} was used for the previous used Fetch polyfill. However this
assumes that only one Wasm module is present per Worker.