### PR TITLE
Minify rust-wasm worker code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +858,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "minifier"
+version = "0.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "macro-utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2007,6 +2020,7 @@ dependencies = [
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minifier 0.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2148,12 +2162,14 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum macro-utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0e72f7deb758fea9ea7d290aebfa788763d0bffae12caa6406a25baaf8fa68a8"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
+"checksum minifier 0.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "70bf0db2475f5e627787da77ca52fe33c294063f49f4134b8bc662eedb5e7332"
 "checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum miniz_oxide 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe2959c5a0747a8d7a56b4444c252ffd2dda5d452cfd147cdfdda73b1c3ece5b"
 "checksum miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c675792957b0d19933816c4e1d56663c341dd9bfa31cb2140ff2267c1d8ecf4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ base64 = "0.10.1"
 lazy_static = "1.3.0"
 text_io = "0.1.7"
 exitfailure = "0.5.1"
+minifier = "0.0.33"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -8,8 +8,8 @@ use log::info;
 use minifier::js;
 use reqwest::multipart::{Form, Part};
 use std::fs;
-use std::path::Path;
 use std::io::prelude::*;
+use std::path::Path;
 
 use crate::commands::build::wranglerjs;
 use crate::settings::binding;
@@ -136,12 +136,19 @@ fn concat_js(name: &str) -> Result<(), failure::Error> {
     let worker_js: String = fs::read_to_string("./worker/worker.js")?.parse()?;
     let worker_js_minified: String = js::minify(&worker_js);
 
-    let mut merged_js = fs::OpenOptions::new().write(true).create(true).open("./worker/generated/script.js")?;
+    let mut merged_js = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open("./worker/generated/script.js")?;
 
     // Need to add trailing ; to bindgen_js_minified because otherwise, the minifier will not add it,
     // which will lead to an error when worker_js_minified is appended.
     // TODO: move this final semicolon logic into wasm-pack instead?
-    write!(&mut merged_js, "{};{}", bindgen_js_minified, worker_js_minified)?;
+    write!(
+        &mut merged_js,
+        "{};{}",
+        bindgen_js_minified, worker_js_minified
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR addresses #384. It streamlines the joining of the rust-wasm "glue" code and the actual worker js code, and minifies it.

I have a concern with the minification crate used for this (which is the only js minification crate for rust, afaik): https://crates.io/crates/minifier. This crate will not automatically add missing semicolons to distinguish between js lines of code, unlike other, more developed minifiers. This means that even one missing semicolon in the worker/worker.js code for rust-wasm projects will throw parsing errors! 

Even a lot of our example/template code lacks proper semicolon usage...
```js
addEventListener('fetch', event => {
  event.respondWith(handleRequest(event.request))
})

/**
 * Fetch and log a request
 * @param {Request} request
 */
async function handleRequest(request) {
    const { greet } = wasm_bindgen;
    await wasm_bindgen(wasm)
    const greeting = greet()
    return new Response(greeting, {status: 200})
}
```

I fear that the minifier's need for perfect semicolon usage will honestly make the rust-wasm worker dev experience worse. We can either shelve this idea for now, or explore using a more advanced (though heavier to integrate) set of minification tooling like that in webpack.

I guess issue #384 is less of a low-hanging fruit than we thought!