### PR TITLE
Add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+### 🐛 Bug Report
+
+<!-- Please answer these questions before submitting your issue. Thanks! -->
+
+#### What version of Wrangler are you using (`wrangler -V`)?
+
+<pre>
+$ wrangler -V
+
+</pre>
+
+#### Does this issue reproduce with the latest release?
+
+
+
+#### What environment are you using?
+* operating system:
+* rustc version:
+
+#### What did you do?
+
+<!--
+If possible, provide a recipe for reproducing the error.
+-->
+
+#### What did you expect to see?
+
+
+
+#### What did you see instead?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+title: 'Bug report'
+labels: user report
+---
+
 ### 🐛 Bug Report
 
 <!-- Please answer these questions before submitting your issue. Thanks! -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,7 @@ $ wrangler -V
 #### What environment are you using?
 * operating system:
 * rustc version:
+* node version:
 
 #### What did you do?
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+---
+title: 'Feature request'
+labels: user report
+---
+
 ### 💡 Feature request
 
 <!-- Please answer these questions before submitting your issue. Thanks! -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,5 @@
+### 💡 Feature request
+Brief explanation of the requested feature.
+
+#### Basic example
+Include a basic code example of this new feature if possible. Omit this section if not applicable.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,8 @@
 ### 💡 Feature request
+
+<!-- Please answer these questions before submitting your issue. Thanks! -->
+
+#### Overview and problem statement
 Brief explanation of the requested feature, and a description of the problem it would solve.
 
 #### Basic example

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ### 💡 Feature request
-Brief explanation of the requested feature.
+Brief explanation of the requested feature, and a description of the problem it would solve.
 
 #### Basic example
 Include a basic code example of this new feature if possible. Omit this section if not applicable.


### PR DESCRIPTION
This PR addresses #250 by adding a bug_report.md template and a feature_request.md template. I primarily drew the bug report template from golang's template, which is good at asking descriptive boilerplate questions to kickstart debugging/assessment.

Let me know if there are any boilerplate questions I might be missing.