### PR TITLE
feat: #341 delete namespace

### DIFF
--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -25,3 +25,13 @@ $ wrangler kv create "new kv namespace"
     title: "new kv namespace",
 }
 ```
+
+### `delete <namespace-id>`
+
+#### Usage
+
+``` sh
+$ wrangler kv delete f7b02e7fc70443149ac906dd81ec1791
+🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791 🌀 
+✨  Success
+```

--- a/src/commands/kv/delete_namespace.rs
+++ b/src/commands/kv/delete_namespace.rs
@@ -1,0 +1,25 @@
+use cloudflare::apiclient::APIClient;
+
+use cloudflare::workerskv::remove_namespace::RemoveNamespace;
+
+use crate::terminal::message;
+
+pub fn delete_namespace(id: &str) -> Result<(), failure::Error> {
+    let client = super::api_client()?;
+    let account_id = super::account_id()?;
+
+    let msg = format!("Deleting namespace {}", id);
+    message::working(&msg);
+
+    let response = client.request(&RemoveNamespace {
+        account_identifier: &account_id,
+        namespace_identifier: id,
+    });
+
+    match response {
+        Ok(_success) => message::success("Success"),
+        Err(e) => super::print_error(e),
+    }
+
+    Ok(())
+}

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -7,8 +7,10 @@ use crate::settings;
 use crate::terminal::message;
 
 mod create_namespace;
+mod delete_namespace;
 
 pub use create_namespace::create_namespace;
+pub use delete_namespace::delete_namespace;
 
 fn api_client() -> Result<HTTPAPIClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,12 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("title")
                         )
                 )
+                .subcommand(
+                    SubCommand::with_name("delete")
+                        .arg(
+                            Arg::with_name("id")
+                        )
+                )
         )
         .subcommand(
             SubCommand::with_name("generate")
@@ -252,6 +258,10 @@ fn run() -> Result<(), failure::Error> {
             ("create", Some(create_matches)) => {
                 let title = create_matches.value_of("title").unwrap();
                 commands::kv::create_namespace(title)?;
+            }
+            ("delete", Some(delete_matches)) => {
+                let id = delete_matches.value_of("id").unwrap();
+                commands::kv::delete_namespace(id)?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
Closes #341 . Branched off of #392, merge first.

This is dependent on an update to the cloudflare-rs library per this issue: https://github.com/cloudflare/cloudflare-rs/issues/10.

Interacting with this code looks a little something like this:
On successful creation:
``` sh
$ wrangler kv delete f7b02e7fc70443149ac906dd81ec1791
🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791 🌀 
✨  Success
```

On API error (in this case kv namespace does not exist):
``` sh
$ wrangler kv create "my namespace"
🌀  Deleting namespace 9cfc4002eae04fd9a5aa4433367f5c7d
⚠️  Error 10013: namespace not found
🕵️‍♂️  Run `wrangler kv list` to see your existing namespaces with IDs
```