### PR TITLE
fix: correctly pass Wasm module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ version = "1.0.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary-install 0.0.3-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rand = "0.6.5"
 fs2 = "0.4.3"
 number_prefix = "0.3.0"
 flate2 = "1.0.7"
+base64 = "0.10.1"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -1,3 +1,4 @@
+use base64::decode;
 #[cfg(test)]
 use std::env;
 use std::fs;
@@ -40,9 +41,10 @@ impl Bundle {
         let mut script = create_prologue();
         script += &wranglerjs_output.script;
 
-        if let Some(wasm) = &wranglerjs_output.wasm {
+        if let Some(encoded_wasm) = &wranglerjs_output.wasm {
+            let wasm = decode(encoded_wasm).expect("could not decode Wasm in base64");
             let mut wasm_file = File::create(self.wasm_path())?;
-            wasm_file.write_all(wasm.as_bytes())?;
+            wasm_file.write_all(&wasm)?;
         }
 
         script_file.write_all(script.as_bytes())?;

--- a/wranglerjs/index.js
+++ b/wranglerjs/index.js
@@ -89,7 +89,7 @@ compiler.run((err, stats) => {
   }, "");
 
   if (hasWasmModule === true) {
-    bundle.wasm = Buffer.from(assets[wasmModuleAsset].source()).toString();
+    bundle.wasm = Buffer.from(assets[wasmModuleAsset].source()).toString("base64");
   }
 
   writeFileSync(args["output-file"], JSON.stringify(bundle));


### PR DESCRIPTION
Between wranglerjs and wrangler the wasm module is encoded in base64 to
avoid any loss, and decoded in Rust.