### PR TITLE
feat kv config

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -126,6 +126,21 @@ fn validate_project(project: &Project, release: bool) -> Result<(), failure::Err
         missing_fields.push("name")
     };
 
+    match &project.kv_namespaces {
+        Some(kv_namespaces) => {
+            for kv in kv_namespaces {
+                if kv.binding.is_empty() {
+                    missing_fields.push("kv-namespace binding")
+                }
+
+                if kv.id.is_empty() {
+                    missing_fields.push("kv-namespace id")
+                }
+            }
+        }
+        None => {}
+    }
+
     let destination = if release {
         //check required fields for release
         if project

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -10,8 +10,6 @@ use upload_form::build_script_upload_form;
 
 use log::info;
 
-use std::collections::HashMap;
-
 use crate::commands;
 use crate::commands::subdomain::Subdomain;
 use crate::http;
@@ -24,7 +22,6 @@ pub fn publish(user: &GlobalUser, project: &Project, release: bool) -> Result<()
 
     validate_project(project, release)?;
     commands::build(&project)?;
-    create_kv_namespaces(user, &project)?;
     publish_script(&user, &project, release)?;
     if release {
         info!("release mode detected, making a route...");
@@ -37,43 +34,6 @@ pub fn publish(user: &GlobalUser, project: &Project, release: bool) -> Result<()
         message::success(&msg);
     } else {
         message::success("Success! Your worker was successfully published.");
-    }
-    Ok(())
-}
-
-pub fn create_kv_namespaces(user: &GlobalUser, project: &Project) -> Result<(), failure::Error> {
-    let kv_addr = format!(
-        "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces",
-        project.account_id,
-    );
-
-    let client = http::auth_client(user);
-
-    if let Some(namespaces) = &project.kv_namespaces {
-        for namespace in namespaces {
-            info!("Attempting to create namespace '{}'", namespace);
-
-            let mut map = HashMap::new();
-            map.insert("title", namespace);
-
-            let request = client.post(&kv_addr).json(&map).send();
-
-            if let Err(error) = request {
-                // A 400 is returned if the account already owns a namespace with this title.
-                //
-                // https://api.cloudflare.com/#workers-kv-namespace-create-a-namespace
-                match error.status() {
-                    Some(code) if code == 400 => {
-                        info!("Namespace '{}' already exists, continuing.", namespace)
-                    }
-                    _ => {
-                        info!("Error when creating namespace '{}'", namespace);
-                        failure::bail!("⛔ Something went wrong! Error: {}", error)
-                    }
-                }
-            }
-            info!("Namespace '{}' exists now", namespace)
-        }
     }
     Ok(())
 }

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use crate::commands::build::wranglerjs::Bundle;
 use crate::settings::binding;
 use crate::settings::metadata::Metadata;
+use crate::settings::project::kv_namespace;
 use crate::settings::project::{Project, ProjectType};
 
 use project_assets::ProjectAssets;
@@ -20,6 +21,7 @@ use super::{krate, Package};
 
 pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
     let project_type = &project.project_type;
