### PR TITLE
Always use multipart upload

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1,24 +1,22 @@
 mod krate;
+pub mod package;
 pub mod preview;
 mod route;
-use route::Route;
+mod script_upload_form;
 
-pub mod package;
 use package::Package;
+use route::Route;
+use script_upload_form::build_script_upload_form;
 
 use log::info;
 
-use reqwest::multipart::{Form, Part};
 use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
 
 use crate::commands;
-use crate::commands::build::wranglerjs::Bundle;
 use crate::commands::subdomain::Subdomain;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::Project;
 use crate::terminal::message;
 
 pub fn publish(user: &GlobalUser, project: &Project, release: bool) -> Result<(), failure::Error> {
@@ -120,26 +118,6 @@ fn publish_script(
     Ok(())
 }
 
-pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
-    let project_type = &project.project_type;
-    let script_upload_form = match project_type {
-        ProjectType::Rust => {
-            info!("Rust project detected. Publishing...");
-            build_multipart_script()?
-        }
-        ProjectType::JavaScript => {
-            info!("JavaScript project detected. Publishing...");
-            build_js_script()?
-        }
-        ProjectType::Webpack => {
-            info!("Webpack project detected. Publishing...");
-            build_webpack_form()?
-        }
-    };
-
-    Ok(script_upload_form)
-}
-
 fn build_subdomain_request() -> String {
     serde_json::json!({ "enabled":true}).to_string()
 }
@@ -176,90 +154,6 @@ fn make_public_on_subdomain(project: &Project, user: &GlobalUser) -> Result<(), 
         )
     }
     Ok(())
