### PR TITLE
Update README with new config and update information

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ Wrangler can be installed both through [npm](https://www.npmjs.com/get-npm) and 
 
     To get the latest version of Wrangler, using Cargo, run:
 
-    ```bash
+    ```sh
     cargo install --git https://github.com/cloudflare/wrangler --force
     ```
 
    To get the latest version of Wrangler, using NPM, run:
 
-   ```bash
+   ```sh
    npm install @cloudflare/wrangler
    ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
     To set up `wrangler` to work with your Cloudflare user, use the following commands:
 
-    - 🔧 `config`: a command that asks you to pass your `email` and `api` key.
+    - 🔧 `config`: a command that prompts you to enter your `email` and `api` key.
     - 🕵️‍♀️ `whoami`: run this command to confirm that your configuration is appropriately set up.
        When successful, this command will print out your user information, including the type of plan you
        are currently on.
@@ -131,7 +131,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
         - `javascript`: This project contains a single JavaScript file, defined in `package.json`'s `main` key.
         - `rust`: This project contains a Rust crate that uses `wasm-bindgen`. It will be built with `wasm-pack`.
         - `webpack`: This project contains any number of JavaScript files or Rust/C/C++ files that compile to
-            WebAssembly. Rust files will be built with `wasm-pack`. `C/C++` files will be build with `emscripten`.
+            WebAssembly. Rust files will be built with `wasm-pack`.
             This project type uses webpack and webpack plugins in the background to build your worker.
     - `zone_id`: This is the ID of the "zone" or domain you want to run your script on. This is optional if you
         are using a workers.dev subdomain and is only reuqired for `publish --release`.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
     To set up `wrangler` to work with your Cloudflare user, use the following commands:
 
-    - 🔧 `config`: an interactive command that asks you to pass your `email` and `api` key. Alternatively, 
-       you can use the flags `--email` and `--api-key` to the command to skip the interactive part.
+    - 🔧 `config`: a command that asks you to pass your `email` and `api` key.
     - 🕵️‍♀️ `whoami`: run this command to confirm that your configuration is appropriately set up.
        When successful, this command will print out your user information, including the type of plan you
        are currently on.
@@ -188,7 +187,20 @@ Wrangler can be installed both through [npm](https://www.npmjs.com/get-npm) and 
     ```
     $ brew install openssl@1.1
     ```
-    
+
+1. Updating `wrangler:
+
+    To get the latest version of Wrangler, using Cargo, run:
+
+    ```bash
+    cargo install --git https://github.com/cloudflare/wrangler --force
+    ```
+
+   To get the latest version of Wrangler, using NPM, run:
+
+   ```bash
+   npm install @cloudflare/wrangler
+   ```
 
 ## ⚡ Quick Start
 


### PR DESCRIPTION
Based on #212, but with some updates and rebase fixes. This PR:

- Updates the `config` subcommand details in the "Configuration" section to indicate that the command is no longer interactive
- Adds a section about updating `wrangler`, using Cargo and NPM