### PR TITLE
feat: #342 list namespaces

### DIFF
--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -48,3 +48,20 @@ $ wrangler kv rename f7b02e7fc70443149ac906dd81ec1791 "updated kv namespace"
     title: "updated kv namespace",
 }
 ```
+
+### `list`
+
+Outputs a list of all KV namespaces associated with your account id.
+
+#### Usage
+
+``` sh
+$ wrangler kv list
+🌀  Retrieving namespaces 🌀 
+✨  Success: 
++------------------+----------------------------------+
+| TITLE            | ID                               |
++------------------+----------------------------------+
+| new kv namespace | f7b02e7fc70443149ac906dd81ec1791 |
++------------------+----------------------------------+
+```

--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -43,10 +43,7 @@ $ wrangler kv delete f7b02e7fc70443149ac906dd81ec1791
 ``` sh
 $ wrangler kv rename f7b02e7fc70443149ac906dd81ec1791 "updated kv namespace"
 🌀  Renaming namespace f7b02e7fc70443149ac906dd81ec1791 with title "updated kv namespace"
-✨  Success: WorkersKVNamespace {
-    id: "f7b02e7fc70443149ac906dd81ec1791",
-    title: "updated kv namespace",
-}
+✨  Success
 ```
 
 ### `list`
@@ -58,7 +55,7 @@ Outputs a list of all KV namespaces associated with your account id.
 ``` sh
 $ wrangler kv list
 🌀  Retrieving namespaces 🌀 
-✨  Success: 
+✨  Success:
 +------------------+----------------------------------+
 | TITLE            | ID                               |
 +------------------+----------------------------------+

--- a/src/commands/kv/list_namespaces.rs
+++ b/src/commands/kv/list_namespaces.rs
@@ -1,0 +1,23 @@
+use cloudflare::apiclient::APIClient;
+
+use cloudflare::workerskv::list_namespaces::ListNamespaces;
+
+use crate::terminal::message;
+
+pub fn list_namespaces() -> Result<(), failure::Error> {
+    let client = super::api_client()?;
+    let account_id = super::account_id()?;
+
+    message::working("Listing namespaces");
+
+    let response = client.request(&ListNamespaces {
+        account_identifier: &account_id,
+    });
+
+    match response {
+        Ok(success) => message::success(&format!("Success: {:#?}", success.result)),
+        Err(e) => super::print_error(e),
+    }
+
+    Ok(())
+}

--- a/src/commands/kv/list_namespaces.rs
+++ b/src/commands/kv/list_namespaces.rs
@@ -1,6 +1,8 @@
 use cloudflare::apiclient::APIClient;
-
 use cloudflare::workerskv::list_namespaces::ListNamespaces;
+use cloudflare::workerskv::WorkersKVNamespace;
+
+use prettytable::{Cell, Row, Table};
 
 use crate::terminal::message;
 
@@ -8,16 +10,32 @@ pub fn list_namespaces() -> Result<(), failure::Error> {
     let client = super::api_client()?;
     let account_id = super::account_id()?;
 
-    message::working("Listing namespaces");
+    message::working("Fetching namespaces...");
 
     let response = client.request(&ListNamespaces {
         account_identifier: &account_id,
     });
 
     match response {
-        Ok(success) => message::success(&format!("Success: {:#?}", success.result)),
+        Ok(success) => {
+            let table = namespace_table(success.result);
+            message::success(&format!("Success: \n{}", table));
+        }
         Err(e) => super::print_error(e),
     }
 
     Ok(())
+}
+
+fn namespace_table(namespaces: Vec<WorkersKVNamespace>) -> Table {
+    let mut table = Table::new();
+    let table_head = Row::new(vec![Cell::new("TITLE"), Cell::new("ID")]);
+
+    table.add_row(table_head);
+    for ns in namespaces {
+        let row = Row::new(vec![Cell::new(&ns.title), Cell::new(&ns.id)]);
+        table.add_row(row);
+    }
+
+    table
 }

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -8,10 +8,12 @@ use crate::terminal::message;
 
 mod create_namespace;
 mod delete_namespace;
+mod list_namespaces;
 mod rename_namespace;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
+pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
 
 fn api_client() -> Result<HTTPAPIClient, failure::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,9 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("title")
                         )
                 )
+                .subcommand(
+                    SubCommand::with_name("list")
+                )
         )
         .subcommand(
             SubCommand::with_name("generate")
@@ -278,6 +281,9 @@ fn run() -> Result<(), failure::Error> {
                 let id = rename_matches.value_of("id").unwrap();
                 let title = rename_matches.value_of("title").unwrap();
                 commands::kv::rename_namespace(id, title)?;
+            }
+            ("list", Some(_create_matches)) => {
+                commands::kv::list_namespaces()?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
Closes #342 . Branched off of #392, merge first.

Interacting with this code looks a little something like this:
On successful creation:
``` sh
$ wrangler kv list
🌀  Retrieving namespaces 🌀 
✨  Success: 
+------------------+----------------------------------+
| TITLE            | ID                               |
+------------------+----------------------------------+
| new kv namespace | f7b02e7fc70443149ac906dd81ec1791 |
+------------------+----------------------------------+
```

On API error (TODO):
``` sh
```