### PR TITLE
properly invoke npm on windows

### DIFF
--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -119,7 +119,8 @@ pub fn run_build(
     wasm_pack_path: PathBuf,
     bundle: &Bundle,
 ) -> Result<WranglerjsOutput, failure::Error> {
-    let mut command = Command::new(executable_path());
+    let mut command = Command::new("node");
+    command.arg(executable_path());
     command.env("WASM_PACK_PATH", wasm_pack_path);
 
     // create temp file for special {wrangler-js} IPC.


### PR DESCRIPTION
This is an attempt to fix #140; it now properly invokes `npm`, but there's still another error:

```text
---- it_builds_with_webpack_single_js stdout ----
dir: "C:\\Users\\STEVEK~1\\AppData\\Local\\Temp\\webpack_simple_js"
thread 'it_builds_with_webpack_single_js' panicked at 'Unexpected failure.
code-101
stderr=```npm WARN webpack_simple_js No description
npm WARN webpack_simple_js No repository field.
npm WARN webpack_simple_js No license field.

npm WARN webpack_simple_js No description
npm WARN webpack_simple_js No repository field.
npm WARN webpack_simple_js No license field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.9 (node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.9: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"
})

thread 'main' panicked at 'could not run wranglerjs: Os { code: 193, kind: Other, message: "%1 is not a valid Win32 application." }', src\libcore\result.rs:997
:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```