### PR TITLE
ci: activate backtracing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
         displayName: "cargo test --locked"
         env:
           RUST_LOG: warn,wrangler=info
+          RUST_BACKTRACE: 1
 
   - job: test_wrangler_nightly
     displayName: "Run wrangler tests (nightly)"
@@ -50,6 +51,7 @@ jobs:
         displayName: "cargo test --locked"
         env:
           RUST_LOG: warn,wrangler=info
+          RUST_BACKTRACE: 1
 
   - job: dist_linux
     displayName: "Dist Linux binary"


### PR DESCRIPTION
Enable Rust's backtracing by default to help with debugging in CI.