### PR TITLE
fix: warnings

### DIFF
--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -2,7 +2,6 @@ pub mod wranglerjs;
 
 use crate::settings::project::{Project, ProjectType};
 use crate::{commands, install};
-use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -11,6 +11,7 @@ use log::info;
 use crate::commands::build::wranglerjs::output::WranglerjsOutput;
 use crate::settings::binding::Binding;
 use crate::settings::metadata;
+#[cfg(test)]
 use crate::terminal::message;
 
 // Directory where we should write the {Bundle}. It represents the built

--- a/src/terminal/emoji.rs
+++ b/src/terminal/emoji.rs
@@ -17,7 +17,6 @@ pub static CONSTRUCTION: Emoji = Emoji("🚧 ", "");
 pub static CRAB: Emoji = Emoji("🦀 ", "");
 pub static DANCERS: Emoji = Emoji("👯 ", "");
 pub static EYES: Emoji = Emoji("👀 ", "");
-pub static FACEPALM: Emoji = Emoji("🤦‍♀️ ", "");
 pub static INBOX: Emoji = Emoji("📥 ", "");
 pub static INFO: Emoji = Emoji("💁‍ ", "");
 pub static MICROSCOPE: Emoji = Emoji("🔬 ", "");

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -13,16 +13,8 @@ pub fn success(msg: &str) {
     message(emoji::SPARKLES, msg);
 }
 
-pub fn warn(msg: &str) {
-    message(emoji::WARN, msg);
-}
-
 pub fn user_error(msg: &str) {
     message(emoji::EYES, msg);
-}
-
-pub fn service_error(msg: &str) {
-    message(emoji::FACEPALM, msg);
 }
 
 pub fn working(msg: &str) {


### PR DESCRIPTION
Since we added the pre-commit/push hook that lints the code and that
warning are considered as errors we can't commit anymore. This change
removes all the current warnings.

Alternatively we could allow warnings but it's good to ensure we don't commit them.