### PR TITLE
Use rust template for rust project

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod installer;
 mod settings;
 mod terminal;
 
+use crate::settings::project::ProjectType;
 use terminal::emoji;
 
 fn main() -> Result<(), failure::Error> {
@@ -167,12 +168,19 @@ fn main() -> Result<(), failure::Error> {
     } else if let Some(matches) = matches.subcommand_matches("generate") {
         let name = matches.value_of("name").unwrap_or("worker");
         let project_type = match matches.value_of("type") {
-            Some(s) => Some(settings::project::ProjectType::from_str(&s.to_lowercase())?),
+            Some(s) => Some(ProjectType::from_str(&s.to_lowercase())?),
             None => None,
         };
-        let template = matches
-            .value_of("template")
-            .unwrap_or("https://github.com/cloudflare/worker-template");
+
+        let default_template = "https://github.com/cloudflare/worker-template";
+        let template = matches.value_of("template").unwrap_or(match project_type {
+            Some(ref pt) => match pt {
+                ProjectType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
+                _ => default_template,
+            },
+            _ => default_template,
+        });
+
         info!(
             "Generate command called with template {}, and name {}",
             template, name


### PR DESCRIPTION
This PR will use the template at https://github.com/cloudflare/rustwasm-worker-template when `—type rust` is passed to `wrangler generate`