+    let kv_namespaces = project.kv_namespaces();
     match project_type {
         ProjectType::Rust => {
             info!("Rust project detected. Publishing...");
@@ -39,6 +41,7 @@ pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Erro
             let assets = ProjectAssets {
                 script_path,
                 wasm_modules: vec![wasm_module],
+                kv_namespaces,
             };
 
             build_form(&assets)
@@ -52,6 +55,7 @@ pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Erro
             let assets = ProjectAssets {
                 script_path,
                 wasm_modules: Vec::new(),
+                kv_namespaces,
             };
 
             build_form(&assets)
@@ -77,6 +81,7 @@ pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Erro
             let assets = ProjectAssets {
                 script_path,
                 wasm_modules,
+                kv_namespaces,
             };
 
             build_form(&assets)

--- a/src/commands/publish/upload_form/project_assets.rs
+++ b/src/commands/publish/upload_form/project_assets.rs
@@ -1,11 +1,13 @@
 use super::binding::Binding;
 use super::file::File;
+use super::kv_namespace::KvNamespace;
 use super::wasm_module::WasmModule;
 
 #[derive(Debug)]
 pub struct ProjectAssets {
     pub script_path: String,
     pub wasm_modules: Vec<WasmModule>,
+    pub kv_namespaces: Vec<KvNamespace>,
 }
 
 impl ProjectAssets {
@@ -18,8 +20,8 @@ impl ProjectAssets {
         files.push(script);
 
         for wm in &self.wasm_modules {
-            let wasm = wm.file();
-            files.push(wasm);
+            let file = wm.file();
+            files.push(file);
         }
 
         files
@@ -28,8 +30,12 @@ impl ProjectAssets {
     pub fn bindings(&self) -> Vec<Binding> {
         let mut bindings = Vec::new();
         for wm in &self.wasm_modules {
-            let wasm = wm.binding();
-            bindings.push(wasm);
+            let binding = wm.binding();
+            bindings.push(binding);
+        }
+        for kv in &self.kv_namespaces {
+            let binding = kv.binding();
+            bindings.push(binding);
         }
 
         bindings

--- a/src/settings/binding.rs
+++ b/src/settings/binding.rs
@@ -5,10 +5,16 @@ use serde::Serialize;
 pub enum Binding {
     #[allow(non_camel_case_types)]
     wasm_module { name: String, part: String },
+    #[allow(non_camel_case_types)]
+    kv_namespace { name: String, namespace_id: String },
 }
 
 impl Binding {
     pub fn new_wasm_module(name: String, part: String) -> Binding {
         Binding::wasm_module { name, part }
+    }
+
+    pub fn new_kv_namespace(name: String, namespace_id: String) -> Binding {
+        Binding::kv_namespace { name, namespace_id }
     }
 }

--- a/src/settings/project/kv_namespace.rs
+++ b/src/settings/project/kv_namespace.rs
@@ -3,18 +3,18 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct KVNamespace {
+pub struct KvNamespace {
     pub id: String,
     pub binding: String,
 }
 
-impl fmt::Display for KVNamespace {
+impl fmt::Display for KvNamespace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "id: {}, binding: {}", self.id, self.binding)
     }
 }
 
-impl std::cmp::PartialEq for KVNamespace {
+impl std::cmp::PartialEq for KvNamespace {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.binding == other.binding
     }

--- a/src/settings/project/kv_namespace.rs
+++ b/src/settings/project/kv_namespace.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct KVNamespace {
+    pub id: String,
+    pub binding: String,
+}
+
+impl fmt::Display for KVNamespace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "id: {}, binding: {}", self.id, self.binding)
+    }
+}
+
+impl std::cmp::PartialEq for KVNamespace {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.binding == other.binding
+    }
+}

--- a/src/settings/project/kv_namespace.rs
+++ b/src/settings/project/kv_namespace.rs
@@ -1,3 +1,4 @@
+use crate::settings::binding::Binding;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -17,5 +18,11 @@ impl fmt::Display for KvNamespace {
 impl std::cmp::PartialEq for KvNamespace {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.binding == other.binding
+    }
+}
+
+impl KvNamespace {
+    pub fn binding(&self) -> Binding {
+        Binding::new_kv_namespace(self.binding.clone(), self.id.clone())
     }
 }

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -1,10 +1,14 @@
+mod kv_namespace;
+mod project_type;
+
+pub use kv_namespace::KVNamespace;
+pub use project_type::ProjectType;
+
 use crate::terminal::emoji;
 
 use std::collections::HashMap;
-use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use log::info;
 
@@ -24,62 +28,6 @@ pub struct Project {
     pub routes: Option<HashMap<String, String>>,
     #[serde(rename = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<KVNamespace>>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ProjectType {
-    JavaScript,
-    Rust,
-    Webpack,
-}
-
-impl Default for ProjectType {
-    fn default() -> Self {
-        ProjectType::Webpack
-    }
-}
-
-impl fmt::Display for ProjectType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match *self {
-            ProjectType::JavaScript => "js",
-            ProjectType::Rust => "rust",
-            ProjectType::Webpack => "webpack",
-        };
-        write!(f, "{}", printable)
-    }
-}
-
-impl FromStr for ProjectType {
-    type Err = failure::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "javascript" => Ok(ProjectType::JavaScript),
-            "rust" => Ok(ProjectType::Rust),
-            "webpack" => Ok(ProjectType::Webpack),
-            _ => failure::bail!("{} is not a valid wrangler project type!", s),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct KVNamespace {
-    id: String,
-    binding: String,
-}
-
-impl fmt::Display for KVNamespace {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "id: {}, binding: {}", self.id, self.binding)
-    }
-}
-
-impl std::cmp::PartialEq for KVNamespace {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.binding == other.binding
-    }
 }
 
 impl Project {

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -1,4 +1,4 @@
-mod kv_namespace;
+pub mod kv_namespace;
 mod project_type;
 
 pub use kv_namespace::KvNamespace;
@@ -66,6 +66,13 @@ impl Project {
         config_path.push("./wrangler.toml");
 
         get_project_config(config_path)
+    }
+
+    pub fn kv_namespaces(&self) -> Vec<KvNamespace> {
+        match &self.kv_namespaces {
+            Some(kv) => kv.clone(),
+            None => Vec::new(),
+        }
     }
 }
 

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -23,7 +23,7 @@ pub struct Project {
     pub route: Option<String>,
     pub routes: Option<HashMap<String, String>>,
     #[serde(rename = "kv-namespaces")]
-    pub kv_namespaces: Option<Vec<String>>,
+    pub kv_namespaces: Option<Vec<KVNamespace>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -64,6 +64,24 @@ impl FromStr for ProjectType {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct KVNamespace {
+    id: String,
+    binding: String,
+}
+
+impl fmt::Display for KVNamespace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "id: {}, binding: {}", self.id, self.binding)
+    }
+}
+
+impl std::cmp::PartialEq for KVNamespace {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.binding == other.binding
+    }
+}
+
 impl Project {
     pub fn generate(
         name: String,
@@ -96,14 +114,16 @@ impl Project {
     }
 
     pub fn new() -> Result<Self, failure::Error> {
-        get_project_config()
+        let mut config_path = PathBuf::new();
+        config_path.push("./wrangler.toml");
+
+        get_project_config(config_path)
     }
 }
 
-pub fn get_project_config() -> Result<Project, failure::Error> {
+fn get_project_config(config_path: PathBuf) -> Result<Project, failure::Error> {
     let mut s = Config::new();
 
-    let config_path = Path::new("./wrangler.toml");
     let config_str = config_path
         .to_str()
         .expect("project config path should be a string");
@@ -126,3 +146,6 @@ pub fn get_project_config() -> Result<Project, failure::Error> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -1,7 +1,7 @@
 mod kv_namespace;
 mod project_type;
 
-pub use kv_namespace::KVNamespace;
+pub use kv_namespace::KvNamespace;
 pub use project_type::ProjectType;
 
 use crate::terminal::emoji;
@@ -27,7 +27,7 @@ pub struct Project {
     pub route: Option<String>,
     pub routes: Option<HashMap<String, String>>,
     #[serde(rename = "kv-namespaces")]
-    pub kv_namespaces: Option<Vec<KVNamespace>>,
+    pub kv_namespaces: Option<Vec<KvNamespace>>,
 }
 
 impl Project {

--- a/src/settings/project/project_type.rs
+++ b/src/settings/project/project_type.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProjectType {
+    JavaScript,
+    Rust,
+    Webpack,
+}
+
+impl Default for ProjectType {
+    fn default() -> Self {
+        ProjectType::Webpack
+    }
+}
+
+impl fmt::Display for ProjectType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            ProjectType::JavaScript => "js",
+            ProjectType::Rust => "rust",
+            ProjectType::Webpack => "webpack",
+        };
+        write!(f, "{}", printable)
+    }
+}
+
+impl FromStr for ProjectType {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "javascript" => Ok(ProjectType::JavaScript),
+            "rust" => Ok(ProjectType::Rust),
+            "webpack" => Ok(ProjectType::Webpack),
+            _ => failure::bail!("{} is not a valid wrangler project type!", s),
+        }
+    }
+}

