### PR TITLE
Better error printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "exitfailure"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +1935,7 @@ dependencies = [
  "console 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "exitfailure 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,6 +2039,7 @@ dependencies = [
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
+"checksum exitfailure 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ number_prefix = "0.3.0"
 flate2 = "1.0.7"
 base64 = "0.10.1"
 lazy_static = "1.3.0"
+exitfailure = "0.5.1"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure)]
 
 use std::env;
-use std::process;
 use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg, SubCommand};
@@ -17,9 +16,10 @@ mod settings;
 mod terminal;
 
 use crate::settings::project::ProjectType;
+use exitfailure::ExitFailure;
 use terminal::emoji;
 
-fn main() {
+fn main() -> Result<(), ExitFailure> {
     env_logger::init();
     if let Ok(me) = env::current_exe() {
         // If we're actually running as the installer then execute our
@@ -31,11 +31,9 @@ fn main() {
             .starts_with("wrangler-init")
         {
             installer::install();
-        } else if let Err(e) = run() {
-            eprintln!("{}", e);
-            process::exit(1);
         }
     }
+    Ok(run()?)
 }
 
 fn run() -> Result<(), failure::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::redundant_closure)]
 
 use std::env;
-use std::str::FromStr;
 use std::process;
+use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg, SubCommand};
 use commands::HTTPMethod;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::str::FromStr;
+use std::process;
 
 use clap::{App, AppSettings, Arg, SubCommand};
 use commands::HTTPMethod;
@@ -31,7 +32,8 @@ fn main() {
         {
             installer::install();
         } else if let Err(e) = run() {
-            println!("{}", e);
+            eprintln!("{}", e);
+            process::exit(1);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod terminal;
 use crate::settings::project::ProjectType;
 use terminal::emoji;
 
-fn main() -> Result<(), failure::Error> {
+fn main() {
     env_logger::init();
     if let Ok(me) = env::current_exe() {
         // If we're actually running as the installer then execute our
@@ -30,9 +30,13 @@ fn main() -> Result<(), failure::Error> {
             .starts_with("wrangler-init")
         {
             installer::install();
+        } else if let Err(e) = run() {
+            println!("{}", e);
         }
     }
+}
 
+fn run() -> Result<(), failure::Error> {
     let matches = App::new(format!("{}{} wrangler", emoji::WORKER, emoji::SPARKLES))
         .version(env!("CARGO_PKG_VERSION"))
         .author("ashley g williams <ashley666ashley@gmail.com>")

--- a/src/terminal/emoji.rs
+++ b/src/terminal/emoji.rs
@@ -25,6 +25,6 @@ pub static SLEUTH: Emoji = Emoji("🕵️‍♂️", "");
 pub static SPARKLES: Emoji = Emoji("✨  ", "");
 pub static SWIRL: Emoji = Emoji("🌀 ", "");
 pub static UP: Emoji = Emoji("🆙 ", "");
-pub static WARN: Emoji = Emoji("⛔ ", "");
+pub static WARN: Emoji = Emoji("⚠️", "");
 pub static WAVING: Emoji = Emoji("👋 ", "");
 pub static WORKER: Emoji = Emoji("👷 ", "");

--- a/src/terminal/emoji.rs
+++ b/src/terminal/emoji.rs
@@ -25,6 +25,6 @@ pub static SLEUTH: Emoji = Emoji("🕵️‍♂️", "");
 pub static SPARKLES: Emoji = Emoji("✨  ", "");
 pub static SWIRL: Emoji = Emoji("🌀 ", "");
 pub static UP: Emoji = Emoji("🆙 ", "");
-pub static WARN: Emoji = Emoji("⚠️", "");
+pub static WARN: Emoji = Emoji("⚠️ ", "");
 pub static WAVING: Emoji = Emoji("👋 ", "");
 pub static WORKER: Emoji = Emoji("👷 ", "");


### PR DESCRIPTION
The default `Termination` impl for `Result` uses `Debug` to print any `Result::Err` returned by `main`. This PR overrides that behavior by moving the contents of main into a wrapper function that we can print the result of ourselves using `Display` instead.
This will print errors in a more human readable fashion.