### PR TITLE
fix(webpack): generate valid json

### DIFF
--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -231,9 +231,9 @@ fn create_metadata(bundle: &Bundle) -> String {
         .to_string()
     } else {
         r#"
-                {{
+                {
                     "body_part": "script"
-                }}
+                }
             "#
         .to_string()
     }


### PR DESCRIPTION
refs #150 

didn't touch the wasm json because i... literally don't know what happens when you pass a raw string literal to format