### PR TITLE
Fixes #278 - Check for rust before installing wasm-pack

### DIFF
--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -64,7 +64,7 @@ pub fn run_build(project: &Project) -> Result<(), failure::Error> {
 
 //setup a build to run wranglerjs, return the command, the ipc temp file, and the bundle
 fn setup_build(project: &Project) -> Result<(Command, PathBuf, Bundle), failure::Error> {
-    for tool in &["node", "npm"] {
+    for tool in &["node", "npm", "rustc"] {
         env_dep_installed(tool)?;
     }
 


### PR DESCRIPTION
I tried to pull in [mocktopus](https://github.com/CodeSandwich/Mocktopus), but it is only available for nightly rust, so I did not go through with it. Let me know about your preference for mocking in tests.