### PR TITLE
Don't break `wrangler preview` when kv namespaces present

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -6,7 +6,7 @@ mod upload_form;
 
 use package::Package;
 use route::Route;
-use upload_form::build_script_upload_form;
+use upload_form::{build_script_upload_form, build_script_upload_form_no_kv};
 
 use log::info;
 
@@ -50,9 +50,7 @@ fn publish_script(
 
     let client = http::auth_client(user);
 
-    // we want to include kv namespaces when we publish, but not when we preview
-    let include_kv = true;
-    let script_upload_form = build_script_upload_form(project, include_kv)?;
+    let script_upload_form = build_script_upload_form(project)?;
 
     let mut res = client
         .put(&worker_addr)

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -50,7 +50,9 @@ fn publish_script(
 
     let client = http::auth_client(user);
 
-    let script_upload_form = build_script_upload_form(project)?;
+    // we want to include kv namespaces when we publish, but not when we preview
+    let include_kv = true;
+    let script_upload_form = build_script_upload_form(project, include_kv)?;
 
     let mut res = client
         .put(&worker_addr)

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -30,8 +30,7 @@ pub fn preview(
     commands::build(&project)?;
 
     // we want to include kv namespaces when we publish, but not when we preview
-    let include_kv = false;
-    let script_upload_form = publish::build_script_upload_form(project, include_kv)?;
+    let script_upload_form = publish::build_script_upload_form_no_kv(project)?;
 
     let res = client
         .post(create_address)

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -60,6 +60,12 @@ pub fn preview(
     let msg = format!("Your worker responded with: {}", worker_res);
     message::preview(&msg);
 
+    if project.kv_namespaces.is_some() {
+        message::warn(
+            "KV Namespaces are not supported in the preview. Consider defining a fallback value.",
+        );
+    }
+
     open(preview_host, https, script_id)?;
 
     Ok(())

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -29,7 +29,9 @@ pub fn preview(
 
     commands::build(&project)?;
 
-    let script_upload_form = publish::build_script_upload_form(project)?;
+    // we want to include kv namespaces when we publish, but not when we preview
+    let include_kv = false;
+    let script_upload_form = publish::build_script_upload_form(project, include_kv)?;
 
     let res = client
         .post(create_address)

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -19,16 +19,19 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_upload_form(
+pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
+    build_script_upload_form_with_kv(project, project.kv_namespaces())
+}
+
+pub fn build_script_upload_form_no_kv(project: &Project) -> Result<Form, failure::Error> {
+    build_script_upload_form_with_kv(project, Vec::new())
+}
+
+fn build_script_upload_form_with_kv(
     project: &Project,
-    include_kv: bool,
+    kv_namespaces: Vec<kv_namespace::KvNamespace>,
 ) -> Result<Form, failure::Error> {
     let project_type = &project.project_type;
-    let mut kv_namespaces = Vec::new();
-
-    if include_kv {
-        kv_namespaces = project.kv_namespaces();
-    }
 
     match project_type {
         ProjectType::Rust => {

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -19,9 +19,17 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
+pub fn build_script_upload_form(
+    project: &Project,
+    include_kv: bool,
+) -> Result<Form, failure::Error> {
     let project_type = &project.project_type;
-    let kv_namespaces = project.kv_namespaces();
+    let mut kv_namespaces = Vec::new();
+
+    if include_kv {
+        kv_namespaces = project.kv_namespaces();
+    }
+
     match project_type {
         ProjectType::Rust => {
             info!("Rust project detected. Publishing...");

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -24,3 +24,7 @@ pub fn working(msg: &str) {
 pub fn preview(msg: &str) {
     message(emoji::WORKER, msg);
 }
+
+pub fn warn(msg: &str) {
+    message(emoji::WARN, msg);
+}


### PR DESCRIPTION
the preview service as we use it today does not ignore kv namespace bindings, but throws an error when sent a script with those bindings. we don't want to take away a user's ability to use preview, for one, and we also want to give a helpful warning when they do.