### PR TITLE
Support publishing multiple routes

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -32,7 +32,7 @@ pub fn publish(user: &GlobalUser, project: &Project, release: bool) -> Result<()
         info!("release mode detected, publishing routes...");
         let routes = ProjectRoutes::new(&project)?;
         routes.publish(&user, &project)?;
-        println!(
+        let msg = format!(
             "✨ Success! Your worker was successfully published. You can view it at:\n - {}\n✨",
             routes.patterns().join("\n - ")
         );

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1,7 +1,7 @@
 mod krate;
 pub mod preview;
 mod route;
-use route::Route;
+use route::ProjectRoutes;
 
 pub mod package;
 use package::Package;
@@ -29,12 +29,12 @@ pub fn publish(user: &GlobalUser, project: &Project, release: bool) -> Result<()
     create_kv_namespaces(user, &project)?;
     publish_script(&user, &project, release)?;
     if release {
-        info!("release mode detected, making a route...");
-        let route = Route::new(&project)?;
-        Route::publish(&user, &project, &route)?;
-        let msg = format!(
-            "Success! Your worker was successfully published. You can view it at {}.",
-            &route.pattern
+        info!("release mode detected, publishing routes...");
+        let routes = ProjectRoutes::new(&project)?;
+        routes.publish(&user, &project)?;
+        println!(
+            "✨ Success! Your worker was successfully published. You can view it at:\n - {}\n✨",
+            routes.patterns().join("\n - ")
         );
         message::success(&msg);
     } else {

--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use log::info;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Route {
     script: Option<String>,
     pub pattern: String,
@@ -17,51 +17,117 @@ struct RoutesResponse {
     result: Vec<Route>,
 }
 
-impl Route {
-    pub fn new(project: &Project) -> Result<Route, failure::Error> {
-        if project
-            .route
-            .clone()
-            .expect("You must provide a zone_id in your wrangler.toml before publishing!")
-            .is_empty()
-        {
-            failure::bail!("You must provide a zone_id in your wrangler.toml before publishing!");
-        }
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ProjectRoutes {
+    routes: Vec<Route>,
+}
 
-        Ok(Route {
-            script: Some(project.name.to_string()),
-            pattern: project.route.clone().expect("⚠️ Your project config has an error, check your `wrangler.toml`: `route` must be provided.").to_string(),
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct RoutesDiff {
+    added: Vec<Route>,
+    modified: Vec<Route>,
+    // remotes: Vec<Route>, // TODO: turn into a HashMap for easy lookup by pattern
+    // removed: Option<Vec<Route>>,
+}
+
+impl ProjectRoutes {
+    pub fn new(project: &Project) -> Result<ProjectRoutes, failure::Error> {
+        Ok(ProjectRoutes {
+            routes: get_local_routes(project)
+                .expect("Could not get local routes from wranger.toml"),
         })
     }
 
-    pub fn publish(
-        user: &GlobalUser,
-        project: &Project,
-        route: &Route,
-    ) -> Result<(), failure::Error> {
-        if route.exists(user, project)? {
-            return Ok(());
-        }
-        create(user, project, route)
+    // patterns returns all patterns listed in this config
+    pub fn patterns(&self) -> Vec<String> {
+        return self
+            .routes
+            .iter()
+            .map(|r| r.pattern.clone())
+            .collect::<Vec<String>>();
     }
 
-    pub fn exists(&self, user: &GlobalUser, project: &Project) -> Result<bool, failure::Error> {
-        let routes = get_routes(user, project)?;
-
-        for route in routes {
-            if route.matches(self) {
-                return Ok(true);
-            }
+    // publish syncs our locally defined routes with Cloudflare
+    // creating, updating or deleting routes as necessary
+    // TODO: needs to be rethought along with diff
+    pub fn publish(&self, user: &GlobalUser, project: &Project) -> Result<(), failure::Error> {
+        let diff = self.diff(user, project)?;
+        // Add new routes
+        for route in diff.added {
+            create(user, project, &route)?;
         }
-        Ok(false)
+        // Modify existing routes (patterns pointing to a different script)
+        for route in diff.modified {
+            println!(
+                "⚠️ Wrangler can't yet sync modified routes: '{pattern}' -> '{script}'",
+                pattern = route.pattern,
+                script = route.script.unwrap_or_default()
+            )
+        }
+        Ok(())
     }
 
+    // diffs local and remote diffs
+    // TODO: the original code was designed to only add paths which might get messy
+    // the whole route-sync logic needs to be rethought IMHO
+    pub fn diff(&self, user: &GlobalUser, project: &Project) -> Result<RoutesDiff, failure::Error> {
+        let remote_routes = get_remote_routes(user, project)?;
+        // Routes to be created (defined locally, but no-matching remote pattern)
+        let new_routes = self
+            .routes
+            .iter()
+            .filter(|r| !remote_routes.iter().any(|rr| r.pattern == rr.pattern))
+            .cloned()
+            .collect::<Vec<Route>>();
+        // Routes to be modified (pattern existed, but is routed to a different script)
+        let modified_routes = self
+            .routes
+            .iter()
+            .filter(|r| !remote_routes.iter().any(|rr| r.pattern == rr.pattern))
+            .cloned()
+            .collect::<Vec<Route>>();
+        // Diff
+        // TODO: explore delete (see above comments on publish/diff)
+        Ok(RoutesDiff {
+            added: new_routes,
+            modified: modified_routes,
+            // remotes: remote_routes,
+        })
+    }
+}
+
+impl Route {
     pub fn matches(&self, route: &Route) -> bool {
         self.pattern == route.pattern && self.script == route.script
     }
 }
 
-fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failure::Error> {
+fn get_local_routes(project: &Project) -> Result<Vec<Route>, failure::Error> {
+    let mut routes: Vec<Route> = vec![];
+    if project.route.is_some() {
+        // Single route
+        routes = vec![Route {
+            script: Some(project.name.to_string()),
+            pattern: project.route.clone().unwrap().to_string(),
+        }];
+    } else if project.routes.is_some() && (project.routes.clone().unwrap().len() > 0) {
+        // Build routes from project's HashMap
+
+        for (pattern, script) in project.routes.clone().unwrap().iter() {
+            routes.push(Route {
+                script: Some(script.to_string()),
+                pattern: pattern.to_string(),
+            })
+        }
+    } else {
+        failure::bail!(
+            "You must provide a route or routes in your wrangler.toml before publishing!"
+        );
+    }
+    return Ok(routes);
+}
+
+fn get_remote_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failure::Error> {
     let routes_addr = get_routes_addr(project)?;
 
     let client = http::auth_client(user);
@@ -82,6 +148,7 @@ fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failur
     Ok(routes_response.result)
 }
 
+// Create or update a route
 fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), failure::Error> {
     let client = http::auth_client(user);
     let body = serde_json::to_string(&route)?;
@@ -113,5 +180,5 @@ fn get_routes_addr(project: &Project) -> Result<String, failure::Error> {
             zone_id
         ));
     }
-    failure::bail!("You much provide a zone_id in your wrangler.toml.")
+    failure::bail!("You must provide a zone_id in your wrangler.toml.")
 }

--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -1,4 +1,5 @@
 use crate::http;
+use std::collections::HashMap;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Project;
 use reqwest::header::CONTENT_TYPE;
@@ -8,6 +9,7 @@ use log::info;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Route {
+    id: Option<String>, // ID if remote
     script: Option<String>,
     pub pattern: String,
 }
@@ -19,6 +21,7 @@ struct RoutesResponse {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ProjectRoutes {
+    script: String,
     routes: Vec<Route>,
 }
 
@@ -26,13 +29,13 @@ pub struct ProjectRoutes {
 pub struct RoutesDiff {
     added: Vec<Route>,
     modified: Vec<Route>,
-    // remotes: Vec<Route>, // TODO: turn into a HashMap for easy lookup by pattern
-    // removed: Option<Vec<Route>>,
+    deleted: Vec<Route>,
 }
 
 impl ProjectRoutes {
     pub fn new(project: &Project) -> Result<ProjectRoutes, failure::Error> {
         Ok(ProjectRoutes {
+            script: project.name.clone(),
             routes: get_local_routes(project)
                 .expect("Could not get local routes from wranger.toml"),
         })
@@ -49,14 +52,26 @@ impl ProjectRoutes {
 
     // publish syncs our locally defined routes with Cloudflare
     // creating, updating or deleting routes as necessary
-    // TODO: needs to be rethought along with diff
     pub fn publish(&self, user: &GlobalUser, project: &Project) -> Result<(), failure::Error> {
         let diff = self.diff(user, project)?;
-        // Add new routes
-        for route in diff.added {
-            create(user, project, &route)?;
+
+        // Then: delete, modify, add
+
+        // Delete old routes (that pointed to this script)
+        for route in diff.deleted {
+            // TODO: delete
+            println!(
+                "⚠️ Wrangler can't yet delete routes: '{pattern}' [#{id}] -> '{script}'",
+                pattern = route.pattern,
+                script = route.script.unwrap_or_default(),
+                id = route.id.unwrap_or_default(),
+            )
         }
+
         // Modify existing routes (patterns pointing to a different script)
+        // TODO:
+        // 1. Safely modify when pattern pointed to this script or "nothing" (i.e: on/off)
+        // 2. Require a --force flag when pattern pointed to another script
         for route in diff.modified {
             println!(
                 "⚠️ Wrangler can't yet sync modified routes: '{pattern}' -> '{script}'",
@@ -64,34 +79,41 @@ impl ProjectRoutes {
                 script = route.script.unwrap_or_default()
             )
         }
+
+        // Add new routes
+        for route in diff.added {
+            create(user, project, &route)?;
+        }
+
         Ok(())
     }
 
-    // diffs local and remote diffs
-    // TODO: the original code was designed to only add paths which might get messy
-    // the whole route-sync logic needs to be rethought IMHO
+    // diffs local and remote routes
     pub fn diff(&self, user: &GlobalUser, project: &Project) -> Result<RoutesDiff, failure::Error> {
-        let remote_routes = get_remote_routes(user, project)?;
+        let remotes = get_remote_routes(user, project)?;
+
+        // Hashmaps for easier lookups
+        let remotes_map = routes_by_pattern(&remotes);
+        let locals_map = routes_by_pattern(&self.routes);
+
+        // Shorthand to tell if a route points to this project
+        let same = |r: &Route| match &r.script {
+            Some(name) => *name == self.script,
+            None => false,
+        };
+
         // Routes to be created (defined locally, but no-matching remote pattern)
-        let new_routes = self
-            .routes
-            .iter()
-            .filter(|r| !remote_routes.iter().any(|rr| r.pattern == rr.pattern))
-            .cloned()
-            .collect::<Vec<Route>>();
+        let added = _where(&self.routes, |r| !remotes_map.contains_key(&r.pattern));
         // Routes to be modified (pattern existed, but is routed to a different script)
-        let modified_routes = self
-            .routes
-            .iter()
-            .filter(|r| !remote_routes.iter().any(|rr| r.pattern == rr.pattern))
-            .cloned()
-            .collect::<Vec<Route>>();
+        let modified = _where(&self.routes, |&r| !same(r) && remotes_map.contains_key(&r.pattern));
+        // Remote routes to be deleted (that aren't specified in this script's config)
+        let deleted = _where(&remotes, |&r| same(r) && !locals_map.contains_key(&r.pattern));
+
         // Diff
-        // TODO: explore delete (see above comments on publish/diff)
         Ok(RoutesDiff {
-            added: new_routes,
-            modified: modified_routes,
-            // remotes: remote_routes,
+            added: added,
+            modified: modified,
+            deleted: deleted,
         })
     }
 }
@@ -102,28 +124,60 @@ impl Route {
     }
 }
 
+fn _where(routes: &Vec<Route>, f: impl Fn(&&Route)->bool) -> Vec<Route> {
+    return routes
+        .iter()
+        .filter(f)
+        .cloned()
+        .collect::<Vec<Route>>();
+}
+
+fn routes_by_pattern(routes: &Vec<Route>) -> HashMap<String, Route> {
+    return routes.iter().fold(HashMap::new(), |mut acc, route| {
+        acc.insert(route.pattern.clone(), route.clone());
+        return acc;
+    });
+}
+
 fn get_local_routes(project: &Project) -> Result<Vec<Route>, failure::Error> {
     let mut routes: Vec<Route> = vec![];
-    if project.route.is_some() {
-        // Single route
-        routes = vec![Route {
-            script: Some(project.name.to_string()),
-            pattern: project.route.clone().unwrap().to_string(),
-        }];
-    } else if project.routes.is_some() && (project.routes.clone().unwrap().len() > 0) {
-        // Build routes from project's HashMap
 
-        for (pattern, script) in project.routes.clone().unwrap().iter() {
-            routes.push(Route {
-                script: Some(script.to_string()),
-                pattern: pattern.to_string(),
-            })
-        }
-    } else {
+    // No specified routes
+    if !(project.route.is_some() || project.routes_on.is_some()) {
         failure::bail!(
             "You must provide a route or routes in your wrangler.toml before publishing!"
         );
     }
+
+    // All routes will point to the project's script (AKA it's name)
+    let script_name = project.name.to_string();
+
+    // Single route
+    if project.route.is_some() {
+        return Ok(vec![Route {
+            id: None,
+            script: Some(script_name),
+            pattern: project.route.clone().unwrap().to_string(),
+        }]);;
+    }
+
+    // Enabled routes
+    for pattern in project.routes_on.clone().unwrap_or_default().iter() {
+        routes.push(Route {
+            id: None,
+            script: Some(script_name.clone()),
+            pattern: pattern.to_string(),
+        })
+    }
+    // Disabled routes
+    for pattern in project.routes_off.clone().unwrap_or_default().iter() {
+        routes.push(Route {
+            id: None,
+            script: None,
+            pattern: pattern.to_string(),
+        })
+    }
+
     return Ok(routes);
 }
 

--- a/src/settings/project.rs
+++ b/src/settings/project.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -19,7 +18,10 @@ pub struct Project {
     pub webpack_config: Option<String>,
     pub account_id: String,
     pub route: Option<String>,
-    pub routes: Option<HashMap<String, String>>,
+    #[serde(rename = "on")]
+    pub routes_on: Option<Vec<String>>,
+    #[serde(rename = "off")]
+    pub routes_off: Option<Vec<String>>,
     #[serde(rename = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<String>>,
 }
@@ -75,7 +77,8 @@ impl Project {
             zone_id: Some(String::new()),
             account_id: String::new(),
             route: Some(String::new()),
-            routes: None,
+            routes_on: None,
+            routes_off: None,
             kv_namespaces: None,
             webpack_config: None,
         };


### PR DESCRIPTION
This PR implements 3 major improvements:
1. It enables publishing multiple routes
2. It changes how routes are defined in the config (`wrangler.toml`), to be less error-prone
3. It improves route syncing via diffs (before `wrangler` could only add routes and could not modify or delete routes).

`1.` is pretty straightforward, I'll explain `2.` and `3.` below:

# 2. Routes Config

Currently routes are a `Map<Pattern, ScriptName>`, this has the following shortcomings:
1. It's redundant, for every route we must explicitly specify the target script (or empty string)
2. It's [error-prone](https://github.com/cloudflare/wrangler/issues/213#issuecomment-499808123) (typos may happen when repeating the name)
3. It's got a leaky scope, since a `wrangler.toml` for a script can define routes for other scripts

It was originally built that way because, that's how the API stores them and routes are technically a zone-level resource.

However I think it's cleaner for the end-user if each `wrangler.toml` is scoped to a single script and all resources (such as routes) are viewed as script-resources (even if they're truly zone-level behind the scenes).

Thus, semantically what we want to capture is:
> What routes is this script enabled/disabled on ?

## Before

```toml
[routes]
"sub1.example.com/*" = "worker-script-name"
"sub2.example.com/*" = "worker-script-name"
"sub1.example.com/except/*" = ""
```

## After

```toml
on = [
    "sub1.example.com/*",
    "sub2.example.com/*"
]
off = ["sub1.example.com/except/*"]
```

I considered other alternatives to `on/off` (e.g: `yes/no`, `accept/deny`, `enabled/disabled`), but finally opted for `on/off` because (I think) it strikes the right balance of being:
1. **Familiar** (even for non-native speakers)
2. **Unambiguous** (in this context, on/off doesn't really have another meaningful interpretation)
3. **Short / Simple** (I don't think we need a `routes_` or `routes.` prefix to disambiguate)
4. **"Flat"** (which makes it easier to have multiple script config's in one file, if we do https://github.com/cloudflare/wrangler/issues/220)

# 3. Routes Sync

Prior to this PR, `wrangler` could only create new (single) routes, which had the following shortcomings:
1. You could only have one route (multiple routes are often needed in real-world use-cases)
2. If you specified a route that already existed (pointing to another script), `wrangler` would crash
3. If you changed your route, old routes pointing to this script would not be deleted, so you would have "dangling" routes that could build up over time

## Syncing logic

When syncing routes (for a given script), I think users expect `wrangler` to:
1. **Create** new routes (as defined in `on = [...]`) pointing to this script
2. **Delete** old routes that used to point to this script (but are no longer in the local config)
3. **Ensure disabled routes** (defined in `off = [...]`) point to another script (possibly `""`)
    - **Note:** it was not possible to express this with the previous config approach
4. **Does not overwrite routes** that point to other scripts by default (except `""`), unless `--force` flag is provided

(This is what I'm implementing in this PR)

### Remaining pitfalls

This new sync logic is a significant improvement over what's currently implemented, but it's not perfect. The following pitfalls still exist:
1. Dangling routes to `""` ("null script") are still a problem, since when syncing a given script we can't delete those dangling `""` routes because we don't know (and can't know) if another script requires those routes to be "off"
    * **Note:** If the set of scripts being deployed in this "bundle" is equal to the set of scripts who have routes in production, we could consider our deploy "exhaustive" and thus trim all non-referenced routes (including the aforementioned "dangling null scripts")
2. Some sync operations (e.g: taking a route previously used by another script) still require `--force`
    *  **Note:** If we add "multi-script" support and allow deploying multiple scripts together as a "bundle" (all defined in the same `wrangler.toml`), we could resolve route conflicts (between the scripts in the bundle) and avoid unnecessary `--force` operations

I'm leaving these notes as improvements to be made in the future.

# Tasks

- [x] Support multiple routes, extracted from either `project.route` or `project.routes`
- [x] No longer crash when updating routes (for now show warning that it's not yet implemented)
- [x] Implement diffs
- [x] Change how routes are defined in config (use `on = ['/app/*']` & `off = [ ... ]`)
- [ ] Update & delete routes that can be (that don't belong to another script)
- [ ] Support taking a route used by another script by passing a `--force` flag

# Finishing notes

- [ ] Maybe we could add a `diff` command that shows which `routes` would be changed if we run `publish` ?