### PR TITLE
Follow operating system config location standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
     In Cloudflare's system, you have a User that can have multiple Accounts and Zones. As a result, your User
     is configured globally on your machine. Your Account(s) and Zone(s) will be configured per project, but
-    will use your User credentials to authenticate all API calls. This config file is created in a `.wrangler`
-    directory in your computer's home directory.
+    will use your User credentials to authenticate all API calls. This config file is created in the `wrangler`
+    directory under the [standard configuration location of your operating system](https://docs.rs/dirs/latest/dirs/fn.config_dir.html).
 
     To set up `wrangler` to work with your Cloudflare user, use the following commands:
 

--- a/npm/install-wrangler.js
+++ b/npm/install-wrangler.js
@@ -7,8 +7,11 @@ const rimraf = require("rimraf");
 const tar = require("tar");
 const { get } = axios;
 const { homedir } = require('os');
+const envPaths = require('env-paths');
 
-const cwd = join(homedir(), ".wrangler");
+let cwd;
+const legacyCwd = join(homedir(), ".wrangler");
+const newCwd = envPaths('wrangler', { suffix: '' }).config;
 
 function getLatestRelease() {
   return get("https://api.github.com/repos/cloudflare/wrangler/releases/latest")
@@ -56,8 +59,14 @@ function downloadAsset(asset) {
   });
 }
 
-if (!existsSync(cwd)) {
-  mkdirSync(cwd);
+if (existsSync(legacyCwd)) {
+  cwd = legacyCwd;
+} else {
+  cwd = newCwd;
+
+  if (!existsSync(cwd)) {
+    mkdirSync(cwd);
+  }
 }
 
 getLatestRelease()

--- a/npm/package.json
+++ b/npm/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/cloudflare/wrangler#readme",
   "dependencies": {
     "axios": "^0.18.0",
+    "env-paths": "^2.2.0",
     "rimraf": "^2.6.3",
     "tar": "^4.4.8"
   }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -13,14 +13,13 @@ pub fn global_config(email: &str, api_key: &str) -> Result<(), failure::Error> {
 
     let toml = toml::to_string(&s)?;
 
-    let config_dir = Path::new(&dirs::home_dir().unwrap_or_else(|| {
+    let config_dir = Path::new(&GlobalUser::config_directory().unwrap_or_else(|| {
         panic!(
-            "{0} could not determine home directory. {0}",
+            "{0} could not determine config directory. {0}",
             emoji::CONSTRUCTION
         )
     }))
-    .join(".wrangler")
-    .join("config");
+    .to_owned();
     fs::create_dir_all(&config_dir)?;
 
     let config_file = config_dir.join("default.toml");

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -20,7 +20,7 @@ impl GlobalUser {
 
 fn get_global_config_directory() -> Option<PathBuf> {
     let legacy_directory = dirs::home_dir()
-        .expect("oops no home dir")
+        .unwrap_or(PathBuf::from("/"))
         .join(".wrangler")
         .join("config");
 

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -1,6 +1,7 @@
 use config::{Config, Environment, File};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use log::info;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GlobalUser {
@@ -26,8 +27,10 @@ fn get_global_config_directory() -> Option<PathBuf> {
     let directory;
     if legacy_directory.exists() {
         directory = Some(legacy_directory);
+        info!("using legacy config directory {:?}", directory);
     } else {
         directory = dirs::config_dir().map(|p| p.join("wrangler"));
+        info!("using standard config directory {:?}", directory);
     }
 
     directory

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -18,14 +18,14 @@ impl GlobalUser {
 }
 
 fn get_global_config_directory() -> Option<PathBuf> {
-    let deprecated_directory = dirs::home_dir()
+    let legacy_directory = dirs::home_dir()
         .expect("oops no home dir")
         .join(".wrangler")
         .join("config");
 
     let directory;
-    if deprecated_directory.exists() {
-        directory = Some(deprecated_directory);
+    if legacy_directory.exists() {
+        directory = Some(legacy_directory);
     } else {
         directory = dirs::config_dir().map(|p| p.join("wrangler"));
     }

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -1,7 +1,7 @@
 use config::{Config, Environment, File};
+use log::info;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use log::info;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GlobalUser {
@@ -20,7 +20,7 @@ impl GlobalUser {
 
 fn get_global_config_directory() -> Option<PathBuf> {
     let legacy_directory = dirs::home_dir()
-        .unwrap_or(PathBuf::from("/"))
+        .unwrap_or_else(|| PathBuf::from("/"))
         .join(".wrangler")
         .join("config");
 


### PR DESCRIPTION
Write configuration to a operating system config directory instead of
the home directory according to the XDG Base Directory Specification.

Closes #180