### PR TITLE
Fix ignoring exit code from spawnSync - run-wrangler.js

### DIFF
--- a/npm/run-wrangler.js
+++ b/npm/run-wrangler.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const { join, resolve } = require("path");
+const { join } = require("path");
 const { spawnSync } = require("child_process");
-const { homedir } = require('os');
+const { homedir } = require("os");
 
 const cwd = join(homedir(), ".wrangler");
 const bin = join(cwd, "out", "wrangler");
@@ -12,4 +12,4 @@ const opts = {
   cwd: process.cwd(),
   stdio: "inherit"
 };
-spawnSync(bin, args, opts);
+process.exit(spawnSync(bin, args, opts).status);


### PR DESCRIPTION
Fixes #433
Fixes #335

I had some api key issues while publishing a route to a specific zone.
I realized that the npm "run-wrangler" wrapper, was exiting zero when our api key was incorrect,
when I expected it to exit non-zero.

Looks like "spawnSync" returns an explicit status field, which has to be propagated up in order to 
have the correct exit status.

This diff fixes that (removes an unused import, and fixes some quotes).

Reproduction:
```
# add wrangler to package.json (yarn add @cloudflare/wrangler -D)
CF_EMAIL=example@example.com CF_API_KEY=incorrect_api_key_here wrangler publish --release
echo $? # will be zero
```

After this fix
```
CF_EMAIL=example@example.com CF_API_KEY=incorrect_api_key_here wrangler publish --release
# error Command failed with exit code 1.
```
