### PR TITLE
Migrate straggler emojis to terminal::emoji

### DIFF
--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -1,6 +1,7 @@
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Project;
+use crate::terminal::emoji;
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 
@@ -27,10 +28,10 @@ impl Route {
         {
             failure::bail!("You must provide a zone_id in your wrangler.toml before publishing!");
         }
-
+        let msg_config_error = format!("{} Your project config has an error, check your `wrangler.toml`: `route` must be provided.", emoji::WARN);
         Ok(Route {
             script: Some(project.name.to_string()),
-            pattern: project.route.clone().expect("⚠️ Your project config has an error, check your `wrangler.toml`: `route` must be provided.").to_string(),
+            pattern: project.route.clone().expect(&msg_config_error),
         })
     }
 
@@ -70,7 +71,8 @@ fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failur
 
     if !res.status().is_success() {
         let msg = format!(
-            "⛔ There was an error fetching your project's routes.\n Status Code: {}\n Msg: {}",
+            "{} There was an error fetching your project's routes.\n Status Code: {}\n Msg: {}",
+            emoji::WARN,
             res.status(),
             res.text()?
         );
@@ -97,7 +99,8 @@ fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), fai
 
     if !res.status().is_success() {
         let msg = format!(
-            "⛔ There was an error creating your route.\n Status Code: {}\n Msg: {}",
+            "{} There was an error creating your route.\n Status Code: {}\n Msg: {}",
+            emoji::WARN,
             res.status(),
             res.text()?
         );

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -60,9 +60,10 @@ fn subdomain_addr(account_id: &str) -> String {
 
 pub fn subdomain(name: &str, user: &GlobalUser, project: &Project) -> Result<(), failure::Error> {
     if project.account_id.is_empty() {
-        failure::bail!(
-            "⛔ You must provide an account_id in your wrangler.toml before creating a subdomain!"
-        )
+        failure::bail!(format!(
+            "{} You must provide an account_id in your wrangler.toml before creating a subdomain!",
+            emoji::WARN
+        ))
     }
     let msg = format!(
         "Registering your subdomain, {}.workers.dev, this could take up to a minute.",

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -1,6 +1,8 @@
 mod krate;
 pub mod target;
 
+use crate::terminal::emoji;
+
 use binary_install::{Cache, Download};
 use krate::Krate;
 use log::info;
@@ -52,9 +54,8 @@ pub fn install_artifact(
 fn tool_exists(tool_name: &str) -> Option<Download> {
     if let Ok(path) = which(tool_name) {
         log::debug!("found global {} binary at: {}", tool_name, path.display());
-        Some(Download::at(
-            path.parent().expect("⚠️ There is no path parent"),
-        ))
+        let no_parent_msg = format!("{} There is no path parent", emoji::WARN);
+        Some(Download::at(path.parent().expect(&no_parent_msg)))
     } else {
         None
     }


### PR DESCRIPTION
This PR changes a few remaining instances where warngler was using hard-coded emojis for messages rather than `terminal::emoji`. There are two instances where this changes ⛔ to ⚠️, but the rest is simply a change in implementation.