### PR TITLE
Move metadata generation at publish-time

### DIFF
--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -47,9 +47,6 @@ impl Bundle {
 
         script_file.write_all(script.as_bytes())?;
 
-        let mut metadata_file = File::create(self.metadata_path())?;
-        metadata_file.write_all(create_metadata(self).as_bytes())?;
-
         // cleanup {Webpack} dist, if specified.
         if let Some(dist_to_clean) = &wranglerjs_output.dist_to_clean {
             info!("Remove {}", dist_to_clean);
@@ -106,8 +103,7 @@ pub fn create_prologue() -> String {
 }
 
 // This metadata describe the bindings on the Worker.
-fn create_metadata(bundle: &Bundle) -> String {
-    info!("create metadata; wasm={}", bundle.has_wasm());
+pub fn create_metadata(bundle: &Bundle) -> String {
     if bundle.has_wasm() {
         format!(
             r#"
@@ -149,8 +145,8 @@ mod tests {
     }
 
     #[test]
-    fn it_writes_the_bundle_metadata() {
-        let out = create_temp_dir("it_writes_the_bundle_metadata");
+    fn it_creates_the_bundle_metadata() {
+        let out = create_temp_dir("it_creates_the_bundle_metadata");
         let wranglerjs_output = WranglerjsOutput {
             errors: vec![],
             script: "".to_string(),
@@ -160,12 +156,10 @@ mod tests {
         let bundle = Bundle::new_at(out.clone());
 
         bundle.write(&wranglerjs_output).unwrap();
-        assert!(Path::new(&bundle.metadata_path()).exists());
-        let contents =
-            fs::read_to_string(&bundle.metadata_path()).expect("could not read metadata");
+        assert_eq!(Path::new(&bundle.metadata_path()).exists(), false);
 
         assert_eq!(
-            contents,
+            create_metadata(&bundle),
             r#"
             {
                 "body_part": "script"
@@ -213,8 +207,8 @@ mod tests {
     }
 
     #[test]
-    fn it_writes_the_bundle_wasm_metadata() {
-        let out = create_temp_dir("it_writes_the_bundle_wasm_metadata");
+    fn it_creates_the_bundle_wasm_metadata() {
+        let out = create_temp_dir("it_creates_the_bundle_wasm_metadata");
         let wranglerjs_output = WranglerjsOutput {
             errors: vec![],
             script: "".to_string(),
@@ -224,12 +218,10 @@ mod tests {
         let bundle = Bundle::new_at(out.clone());
 
         bundle.write(&wranglerjs_output).unwrap();
-        assert!(Path::new(&bundle.metadata_path()).exists());
-        let contents =
-            fs::read_to_string(&bundle.metadata_path()).expect("could not read metadata");
+        assert_eq!(Path::new(&bundle.metadata_path()).exists(), false);
 
         assert_eq!(
-            contents,
+            create_metadata(&bundle),
             r#"
                 {
                     "body_part": "script",

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -1,4 +1,4 @@
-mod bundle;
+pub mod bundle;
 pub mod output;
 
 use crate::commands::publish::package::Package;

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -7,13 +7,15 @@ pub mod package;
 use package::Package;
 
 use log::info;
-
-use reqwest::multipart::Form;
 use std::collections::HashMap;
 use std::fs;
+use std::fs::File;
+use std::io::prelude::*;
 use std::path::Path;
 
-use crate::commands::build::wranglerjs::Bundle;
+use reqwest::multipart::Form;
+
+use crate::commands::build::wranglerjs::{bundle, Bundle};
 use crate::commands::subdomain::Subdomain;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::{Project, ProjectType};
@@ -116,6 +118,15 @@ fn publish_script(
         }
         ProjectType::Webpack => {
             info!("Webpack project detected. Publishing...");
+
+            // FIXME(sven): shouldn't new
+            let bundle = Bundle::new();
+
+            let metadata = bundle::create_metadata(&bundle);
+            info!("generate metadata {:?}", metadata);
+            let mut metadata_file = File::create(bundle.metadata_path())?;
+            metadata_file.write_all(metadata.as_bytes())?;
+
             client
                 .put(&worker_addr)
                 .header("X-Auth-Key", &*user.api_key)

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -38,7 +38,6 @@ fn it_builds_with_webpack_single_js() {
 
     build(fixture);
     assert!(fixture_out_path(fixture).join("script.js").exists());
-    assert!(fixture_out_path(fixture).join("metadata.json").exists());
     cleanup(fixture);
 }
 
@@ -53,7 +52,6 @@ fn it_builds_with_webpack_single_js_use_package_main() {
 
     build(fixture);
     assert!(fixture_out_path(fixture).join("script.js").exists());
-    assert!(fixture_out_path(fixture).join("metadata.json").exists());
     cleanup(fixture);
 }
 
@@ -84,12 +82,7 @@ fn it_builds_with_webpack_wast() {
 
     build(fixture);
     assert!(fixture_out_path(fixture).join("script.js").exists());
-    assert!(fixture_out_path(fixture).join("metadata.json").exists());
     assert!(fixture_out_path(fixture).join("module.wasm").exists());
-
-    let metadata = fs::read_to_string(fixture_out_path(fixture).join("metadata.json"))
-        .expect("could not read metadata");
-    assert!(metadata.contains("wasm_module"));
 
     cleanup(fixture);
 }


### PR DESCRIPTION
This is required for creating kv-namespaces because their ids are known
at publish-time.