### PR TITLE
Add acceptance test procedures for KV config

### DIFF
--- a/tests/end_to_end/kv_namespace_config/README.md
+++ b/tests/end_to_end/kv_namespace_config/README.md
@@ -1,0 +1,128 @@
+For each of the Wrangler projects in this directory, the following procedure should result in a successful write to a KV namespace in the user's project.
+
+## Setup: do once for all tests
+
+### Set env vars
+
+`test_env.sh.sample` contains all the env var keys you should need to run these tests. `cp` it to `test_env.sh` and run `source test_env.sh` before testing to pull those keys into your environment during testing.
+
+### Add test KV namespace
+
+Before running any of these tests, you should have a Cloudflare account with entitlement for KV. You should also have configured a subdomain for your Cloudflare account.
+
+Run the following curl command to add the appropriate KV namespace, substituting your Cloudflare Account ID, Auth Email, and Auth Key. It's a good idea to export these as environment variables if you find yourself repeatedly running these commands.
+
+``` sh
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY" \
+     -H "Content-Type: application/json" \
+     --data '{"title":"test kv integration"}'
+```
+
+The output of this request will look like the following:
+
+``` sh
+{
+  "result": {
+    "id": "a99213f3975246aca6b83dec10873c97",
+    "title": "test kv integration"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+```
+
+Record the `result.id` field for use in the wrangler.toml files. Consider also adding it as an environment variable `$NAMESPACE_ID` to aid in this process.
+
+#### Error: namespace already exists
+
+If you receive an error that looks like this:
+
+``` sh
+{
+  "result": null,
+  "success": false,
+  "errors": [
+    {
+      "code": 10014,
+      "message": "a namespace with this account ID and title already exists"
+    }
+  ],
+  "messages": []
+}
+```
+
+Run the following to get a list of your namespaces.
+
+``` sh
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY"
+```
+
+And find the entry with title "test kv integration".
+
+### Set a value in your new namespace.
+
+Run the following to set the KV pair "foo: bar" on the test namespace, subbing in your auth values and the NAMESPACE_ID you retrieved in the Create KV Namespace step:
+
+``` sh
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces/$NAMESPACE_ID/values/foo" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY" \
+     -H "Content-Type: text/plain" \
+     --data 'bar'
+```
+
+This value will take about ten seconds to populate to the edge, so keep this in mind when automating these tests. The same key/value pair is used across tests.
+
+### Configure Wrangler
+
+[TODO: Outline how this is done in a dev env]
+Run `cargo run -- config` with your Cloudflare auth email and auth key.
+
+## Per project
+
+In each project, add your account id and the newly generated kv namespace id to the toml (both of these should be strings):
+
+``` toml
+name = "webpack-worker"
+type = "webpack"
+private = false
+account_id = <YOUR ACCOUNT ID>
+
+[[kv-namespaces]]
+binding = "TEST_KV_INTEGRATION"
+id = "NEW KV NAMESPACE ID"
+```
+
+From the project root:
+
+* Run `cargo run -- publish` and wait for the command to complete.
+* Run the following `curl` command, substituting your workers.dev subdomain:
+
+``` sh
+curl -X GET "https://test-worker.$YOUR_SUBDOMAIN.workers.dev"
+```
+
+The response should include the value you added to the KV store in the setup stage (in this case "bar").
+
+## Clean up
+
+Run the following three `curl` commands to clean up your namespace and your worker:
+
+``` sh
+curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces/$NAMESPACE_ID/values/foo" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY"
+
+curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces/$NAMESPACE_ID" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY"
+
+curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$SCRIPT_NAME" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_AUTH_KEY"
+```

