### PR TITLE
refactor: handle success in endpoint caller

### DIFF
--- a/src/commands/kv/create_namespace.rs
+++ b/src/commands/kv/create_namespace.rs
@@ -19,7 +19,10 @@ pub fn create_namespace(title: &str) -> Result<(), failure::Error> {
         },
     });
 
-    super::print_response(response);
+    match response {
+        Ok(success) => message::success(&format!("Success: {:#?}", success.result)),
+        Err(e) => super::print_error(e),
+    }
 
     Ok(())
 }

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -1,7 +1,6 @@
 use cloudflare::auth::Credentials;
 use cloudflare::response::APIFailure;
-use cloudflare::response::APIResponse;
-use cloudflare::response::APIResult;
+
 use cloudflare::HTTPAPIClient;
 
 use crate::settings;
@@ -26,22 +25,19 @@ fn account_id() -> Result<String, failure::Error> {
     Ok(project.account_id)
 }
 
-fn print_response<T: APIResult>(response: APIResponse<T>) {
-    match response {
-        Ok(success) => message::success(&format!("Success: {:#?}", success.result)),
-        Err(e) => match e {
-            APIFailure::Error(_status, errors) => {
-                for error in errors {
-                    message::warn(&format!("Error {}: {}", error.code, error.message,));
+fn print_error(e: APIFailure) {
+    match e {
+        APIFailure::Error(_status, errors) => {
+            for error in errors {
+                message::warn(&format!("Error {}: {}", error.code, error.message,));
 
-                    let suggestion = help(error.code);
-                    if !suggestion.is_empty() {
-                        message::help(suggestion);
-                    }
+                let suggestion = help(error.code);
+                if !suggestion.is_empty() {
+                    message::help(suggestion);
                 }
             }
-            APIFailure::Invalid(reqwest_err) => message::warn(&format!("Error: {}", reqwest_err)),
-        },
+        }
+        APIFailure::Invalid(reqwest_err) => message::warn(&format!("Error: {}", reqwest_err)),
     }
 }
 


### PR DESCRIPTION
this PR will allow for easier customization of output for different endpoints, rather than just using the debug output for every response. Keeps error printing centralized.