### PR TITLE
Display commands in their defined order

### DIFF
--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -13,9 +13,9 @@
 
 use console::Emoji;
 
-pub static WORKER: Emoji = Emoji("👷  ", "");
+pub static WORKER: Emoji = Emoji("👷 ", "");
 pub static SPARKLES: Emoji = Emoji("✨  ", "");
-pub static DANCERS: Emoji = Emoji("👯  ", "");
+pub static DANCERS: Emoji = Emoji("👯 ", "");
 pub static MICROSCOPE: Emoji = Emoji("🔬 ", "");
 pub static CRAB: Emoji = Emoji("🦀 ", "");
 pub static SLEUTH: Emoji = Emoji("🕵️‍♂️", "");
@@ -25,3 +25,4 @@ pub static UP: Emoji = Emoji("🆙 ", "");
 pub static SHEEP: Emoji = Emoji("🐑 ", "");
 pub static WAVING: Emoji = Emoji("👋 ", "");
 pub static SNAIL: Emoji = Emoji("🐌 ", "");
+pub static INBOX: Emoji = Emoji("📥 ", "");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), failure::Error> {
         .subcommand(
             SubCommand::with_name("generate")
                 .about(&*format!(
-                    "{} Generate a new workers project",
+                    "{} Generate a new worker project",
                     emoji::DANCERS
                 ))
                 .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,11 @@ fn main() -> Result<(), failure::Error> {
         .version(env!("CARGO_PKG_VERSION"))
         .author("ashley g williams <ashley666ashley@gmail.com>")
         .setting(AppSettings::ArgRequiredElseHelp)
+        .setting(AppSettings::DeriveDisplayOrder)
         .subcommand(
             SubCommand::with_name("generate")
                 .about(&*format!(
-                    "{} Generates a new worker project",
+                    "{} Generate a new workers project",
                     emoji::DANCERS
                 ))
                 .arg(
@@ -64,8 +65,8 @@ fn main() -> Result<(), failure::Error> {
         .subcommand(
             SubCommand::with_name("init")
                 .about(&*format!(
-                    "{} Generates a wrangler.toml for an existing project",
-                    emoji::DANCERS
+                    "{} Create a wrangler.toml for an existing project",
+                    emoji::INBOX
                 ))
                 .arg(
                     Arg::with_name("name")
@@ -81,9 +82,17 @@ fn main() -> Result<(), failure::Error> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("build")
+                .about(&*format!(
+                    "{} Build your worker",
+                    emoji::CRAB
+                )
+            ),
+        )
+        .subcommand(
             SubCommand::with_name("preview")
                 .about(&*format!(
-                    "{} Publish your code temporarily on cloudflareworkers.com",
+                    "{} Preview your code temporarily on cloudflareworkers.com",
                     emoji::MICROSCOPE
                 ))
                 .arg(
@@ -98,11 +107,8 @@ fn main() -> Result<(), failure::Error> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("build").about(&*format!("{} Build your worker", emoji::CRAB)),
-        )
-        .subcommand(
             SubCommand::with_name("publish").about(&*format!(
-                "{} Push your worker to the orange cloud",
+                "{} Publish your worker to the orange cloud",
                 emoji::UP
             ))
             .arg(


### PR DESCRIPTION
Clap was re-arranging commands alphabetically, this change lets us define our own order. This moves help to the bottom so it's less awkward (since it has no emoji!) Also fixed some emoji spacing issues.

### **OLD:**
![Screen Shot 2019-06-09 at 11 48 04 AM](https://user-images.githubusercontent.com/3238291/59161797-a217fd80-8aac-11e9-84ce-e8b0b54825f0.png)

### **NEW:**
![Screen Shot 2019-06-09 at 11 47 36 AM](https://user-images.githubusercontent.com/3238291/59161800-a7754800-8aac-11e9-9e83-59343de9864a.png)
