### PR TITLE
Fix typo in build output for JS projects

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -11,7 +11,7 @@ use crate::emoji;
 pub fn build(cache: &Cache, project_type: &ProjectType) -> Result<(), failure::Error> {
     match project_type {
         ProjectType::JavaScript => {
-            println!("⚠️ JavaScript project found. Skipping unecessary build!")
+            println!("⚠️ JavaScript project found. Skipping unnecessary build!")
         }
         ProjectType::Rust => {
             let tool_name = "wasm-pack";


### PR DESCRIPTION
`s/unecessary/unnecessary`