### PR TITLE
Use serde for metadata

### DIFF
--- a/src/settings/binding.rs
+++ b/src/settings/binding.rs
@@ -1,0 +1,14 @@
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type")]
+pub enum Binding {
+    #[allow(non_camel_case_types)]
+    wasm_module { name: String, part: String },
+}
+
+impl Binding {
+    pub fn new_wasm_module(name: String, part: String) -> Binding {
+        Binding::wasm_module { name, part }
+    }
+}

--- a/src/settings/metadata.rs
+++ b/src/settings/metadata.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+
+use crate::settings::binding::Binding;
+
+#[derive(Serialize, Debug)]
+pub struct Metadata {
+    pub body_part: String,
+    pub bindings: Vec<Binding>,
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,2 +1,4 @@
+pub mod binding;
 pub mod global_user;
+pub mod metadata;
 pub mod project;


### PR DESCRIPTION
This change adds proper construction of the worker metadata, previously
it was an error-prone string.

`bindings.rs` is used to build certain binding type, currently only
wasm_module is supported.