### PR TITLE
Refactor: Conditional per command in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,97 +159,85 @@ fn main() -> Result<(), failure::Error> {
         )))
         .get_matches();
 
-    if matches.subcommand_matches("config").is_some()
-        || matches.subcommand_matches("generate").is_some()
-        || matches.subcommand_matches("init").is_some()
-    {
-        if let Some(matches) = matches.subcommand_matches("config") {
-            let email = matches
-                .value_of("email")
-                .expect("An email address must be provided.");
-            let api_key = matches
-                .value_of("api-key")
-                .expect("An API key must be provided.");
-            commands::global_config(email, api_key)?;
-        }
+    if let Some(matches) = matches.subcommand_matches("config") {
+        let email = matches
+            .value_of("email")
+            .expect("An email address must be provided.");
+        let api_key = matches
+            .value_of("api-key")
+            .expect("An API key must be provided.");
 
-        if let Some(matches) = matches.subcommand_matches("generate") {
-            let name = matches.value_of("name").unwrap_or("worker");
-            let project_type = match matches.value_of("type") {
-                Some(s) => Some(settings::project::ProjectType::from_str(&s.to_lowercase())?),
-                None => None,
-            };
-            let template = matches
-                .value_of("template")
-                .unwrap_or("https://github.com/cloudflare/worker-template");
-            info!(
-                "Generate command called with template {}, and name {}",
-                template, name
-            );
-            commands::generate(name, template, project_type, &cache)?;
-        }
-
-        if let Some(matches) = matches.subcommand_matches("init") {
-            let name = matches.value_of("name");
-            let project_type = match matches.value_of("type") {
-                Some(s) => Some(settings::project::ProjectType::from_str(&s.to_lowercase())?),
-                None => None,
-            };
-            commands::init(name, project_type)?;
-        }
-    } else if matches.subcommand_matches("build").is_some()
-        || matches.subcommand_matches("preview").is_some()
-    {
+        commands::global_config(email, api_key)?;
+    } else if let Some(matches) = matches.subcommand_matches("generate") {
+        let name = matches.value_of("name").unwrap_or("worker");
+        let project_type = match matches.value_of("type") {
+            Some(s) => Some(settings::project::ProjectType::from_str(&s.to_lowercase())?),
+            None => None,
+        };
+        let template = matches
+            .value_of("template")
+            .unwrap_or("https://github.com/cloudflare/worker-template");
+        info!(
+            "Generate command called with template {}, and name {}",
+            template, name
+        );
+        commands::generate(name, template, project_type, &cache)?;
+    } else if let Some(matches) = matches.subcommand_matches("init") {
+        let name = matches.value_of("name");
+        let project_type = match matches.value_of("type") {
+            Some(s) => Some(settings::project::ProjectType::from_str(&s.to_lowercase())?),
+            None => None,
+        };
+        commands::init(name, project_type)?;
+    } else if matches.subcommand_matches("build").is_some() {
+        info!("Getting project settings");
+        let project = settings::project::Project::new()?;
+        commands::build(&cache, &project)?;
+    } else if let Some(matches) = matches.subcommand_matches("preview") {
         info!("Getting project settings");
         let project = settings::project::Project::new()?;
 
-        if matches.subcommand_matches("build").is_some() {
-            commands::build(&cache, &project)?;
-        }
+        let method = HTTPMethod::from_str(matches.value_of("method").unwrap_or("get"));
 
-        if let Some(matches) = matches.subcommand_matches("preview") {
-            let method = HTTPMethod::from_str(matches.value_of("method").unwrap_or("get"));
+        let body = match matches.value_of("body") {
+            Some(s) => Some(s.to_string()),
+            None => None,
+        };
 
-            let body = match matches.value_of("body") {
-                Some(s) => Some(s.to_string()),
-                None => None,
-            };
-
-            commands::build(&cache, &project)?;
-            commands::preview(method, body)?;
-        }
+        commands::build(&cache, &project)?;
+        commands::preview(method, body)?;
     } else if matches.subcommand_matches("whoami").is_some() {
         info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;
 
-        if matches.subcommand_matches("whoami").is_some() {
-            commands::whoami(&user);
-        }
-    } else if matches.subcommand_matches("publish").is_some()
-        || matches.subcommand_matches("subdomain").is_some()
-    {
+        commands::whoami(&user);
+    } else if let Some(matches) = matches.subcommand_matches("publish") {
         info!("Getting project settings");
         let project = settings::project::Project::new()?;
 
         info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;
 
-        if let Some(matches) = matches.subcommand_matches("publish") {
-            info!("{}", matches.occurrences_of("release"));
-            let release = match matches.occurrences_of("release") {
-                1 => true,
-                _ => false,
-            };
-            commands::build(&cache, &project)?;
-            commands::publish(&user, &project, release)?;
-        }
+        info!("{}", matches.occurrences_of("release"));
+        let release = match matches.occurrences_of("release") {
+            1 => true,
+            _ => false,
+        };
 
-        if let Some(matches) = matches.subcommand_matches("subdomain") {
-            let name = matches
-                .value_of("name")
-                .expect("The subdomain name you are requesting must be provided.");
-            commands::subdomain(name, &user, &project)?;
-        }
+        commands::build(&cache, &project)?;
+        commands::publish(&user, &project, release)?;
+    } else if let Some(matches) = matches.subcommand_matches("subdomain") {
+        info!("Getting project settings");
+        let project = settings::project::Project::new()?;
+
+        info!("Getting User settings");
+        let user = settings::global_user::GlobalUser::new()?;
+
+        let name = matches
+            .value_of("name")
+            .expect("The subdomain name you are requesting must be provided.");
+
+        commands::subdomain(name, &user, &project)?;
     }
     Ok(())
 }


### PR DESCRIPTION
All this does is split out the code to specify a single conditional per command match. It's my version of "dipping a toe in". I'm sure there's a better way to do this w/ matching, but this is at least a readability improvement.