### PR TITLE
ux: add HTTP prefix to publish command output.

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -172,7 +172,7 @@ fn make_public_on_subdomain(project: &Project, user: &GlobalUser) -> Result<(), 
 
     if res.status().is_success() {
         println!(
-            "🥳 Successfully made your script available at {}.{}.workers.dev",
+            "🥳 Successfully made your script available at https://{}.{}.workers.dev",
             project.name, subdomain
         );
     } else {


### PR DESCRIPTION
Prefix "https://" in front of the "script available" output to allow shells to automatically detect it as a link.

This was the only relevant instance - e.g. other instances are typically referring to the domain structure, and not a deployed script.

```sh
/mnt/c/Users/Gamer/repos/wrangler (master) ✔ ➜  rg '\.workers\.dev'
README.md
63:    By default, `publish` will make your worker available at `<project-name>.<subdomain>.workers.dev`.
66:    explicitly enable deployment to `<project-name>.<subdomain>.workers.dev`, you can set `private = false`. 
npm/README.md
63:    By default, `publish` will make your worker available at `<project-name>.<subdomain>.workers.dev`.
66:    explicitly enable deployment to `<project-name>.<subdomain>.workers.dev`, you can set `private = false`. 
src/commands/subdomain.rs
65:        "{} Registering your subdomain, {}.workers.dev, this could take up to a minute.",
92:                "⛔ This account already has a registered subdomain. You can only register one subdomain per account. Your subdomain is {}.workers.dev \n Status Code: {}\n Msg: {}",
src/commands/publish/mod.rs
175:            "🥳 Successfully made your script available at {}.{}.workers.dev",
```
