### PR TITLE
[WIP][RFC] Use Homebrew instead of NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 You have many options to install wrangler!
 
-### Using `npm`
+### Using [Homebrew](https://brew.sh/)
 
 ```
-npm i @cloudflare/wrangler -g
+brew install cf-wrangler
 ```
 
 ### Using `cargo`
@@ -146,18 +146,16 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
 ## ⚓ Installation
 
-Wrangler can be installed both through [npm](https://www.npmjs.com/get-npm) and through Rust's package manager, [Cargo](https://github.com/rust-lang/cargo).
+Wrangler can be installed both through [Homebrew](https://brew.sh/) and through Rust's package manager, [Cargo](https://github.com/rust-lang/cargo).
 
-### Using `npm`:
+### Using [Homebrew](https://brew.sh/):
 
-1. If you don't already have npm on your machine, install it using [npm's recommended method](https://www.npmjs.com/get-npm), a node.js version manager.
-
-    If you have already installed npm with a package manager, it is possible you will run into an `EACCES` error while installing wrangler. This is related to how many system packagers install npm. You can either uninstall npm and reinstall using the npm recommended install method (a version manager), or use one of our other install methods.
+1. If you don't already have brew on your machine, [install](https://brew.sh/) it.
 
 1. Install Wrangler by running:
 
     ```
-    npm i @cloudflare/wrangler -g
+    brew install cf-wrangler
     ```
 
 ### Using `cargo`:
@@ -201,10 +199,10 @@ Wrangler can be installed both through [npm](https://www.npmjs.com/get-npm) and 
    cargo install wrangler --force
    ```
 
-   To get the latest version of Wrangler, using NPM, run:
+   To get the latest version of Wrangler, using Homebrew, run:
 
    ```
-   npm install @cloudflare/wrangler
+   brew upgrade wrangler
    ```
 
 ## ⚡ Quick Start


### PR DESCRIPTION
Using npm to distribute our binary is prone to issues (#240) since misconfigured npm installs are common. Fixing this opens a whole can of worms, due to the way npm treats postinstall scripts. Making this work would require making our own cross-platform installer for wrangler and maintaining it.

Homebrew does a nice job of handling this, works on Linux, macOS, and Windows (for WSL users), and will also install our dependencies (node and openssl@1.1) for the user. Users who prefer `nvm` can just put `nvm`'s node in front of `brew` node in their PATH. Users who dislike homebrew can use our manual install method for now.

While we evaluate the pros/cons of creating our own installer, I believe this is a potential solution to provide a consistent cross-platform solution for users.

My proposed brew formula `cf-wrangler`:

```
class CfWrangler < Formula
  desc "Management tool for Cloudflare Workers"
  homepage "https://github.com/cloudflare/wrangler/"
  url "https://github.com/cloudflare/wrangler/archive/v1.0.0.tar.gz"
  sha256 "f3cfd04c0d69372fa1bb09e8e23200e7da7988cd9767f107daa73771a380d096"

  depends_on "rust" => :build
  depends_on "node"
  depends_on "openssl@1.1"

  def install
    system "cargo", "install", "--root", prefix, "--path", "."
  end

  test do
    system "wrangler", "generate"
    system "cd", "worker"
    system "wrangler", "build"
  end
end
```