--- a/src/settings/project/tests/mod.rs
+++ b/src/settings/project/tests/mod.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn it_builds_from_config() {
+    let toml_path = toml_fixture_path("default");
+
+    let project = get_project_config(toml_path).unwrap();
+
+    assert!(project.kv_namespaces.is_none());
+}
+
+#[test]
+fn it_builds_from_config_with_kv() {
+    let toml_path = toml_fixture_path("kv_namespaces");
+
+    let project = get_project_config(toml_path).unwrap();
+
+    let kv_1 = KVNamespace {
+        id: "somecrazylongidentifierstring".to_string(),
+        binding: "prodKV".to_string(),
+    };
+    let kv_2 = KVNamespace {
+        id: "anotherwaytoolongidstring".to_string(),
+        binding: "stagingKV".to_string(),
+    };
+
+    match project.kv_namespaces {
+        Some(kv_namespaces) => {
+            assert!(kv_namespaces.len() == 2);
+            assert!(kv_namespaces.contains(&kv_1));
+            assert!(kv_namespaces.contains(&kv_2));
+        }
+        None => assert!(false),
+    }
+}
+
+fn toml_fixture_path(fixture: &str) -> PathBuf {
+    let current_dir = env::current_dir().unwrap();
+
+    // TODO: This is kind of stupid but idk worth it for now?
+    Path::new(&current_dir)
+        .join("src")
+        .join("settings")
+        .join("project")
+        .join("tests")
+        .join("tomls")
+        .join(fixture)
+}

