### PR TITLE
Update issue templates to fit Github's data model

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,36 +1,30 @@
 ---
-title: 'Bug report'
+name: 🐛 Bug report
+about: Something's not quite right? You're in the right place!
 labels: user report
 ---
 
 ### 🐛 Bug Report
 
-<!-- Please answer these questions before submitting your issue. Thanks! -->
+<!-- 
+  Please fill out each section below before submitting your 🐛 bug report.
 
-#### What version of Wrangler are you using (`wrangler -V`)?
+  Before opening a new issue, please:
+  * search for existing issues: https://github.com/cloudflare/wrangler/issues
+  * make sure you are using the latest release: https://workers.cloudflare.com/docs/quickstart/updating-the-cli/
+  
+  Thanks! -->
 
-<pre>
-$ wrangler -V
+#### Environment
 
-</pre>
-
-#### Does this issue reproduce with the latest release?
-
-
-
-#### What environment are you using?
 * operating system:
-* rustc version:
-* node version:
+* output of `rustc -V`:
+* output of `node -v`:
 
-#### What did you do?
+#### Steps to reproduce
 
-<!--
-If possible, provide a recipe for reproducing the error.
--->
+<!-- Clear steps describing how to reproduce the issue. If you have a repository that exhibits the problem, please link it! -->
 
 #### What did you expect to see?
-
-
 
 #### What did you see instead?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,22 @@
 ---
-title: 'Feature request'
+nane: 💡 Feature request
+about: Suggest a feature for wrangler
 labels: user report
 ---
 
 ### 💡 Feature request
 
-<!-- Please answer these questions before submitting your issue. Thanks! -->
+<!-- 
+  Please fill out each section below before submitting your 💡 feature request.
+
+  Before opening a new issue, please search for existing issues: https://github.com/cloudflare/wrangler/issues
+
+  Thanks! -->
 
 #### Overview and problem statement
+
 Brief explanation of the requested feature, and a description of the problem it would solve.
 
 #### Basic example
+
 Include a basic code example of this new feature if possible. Omit this section if not applicable.


### PR DESCRIPTION
Our current issue templates are not being picked up by Github, this PR updates the templates to fit the accepted data model in addition to some style tweaks for the templates themselves.

![image](https://user-images.githubusercontent.com/9408157/62472062-91f66480-b763-11e9-9726-247157336f20.png)