### PR TITLE
feat: #348 rename namespace

### DIFF
--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -35,3 +35,16 @@ $ wrangler kv delete f7b02e7fc70443149ac906dd81ec1791
 🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791 🌀 
 ✨  Success
 ```
+
+### ✨ `rename <namespace-id> <new-title>`
+
+#### Usage
+
+``` sh
+$ wrangler kv rename f7b02e7fc70443149ac906dd81ec1791 "updated kv namespace"
+🌀  Renaming namespace f7b02e7fc70443149ac906dd81ec1791 with title "updated kv namespace"
+✨  Success: WorkersKVNamespace {
+    id: "f7b02e7fc70443149ac906dd81ec1791",
+    title: "updated kv namespace",
+}
+```

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -8,9 +8,11 @@ use crate::terminal::message;
 
 mod create_namespace;
 mod delete_namespace;
+mod rename_namespace;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
+pub use rename_namespace::rename_namespace;
 
 fn api_client() -> Result<HTTPAPIClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/commands/kv/rename_namespace.rs
+++ b/src/commands/kv/rename_namespace.rs
@@ -1,0 +1,29 @@
+use cloudflare::apiclient::APIClient;
+
+use cloudflare::workerskv::rename_namespace::RenameNamespace;
+use cloudflare::workerskv::rename_namespace::RenameNamespaceParams;
+
+use crate::terminal::message;
+
+pub fn rename_namespace(id: &str, title: &str) -> Result<(), failure::Error> {
+    let client = super::api_client()?;
+    let account_id = super::account_id()?;
+
+    let msg = format!("Renaming namespace {} to have title \"{}\"", id, title);
+    message::working(&msg);
+
+    let response = client.request(&RenameNamespace {
+        account_identifier: &account_id,
+        namespace_identifier: &id,
+        params: RenameNamespaceParams {
+            title: title.to_string(),
+        },
+    });
+
+    match response {
+        Ok(_success) => message::success("Success"),
+        Err(e) => super::print_error(e),
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,15 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("id")
                         )
                 )
+                .subcommand(
+                    SubCommand::with_name("rename")
+                        .arg(
+                            Arg::with_name("id")
+                        )
+                        .arg(
+                            Arg::with_name("title")
+                        )
+                )
         )
         .subcommand(
             SubCommand::with_name("generate")
@@ -264,6 +273,11 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("id").unwrap();
                 commands::kv::delete_namespace(id)?;
+            }
+            ("rename", Some(rename_matches)) => {
+                let id = rename_matches.value_of("id").unwrap();
+                let title = rename_matches.value_of("title").unwrap();
+                commands::kv::rename_namespace(id, title)?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
Closes #348 . Branched off of #392, merge first.

Interacting with this code looks a little something like this:
On successful creation:
``` sh
$ wrangler kv rename 40de2c538b0a44f89bb8a41d4e1113c1 "renamed namespace"
🌀  Renaming namespace 40de2c538b0a44f89bb8a41d4e1113c1 to have title "renamed namespace"
✨  Success
```

On API error (in this case kv namespace format incorrect):
``` sh
$ wrangler kv rename 40de2c538b0a44f89bb8a41d4e1113c "renamed namespace"
🌀  Renaming namespace 40de2c538b0a44f89bb8a41d4e1113c to have title "renamed namespace"
⚠️  Error 10011: could not parse UUID from request's namespace_id: 'uuid: incorrect UUID length: 40de2c538b0a44f89bb8a41d4e1113c'
🕵️‍♂️  Run `wrangler kv list` to see your existing namespaces with IDs
```