-}
-
-fn build_js_script() -> Result<Form, failure::Error> {
-    let package = Package::new("./")?;
-    let script_path = package.main()?;
-    let metadata_json = r#"{"body_part":"script","bindings":[]}"#;
-
-    let metadata = Part::text(metadata_json)
-        .file_name("metadata.json")
-        .mime_str("application/json")?;
-
-    let form = Form::new()
-        .file("script", script_path)
-        .unwrap_or_else(|_| panic!("{} not found. Did you rename your js files?", script_path));
-
-    form.part("metadata", metadata);
-
-    Ok(form)
-}
-
-fn build_multipart_script() -> Result<Form, failure::Error> {
-    let name = krate::Krate::new("./")?.name.replace("-", "_");
-    build_generated_dir()?;
-    concat_js(&name)?;
-
-    let metadata_path = "./worker/metadata_wasm.json";
-    let wasm_path = &format!("./pkg/{}_bg.wasm", name);
-    let script_path = "./worker/generated/script.js";
-
-    Ok(Form::new()
-        .file("metadata", metadata_path)
-        .unwrap_or_else(|_| panic!("{} not found. Did you delete it?", metadata_path))
-        .file("wasmprogram", wasm_path)
-        .unwrap_or_else(|_| panic!("{} not found. Have you run wrangler build?", wasm_path))
-        .file("script", script_path)
-        .unwrap_or_else(|_| panic!("{} not found. Did you rename your js files?", script_path)))
-}
-
-fn build_generated_dir() -> Result<(), failure::Error> {
-    let dir = "./worker/generated";
-    if !Path::new(dir).is_dir() {
-        fs::create_dir("./worker/generated")?;
-    }
-    Ok(())
-}
-
-fn concat_js(name: &str) -> Result<(), failure::Error> {
-    let bindgen_js_path = format!("./pkg/{}.js", name);
-    let bindgen_js: String = fs::read_to_string(bindgen_js_path)?.parse()?;
-
-    let worker_js: String = fs::read_to_string("./worker/worker.js")?.parse()?;
-    let js = format!("{} {}", bindgen_js, worker_js);
-
-    fs::write("./worker/generated/script.js", js.as_bytes())?;
-    Ok(())
-}
-
-fn build_webpack_form() -> Result<Form, failure::Error> {
-    // FIXME(sven): shouldn't new
-    let bundle = Bundle::new();
-
-    let form = Form::new()
-        .file("metadata", bundle.metadata_path())
-        .unwrap_or_else(|_| panic!("{} not found. Did you delete it?", bundle.metadata_path()))
-        .file("script", bundle.script_path())
-        .unwrap_or_else(|_| {
-            panic!(
-                "{} not found. Did you rename your js files?",
-                bundle.script_path()
-            )
-        });
-
-    if bundle.has_wasm() {
-        Ok(form
-            .file(bundle.get_wasm_binding(), bundle.wasm_path())
-            .unwrap_or_else(|_| {
-                panic!(
-                    "{} not found. Have you run wrangler build?",
-                    bundle.wasm_path()
-                )
-            }))
-    } else {
-        Ok(form)
-    }
 }
 
 fn validate_project(project: &Project, release: bool) -> Result<(), failure::Error> {

--- a/src/commands/publish/script_upload_form.rs
+++ b/src/commands/publish/script_upload_form.rs
@@ -1,0 +1,112 @@
+use log::info;
+
+use reqwest::multipart::{Form, Part};
+use std::fs;
+use std::path::Path;
+
+use crate::commands::build::wranglerjs::Bundle;
+use crate::settings::project::{Project, ProjectType};
+
+use super::{krate, Package};
+
+pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
+    let project_type = &project.project_type;
+    let script_upload_form = match project_type {
+        ProjectType::Rust => {
+            info!("Rust project detected. Publishing...");
+            build_multipart_script()?
+        }
+        ProjectType::JavaScript => {
+            info!("JavaScript project detected. Publishing...");
+            build_js_script()?
+        }
+        ProjectType::Webpack => {
+            info!("Webpack project detected. Publishing...");
+            build_webpack_form()?
+        }
+    };
+
+    Ok(script_upload_form)
+}
+
+fn build_js_script() -> Result<Form, failure::Error> {
+    let package = Package::new("./")?;
+    let script_path = package.main()?;
+    let metadata_json = r#"{"body_part":"script","bindings":[]}"#;
+
+    let metadata = Part::text(metadata_json)
+        .file_name("metadata.json")
+        .mime_str("application/json")?;
+
+    Ok(Form::new()
+        .file("script", &script_path)
+        .unwrap_or_else(|_| panic!("{} not found. Did you rename your js files?", &script_path))
+        .part("metadata", metadata))
+}
+
+fn build_multipart_script() -> Result<Form, failure::Error> {
+    let name = krate::Krate::new("./")?.name.replace("-", "_");
+    build_generated_dir()?;
+    concat_js(&name)?;
+
+    let metadata_path = "./worker/metadata_wasm.json";
+    let wasm_path = &format!("./pkg/{}_bg.wasm", name);
+    let script_path = "./worker/generated/script.js";
+
+    Ok(Form::new()
+        .file("metadata", metadata_path)
+        .unwrap_or_else(|_| panic!("{} not found. Did you delete it?", metadata_path))
+        .file("wasmprogram", wasm_path)
+        .unwrap_or_else(|_| panic!("{} not found. Have you run wrangler build?", wasm_path))
+        .file("script", script_path)
+        .unwrap_or_else(|_| panic!("{} not found. Did you rename your js files?", script_path)))
+}
+
+fn build_generated_dir() -> Result<(), failure::Error> {
+    let dir = "./worker/generated";
+    if !Path::new(dir).is_dir() {
+        fs::create_dir("./worker/generated")?;
+    }
+
+    Ok(())
+}
+
+fn concat_js(name: &str) -> Result<(), failure::Error> {
+    let bindgen_js_path = format!("./pkg/{}.js", name);
+    let bindgen_js: String = fs::read_to_string(bindgen_js_path)?.parse()?;
+
+    let worker_js: String = fs::read_to_string("./worker/worker.js")?.parse()?;
+    let js = format!("{} {}", bindgen_js, worker_js);
+
+    fs::write("./worker/generated/script.js", js.as_bytes())?;
+    Ok(())
+}
+
+fn build_webpack_form() -> Result<Form, failure::Error> {
+    // FIXME(sven): shouldn't new
+    let bundle = Bundle::new();
+
+    let form = Form::new()
+        .file("metadata", bundle.metadata_path())
+        .unwrap_or_else(|_| panic!("{} not found. Did you delete it?", bundle.metadata_path()))
+        .file("script", bundle.script_path())
+        .unwrap_or_else(|_| {
+            panic!(
+                "{} not found. Did you rename your js files?",
+                bundle.script_path()
+            )
+        });
+
+    if bundle.has_wasm() {
+        Ok(form
+            .file(bundle.get_wasm_binding(), bundle.wasm_path())
+            .unwrap_or_else(|_| {
+                panic!(
+                    "{} not found. Have you run wrangler build?",
+                    bundle.wasm_path()
+                )
+            }))
+    } else {
+        Ok(form)
+    }
+}


### PR DESCRIPTION
Closes #280 

Previously we would conditionally use multipart based on project type, but since all project types can have bindings, and since multipart works with or without bindings, this PR standardizes toward doing just that.

There is one ugly thing here that I would like advice on handling better. Commented inline.