### PR TITLE
Show command help when given no arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::str::FromStr;
 
 use cache::get_wrangler_cache;
-use clap::{App, Arg, SubCommand};
+use clap::{App, AppSettings, Arg, SubCommand};
 use commands::HTTPMethod;
 
 use log::info;
@@ -35,6 +35,7 @@ fn main() -> Result<(), failure::Error> {
     let matches = App::new(format!("{}{} wrangler", emoji::WORKER, emoji::SPARKLES))
         .version(env!("CARGO_PKG_VERSION"))
         .author("ashley g williams <ashley666ashley@gmail.com>")
+        .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("generate")
                 .about(&*format!(


### PR DESCRIPTION
Running just `wrangler` with no arguments will show the command help
(same output as `wrangler help`). 