### PR TITLE
initial kv namespace support

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -46,7 +46,7 @@ pub fn create_kv_namespaces(user: &GlobalUser, project: &Project) -> Result<(), 
 
     if let Some(namespaces) = &project.kv_namespaces {
         for namespace in namespaces {
-            info!("Attempting to create namesapce '{}'", namespace);
+            info!("Attempting to create namespace '{}'", namespace);
 
             let mut map = HashMap::new();
             map.insert("title", namespace);

--- a/src/settings/project.rs
+++ b/src/settings/project.rs
@@ -19,6 +19,8 @@ pub struct Project {
     pub account_id: String,
     pub route: Option<String>,
     pub routes: Option<HashMap<String, String>>,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -69,6 +71,7 @@ impl Project {
             account_id: String::new(),
             route: Some(String::new()),
             routes: None,
+            kv_namespaces: None,
         };
 
         let toml = toml::to_string(&project)?;


### PR DESCRIPTION
* set your namespaces in wrangler.toml
* attempt to create them upon publish
* If they exist, don't worry about it

So, this doesn't address #92 yet, because you need to modify your worker's `worker/metadata_wasm.json`. However, since we're mostly doing this to get docs upload working, rather than KV as a general feature, it's good to go.

EDIT: ignore the rest of the discussion on this PR, as it's now invalid.