--- a/src/settings/project/tests/mod.rs
+++ b/src/settings/project/tests/mod.rs
@@ -18,11 +18,11 @@ fn it_builds_from_config_with_kv() {
 
     let project = get_project_config(toml_path).unwrap();
 
-    let kv_1 = KVNamespace {
+    let kv_1 = KvNamespace {
         id: "somecrazylongidentifierstring".to_string(),
         binding: "prodKV".to_string(),
     };
-    let kv_2 = KVNamespace {
+    let kv_2 = KvNamespace {
         id: "anotherwaytoolongidstring".to_string(),
         binding: "stagingKV".to_string(),
     };

--- a/src/settings/project/tests/tomls/default.toml
+++ b/src/settings/project/tests/tomls/default.toml
@@ -1,0 +1,6 @@
+name = "worker"
+type = "webpack"
+zone_id = ""
+private = false
+account_id = ""
+route = ""

--- a/src/settings/project/tests/tomls/kv_namespaces.toml
+++ b/src/settings/project/tests/tomls/kv_namespaces.toml
@@ -1,0 +1,14 @@
+name = "worker"
+type = "webpack"
+zone_id = ""
+private = false
+account_id = ""
+route = ""
+
+[[kv-namespaces]]
+id = "somecrazylongidentifierstring"
+binding = "prodKV"
+
+[[kv-namespaces]]
+id = "anotherwaytoolongidstring"
+binding = "stagingKV"


### PR DESCRIPTION
This PR starts us off on grabbing the correct info from `wrangler.toml` for KVNamespace support. Two breaking changes to note:

- as of this feature, we will no longer provision namespaces on behalf of the user. We will revisit that feature once we implement KV subcommands.
- KV Namespace now takes both an `id` and a `binding` name in the toml per design.
- Wrangler includes KV Namespace Bindings in upload requests

~Next PR to include logic for including KV Bindings in upload requests 🎉~ Pushed up KV Bindings upload here...

API Error handling to come.