### PR TITLE
Add an authenticated HTTP client

### DIFF
--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -64,13 +64,9 @@ impl Route {
 fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failure::Error> {
     let routes_addr = get_routes_addr(project)?;
 
-    let client = http::client();
+    let client = http::auth_client(user);
 
-    let mut res = client
-        .get(&routes_addr)
-        .header("X-Auth-Key", &*user.api_key)
-        .header("X-Auth-Email", &*user.email)
-        .send()?;
+    let mut res = client.get(&routes_addr).send()?;
 
     if !res.status().is_success() {
         let msg = format!(
@@ -87,7 +83,7 @@ fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failur
 }
 
 fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), failure::Error> {
-    let client = http::client();
+    let client = http::auth_client(user);
     let body = serde_json::to_string(&route)?;
 
     let routes_addr = get_routes_addr(project)?;
@@ -95,8 +91,6 @@ fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), fai
     info!("Creating your route {:#?}", &route.pattern,);
     let mut res = client
         .post(&routes_addr)
-        .header("X-Auth-Key", &*user.api_key)
-        .header("X-Auth-Email", &*user.email)
         .header(CONTENT_TYPE, "application/json")
         .body(body)
         .send()?;

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -14,13 +14,9 @@ impl Subdomain {
     pub fn get(account_id: &str, user: &GlobalUser) -> Result<String, failure::Error> {
         let addr = subdomain_addr(account_id);
 
-        let client = http::client();
+        let client = http::auth_client(user);
 
-        let mut res = client
-            .get(&addr)
-            .header("X-Auth-Key", &*user.api_key)
-            .header("X-Auth-Email", &*user.email)
-            .send()?;
+        let mut res = client.get(&addr).send()?;
 
         if !res.status().is_success() {
             failure::bail!(
@@ -80,14 +76,9 @@ pub fn subdomain(name: &str, user: &GlobalUser, project: &Project) -> Result<(),
     };
     let sd_request = serde_json::to_string(&sd)?;
 
-    let client = http::client();
+    let client = http::auth_client(user);
 
-    let mut res = client
-        .put(&addr)
-        .header("X-Auth-Key", &*user.api_key)
-        .header("X-Auth-Email", &*user.email)
-        .body(sd_request)
-        .send()?;
+    let mut res = client.put(&addr).body(sd_request).send()?;
 
     let msg;
     if !res.status().is_success() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,26 +1,45 @@
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
-use reqwest::Client;
+use reqwest::{Client, ClientBuilder, RedirectPolicy};
+use std::time::Duration;
 
 use crate::install;
+use crate::settings::global_user::GlobalUser;
 
-fn client_headers() -> HeaderMap {
-    let user_agent = if install::target::DEBUG {
-        "wrangler/dev".to_string()
+fn headers() -> HeaderMap {
+    let version = if install::target::DEBUG {
+        "dev"
     } else {
-        let version = env!("CARGO_PKG_VERSION");
-        format!("wrangler/{}", version)
+        env!("CARGO_PKG_VERSION")
     };
+    let user_agent = format!("wrangler/{}", version);
 
-    let value = HeaderValue::from_str(&user_agent).unwrap();
     let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, value);
+    headers.insert(USER_AGENT, HeaderValue::from_str(&user_agent).unwrap());
     headers
 }
 
-pub fn client() -> Client {
+fn builder() -> ClientBuilder {
     let builder = reqwest::Client::builder();
     builder
-        .default_headers(client_headers())
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+}
+
+pub fn client() -> Client {
+    builder()
+        .default_headers(headers())
         .build()
         .expect("could not create http client")
+}
+
+pub fn auth_client(user: &GlobalUser) -> Client {
+    let mut headers = headers();
+    headers.insert("X-Auth-Key", HeaderValue::from_str(&user.api_key).unwrap());
+    headers.insert("X-Auth-Email", HeaderValue::from_str(&user.email).unwrap());
+
+    builder()
+        .default_headers(headers)
+        .redirect(RedirectPolicy::none())
+        .build()
+        .expect("could not create authenticated http client")
 }


### PR DESCRIPTION
Resolves #238. Any requests to the Cloudflare API will now use `auth_client`. Tested and works.