### PR TITLE
Fix `wrangler config` for systems with non-unix EOL

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -17,11 +17,8 @@ pub fn set_file_mode(file: &PathBuf) {
         .expect("could not set permissions on file");
 }
 
-pub fn global_config(email: &str, api_key: &str) -> Result<(), failure::Error> {
-    let s = GlobalUser {
-        email: email.to_string(),
-        api_key: api_key.to_string(),
-    };
+pub fn global_config(email: String, api_key: String) -> Result<(), failure::Error> {
+    let s = GlobalUser { email, api_key };
 
     let toml = toml::to_string(&s)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,11 +153,13 @@ fn run() -> Result<(), failure::Error> {
 
     if let Some(_matches) = matches.subcommand_matches("config") {
         println!("Enter email: ");
-        let email: String = read!("{}\n");
+        let mut email: String = read!("{}\n");
+        email.truncate(email.trim_end().len());
         println!("Enter api key: ");
-        let api_key: String = read!("{}\n");
+        let mut api_key: String = read!("{}\n");
+        api_key.truncate(api_key.trim_end().len());
 
-        commands::global_config(&email, &api_key)?;
+        commands::global_config(email, api_key)?;
     } else if let Some(matches) = matches.subcommand_matches("generate") {
         let name = matches.value_of("name").unwrap_or("worker");
         let project_type = match matches.value_of("type") {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -5,15 +5,24 @@ use std::io::prelude::*;
 use std::process::{Child, Command, Stdio};
 
 #[test]
-fn it_generates_the_config() {
+fn it_generates_the_config_unix_eol() {
+    generate_config_with("\n");
+}
+
+#[test]
+fn it_generates_the_config_windows_eol() {
+    generate_config_with("\r\n");
+}
+
+fn generate_config_with(eol: &str) {
     let fake_home_dir = env::current_dir()
         .expect("could not retrieve cwd")
-        .join(".it_generates_the_config");
+        .join(format!(".it_generates_the_config_{}", random_chars(5)));
     let cmd = config_with_wrangler_home(fake_home_dir.to_str().unwrap());
     let mut stdin = cmd.stdin.unwrap();
 
-    write!(stdin, "email@example.com\n").unwrap();
-    write!(stdin, "apikeythisissecretandlong\n").unwrap();
+    write!(stdin, "email@example.com{}", eol).unwrap();
+    write!(stdin, "apikeythisissecretandlong{}", eol).unwrap();
 
     let mut buffer = "".to_string();
     let mut stdout = cmd.stdout.expect("stdout");
@@ -56,4 +65,15 @@ fn config_with_wrangler_home(home_dir: &str) -> Child {
         .env("WRANGLER_HOME", home_dir)
         .spawn()
         .unwrap()
+}
+
+fn random_chars(n: usize) -> String {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use std::iter;
+    let mut rng = thread_rng();
+    iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .take(n)
+        .collect()
 }


### PR DESCRIPTION
`wrangler config` was not properly truncating whitespace from the end of user input, resulting in a panic when trying to use `wrangler publish` as wrangler would try to create an HTTP header with invalid characters. Now, wrangler will properly truncate extra whitespace (including `\r`) from the end of input to `wrangler config`

Fixes #389 