### PR TITLE
fix: correct binding format

### DIFF
--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -109,11 +109,11 @@ pub fn create_metadata(bundle: &Bundle) -> String {
             r#"
                 {{
                     "body_part": "script",
-                    "binding": {{
+                    "bindings": [{{
                         "name": "{name}",
                         "type": "wasm_module",
                         "part": "{name}"
-                    }}
+                    }}]
                 }}
             "#,
             name = bundle.get_wasm_binding(),
@@ -225,11 +225,11 @@ mod tests {
             r#"
                 {
                     "body_part": "script",
-                    "binding": {
+                    "bindings": [{
                         "name": "wasmprogram",
                         "type": "wasm_module",
                         "part": "wasmprogram"
-                    }
+                    }]
                 }
             "#
         );


### PR DESCRIPTION
Rename binding to bindings and use an array.

We should use #217 instead. 