### PR TITLE
[chore] Deny clippy warnings in CI, run rustfmt in --check mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ jobs:
       - script: rustup component add rustfmt
         displayName: rustup component add rustfmt
       - script: cargo fmt --all -- --check
-        displayName: "cargo fmt"
+        displayName: "cargo fmt --all -- --check"
       - script: rustup component add clippy
         displayName: rustup component add clippy
       - script: cargo clippy
-        displayName: "cargo clippy"
+        displayName: "cargo clippy --all --all-features -- -D warnings"
 
   - job: test_wrangler_windows
     displayName: "Run wrangler tests (Windows)"


### PR DESCRIPTION
Depends on #427 (merge that first) since CI won't pass now if there are clippy warnings
Fixes #426 