### PR TITLE
Change global config perm

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,7 +1,21 @@
 use crate::terminal::message;
 use std::fs;
+use std::fs::File;
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 
 use crate::settings::global_user::{get_global_config_dir, GlobalUser};
+
+// set the permissions on the dir, we want to avoid that other user reads to
+// file
+#[cfg(not(target_os = "windows"))]
+pub fn set_file_mode(file: &PathBuf) {
+    File::open(&file)
+        .unwrap()
+        .set_permissions(PermissionsExt::from_mode(0o600))
+        .expect("could not set permissions on file");
+}
 
 pub fn global_config(email: &str, api_key: &str) -> Result<(), failure::Error> {
     let s = GlobalUser {
@@ -16,6 +30,10 @@ pub fn global_config(email: &str, api_key: &str) -> Result<(), failure::Error> {
 
     let config_file = config_dir.join("default.toml");
     fs::write(&config_file, &toml)?;
+
+    // set permissions on the file
+    #[cfg(not(target_os = "windows"))]
+    set_file_mode(&config_file);
 
     message::success(&format!(
         "Successfully configured. You can find your configuration file at: {}",

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -21,7 +21,6 @@ fn it_generates_the_config() {
         .read_to_string(&mut buffer)
         .expect("could not read output");
     assert!(buffer.contains("Enter email: \nEnter api key: \n Successfully configured."));
-    eprintln!("{}", buffer);
 
     let config_file = fake_home_dir.join("config").join("default.toml");
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use std::env;
 use std::fs;
+use std::fs::File;
 use std::io::prelude::*;
 use std::process::{Child, Command, Stdio};
 
@@ -32,6 +33,17 @@ fn it_generates_the_config() {
 api_key = "b"
 "#
     );
+
+    // check dir permissions (but not on windows)
+    if !cfg!(target_os = "windows") {
+        let mut command = Command::new("stat");
+        command.arg("-c");
+        command.arg("%a %n");
+        command.arg(&config_file);
+        let out = String::from_utf8(command.output().expect("could not stat file").stdout).unwrap();
+        // stat format is: "mode file"
+        assert!(out.starts_with("600"));
+    }
 
     fs::remove_dir_all(&fake_home_dir).expect("could not delete dir");
 }


### PR DESCRIPTION
Avoid the global user config to be system readable, restrict any access
to the current user and only in read only (600).

Merge https://github.com/cloudflare/wrangler/pull/239 first.