### PR TITLE
Pin webpack version

### DIFF
--- a/wranglerjs/package.json
+++ b/wranglerjs/package.json
@@ -4,6 +4,6 @@
   "author": "Sven Sauleau <sven@sauleau.com>",
   "license": "MIT",
   "dependencies": {
-    "webpack": "^4.29.6"
+    "webpack": "4.33.0"
   }
 }


### PR DESCRIPTION
Adds a better control over webpack's version, avoiding possible upstream
issues.

Also we depend on one internal.