--- a/tests/end_to_end/kv_namespace_config/js_with_kv/webpack-worker/index.js
+++ b/tests/end_to_end/kv_namespace_config/js_with_kv/webpack-worker/index.js
@@ -1,0 +1,17 @@
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+/**
+ * read value "bar" from key "foo" in KV namespace "TEST_KV_INTEGRATION"
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+	try {
+		let value = await TEST_KV_INTEGRATION.get('foo')
+
+	    return new Response(`The value at key foo is ${value}`, { status: 200 })
+	} catch (e) {
+		return new Response(`internal error: ${e.message}`, { status: 500 })
+	}
+}

--- a/tests/end_to_end/kv_namespace_config/js_with_kv/webpack-worker/wrangler.toml
+++ b/tests/end_to_end/kv_namespace_config/js_with_kv/webpack-worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "js-worker"
+type = "js"
+private = false
+account_id = "43434f8d0d9f52a395a1472b35f23439"
+
+[[kv-namespaces]]
+binding = "TEST_KV_INTEGRATION"
+id = ""

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/Cargo.toml
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "wasm-worker"
+version = "0.1.0"
+authors = ["Ashley Lewis <alewis@cloudflare.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+cfg-if = "0.1.2"
+wasm-bindgen = "0.2"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.1", optional = true }
+
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however.
+#
+# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
+wee_alloc = { version = "0.4.2", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.2"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/src/lib.rs
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate cfg_if;
+extern crate wasm_bindgen;
+
+mod utils;
+
+use cfg_if::cfg_if;
+use wasm_bindgen::prelude::*;
+
+cfg_if! {
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+    // allocator.
+    if #[cfg(feature = "wee_alloc")] {
+        extern crate wee_alloc;
+        #[global_allocator]
+        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+    }
+}
+
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello, wasm-worker!".to_string()
+}

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/src/utils.rs
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/src/utils.rs
@@ -1,0 +1,17 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    if #[cfg(feature = "console_error_panic_hook")] {
+        extern crate console_error_panic_hook;
+        pub use self::console_error_panic_hook::set_once as set_panic_hook;
+    } else {
+        #[inline]
+        pub fn set_panic_hook() {}
+    }
+}

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/tests/web.rs
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/tests/web.rs
@@ -1,0 +1,12 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/worker/worker.js
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/worker/worker.js
@@ -1,0 +1,21 @@
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+/**
+ * read value "bar" from key "foo" in KV namespace "TEST_KV_INTEGRATION"
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+	try {
+		let value = await TEST_KV_INTEGRATION.get('foo')
+
+	    const { greet } = wasm_bindgen
+	    await wasm_bindgen(wasm)
+	    const greeting = greet()
+
+	    return new Response(`${greeting}. The value at key foo is ${value}`, { status: 200 })
+	} catch (e) {
+		return new Response(`internal error: ${e.message}`, { status: 500 })
+	}
+}

--- a/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/wrangler.toml
+++ b/tests/end_to_end/kv_namespace_config/rust_with_kv/wasm-worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "wasm-worker"
+type = "rust"
+private = false
+account_id = ""
+
+[[kv-namespaces]]
+binding = "TEST_KV_INTEGRATION"
+id = ""

--- a/tests/end_to_end/kv_namespace_config/test_env.sample.sh
+++ b/tests/end_to_end/kv_namespace_config/test_env.sample.sh
@@ -1,0 +1,10 @@
+# config.sample.sh
+
+# https://workers.cloudflare.com/docs/quickstart/api-keys/
+CLOUDFLARE_AUTH_EMAIL=""
+CLOUDFLARE_AUTH_KEY=""
+CLOUDFLARE_ACCOUNT_ID=""
+# your workers.dev subdomain
+YOUR_SUBDOMAIN=""
+# the id returned from workers kv api in the Setup phase
+NAMESPACE_ID=""

--- a/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/index.js
+++ b/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/index.js
@@ -1,0 +1,17 @@
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+/**
+ * read value "bar" from key "foo" in KV namespace "TEST_KV_INTEGRATION"
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+	try {
+		let value = await TEST_KV_INTEGRATION.get('foo')
+
+	    return new Response(`The value at key foo is ${value}`, { status: 200 })
+	} catch (e) {
+		return new Response(`internal error: ${e.message}`, { status: 500 })
+	}
+}

--- a/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/package.json
+++ b/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "webpack-worker",
+    "version": "1.0.0",
+    "description": "A template for kick starting a Cloudflare Workers project",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "format": "prettier --write '**/*.{js,css,json,md}'"
+    },
+    "author": "Ashley Lewis <alewis@cloudflare.com>",
+    "license": "MIT",
+    "devDependencies": {
+        "husky": "^2.1.0",
+        "prettier": "^1.17.0"
+    }
+}

--- a/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/wrangler.toml
+++ b/tests/end_to_end/kv_namespace_config/webpack_with_kv/webpack-worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "webpack-worker"
+type = "webpack"
+private = false
+account_id = ""
+
+[[kv-namespaces]]
+binding = "TEST_KV_INTEGRATION"
+id = ""


### PR DESCRIPTION
This PR starts to outline the happy path acceptance procedure for KV Config. Remaining steps include:

- state the expected output for each step (that isn't already defined in the code).
- another pr to add sad path test instructions.

closes #297 