### PR TITLE
Add gets for single keys from Workers KV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ exitfailure = "0.5.1"
 prettytable-rs = "0.8.0"
 notify = "4.0.12"
 ws = "0.9.0"
+percent-encoding = "1.0.1"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/kv/get_key.rs
+++ b/src/commands/kv/get_key.rs
@@ -1,0 +1,38 @@
+// todo(gabbi): This file should use cloudflare-rs instead of our http::auth_client 
+// when https://github.com/cloudflare/cloudflare-rs/issues/26 is handled (this is 
+// because the GET key operation doesn't return json on success--just the raw
+// value).
+
+use cloudflare::framework::response::ApiFailure;
+
+use crate::settings::global_user::GlobalUser;
+use crate::settings::project::Project;
+use crate::http;
+
+pub fn get_key(project: &Project, user: &GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
+    let api_endpoint = format!(
+        "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
+        project.account_id, id, key
+    );
+
+    let client = http::auth_client(user); 
+
+    let mut res = client
+    .get(&api_endpoint)
+    .send()?;
+
+    if res.status().is_success() {
+        let body_text = res.text()?;
+        // We don't use message::success because we don't want to include the emoji/formatting
+        // in case someone is piping this to stdin
+        println!("{}", &body_text);
+    } else {
+        // This is logic pulled from cloudflare-rs for pretty error formatting right now; 
+        // it will be redundant when we switch to using cloudflare-rs for all API requests.
+        let parsed = res.json();
+        let errors = parsed.unwrap_or_default();
+        super::print_error(ApiFailure::Error(res.status(), errors));
+    }
+
+    Ok(())
+}

--- a/src/commands/kv/get_key.rs
+++ b/src/commands/kv/get_key.rs
@@ -3,6 +3,7 @@
 // because the GET key operation doesn't return json on success--just the raw
 // value).
 
+use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 use cloudflare::framework::response::ApiFailure;
 
 use crate::http;
@@ -15,9 +16,10 @@ pub fn get_key(
     id: &str,
     key: &str,
 ) -> Result<(), failure::Error> {
+    let encoded_key = percent_encode(key.as_bytes(), PATH_SEGMENT_ENCODE_SET).to_string();
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
-        project.account_id, id, key
+        project.account_id, id, encoded_key
     );
 
     let client = http::auth_client(user);
@@ -28,7 +30,7 @@ pub fn get_key(
         let body_text = res.text()?;
         // We don't use message::success because we don't want to include the emoji/formatting
         // in case someone is piping this to stdin
-        println!("{}", &body_text);
+        print!("{}", &body_text);
     } else {
         // This is logic pulled from cloudflare-rs for pretty error formatting right now;
         // it will be redundant when we switch to using cloudflare-rs for all API requests.

--- a/src/commands/kv/get_key.rs
+++ b/src/commands/kv/get_key.rs
@@ -1,25 +1,28 @@
-// todo(gabbi): This file should use cloudflare-rs instead of our http::auth_client 
-// when https://github.com/cloudflare/cloudflare-rs/issues/26 is handled (this is 
+// todo(gabbi): This file should use cloudflare-rs instead of our http::auth_client
+// when https://github.com/cloudflare/cloudflare-rs/issues/26 is handled (this is
 // because the GET key operation doesn't return json on success--just the raw
 // value).
 
 use cloudflare::framework::response::ApiFailure;
 
+use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Project;
-use crate::http;
 
-pub fn get_key(project: &Project, user: &GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
+pub fn get_key(
+    project: &Project,
+    user: &GlobalUser,
+    id: &str,
+    key: &str,
+) -> Result<(), failure::Error> {
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
         project.account_id, id, key
     );
 
-    let client = http::auth_client(user); 
+    let client = http::auth_client(user);
 
-    let mut res = client
-    .get(&api_endpoint)
-    .send()?;
+    let mut res = client.get(&api_endpoint).send()?;
 
     if res.status().is_success() {
         let body_text = res.text()?;
@@ -27,7 +30,7 @@ pub fn get_key(project: &Project, user: &GlobalUser, id: &str, key: &str) -> Res
         // in case someone is piping this to stdin
         println!("{}", &body_text);
     } else {
-        // This is logic pulled from cloudflare-rs for pretty error formatting right now; 
+        // This is logic pulled from cloudflare-rs for pretty error formatting right now;
         // it will be redundant when we switch to using cloudflare-rs for all API requests.
         let parsed = res.json();
         let errors = parsed.unwrap_or_default();

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -8,13 +8,13 @@ use crate::terminal::message;
 
 mod create_namespace;
 mod delete_namespace;
-mod get_key;
+mod read_key;
 mod list_namespaces;
 mod rename_namespace;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
-pub use get_key::get_key;
+pub use read_key::read_key;
 pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
 

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -8,14 +8,14 @@ use crate::terminal::message;
 
 mod create_namespace;
 mod delete_namespace;
-mod read_key;
 mod list_namespaces;
+mod read_key;
 mod rename_namespace;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
-pub use read_key::read_key;
 pub use list_namespaces::list_namespaces;
+pub use read_key::read_key;
 pub use rename_namespace::rename_namespace;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -8,15 +8,15 @@ use crate::terminal::message;
 
 mod create_namespace;
 mod delete_namespace;
+mod get_key;
 mod list_namespaces;
 mod rename_namespace;
-mod get_key;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
+pub use get_key::get_key;
 pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
-pub use get_key::get_key;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -10,11 +10,13 @@ mod create_namespace;
 mod delete_namespace;
 mod list_namespaces;
 mod rename_namespace;
+mod get_key;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
 pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
+pub use get_key::get_key;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/commands/kv/read_key.rs
+++ b/src/commands/kv/read_key.rs
@@ -10,7 +10,7 @@ use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Project;
 
-pub fn get_key(
+pub fn read_key(
     project: &Project,
     user: &GlobalUser,
     id: &str,

--- a/src/commands/kv/read_key.rs
+++ b/src/commands/kv/read_key.rs
@@ -3,8 +3,8 @@
 // because the GET key operation doesn't return json on success--just the raw
 // value).
 
-use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 use cloudflare::framework::response::ApiFailure;
+use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
 use crate::http;
 use crate::settings::global_user::GlobalUser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn run() -> Result<(), failure::Error> {
                     SubCommand::with_name("list")
                 )
                 .subcommand(
-                    SubCommand::with_name("get-key")
+                    SubCommand::with_name("read-key")
                         .arg(
                             Arg::with_name("id")
                         )
@@ -307,12 +307,12 @@ fn run() -> Result<(), failure::Error> {
             ("list", Some(_create_matches)) => {
                 commands::kv::list_namespaces()?;
             }
-            ("get-key", Some(get_key_matches)) => {
+            ("read-key", Some(read_key_matches)) => {
                 let project = settings::project::Project::new()?;
                 let user = settings::global_user::GlobalUser::new()?;
-                let id = get_key_matches.value_of("id").unwrap();
-                let key = get_key_matches.value_of("key").unwrap();
-                commands::kv::get_key(&project, &user, id, key)?;
+                let id = read_key_matches.value_of("id").unwrap();
+                let key = read_key_matches.value_of("key").unwrap();
+                commands::kv::read_key(&project, &user, id, key)?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,15 @@ fn run() -> Result<(), failure::Error> {
                 .subcommand(
                     SubCommand::with_name("list")
                 )
+                .subcommand(
+                    SubCommand::with_name("get-key")
+                        .arg(
+                            Arg::with_name("id")
+                        )
+                        .arg(
+                            Arg::with_name("key")
+                        )
+                )
         )
         .subcommand(
             SubCommand::with_name("generate")
@@ -297,6 +306,13 @@ fn run() -> Result<(), failure::Error> {
             }
             ("list", Some(_create_matches)) => {
                 commands::kv::list_namespaces()?;
+            }
+            ("get-key", Some(get_key_matches)) => {
+                let project = settings::project::Project::new()?;
+                let user = settings::global_user::GlobalUser::new()?;
+                let id = get_key_matches.value_of("id").unwrap();
+                let key = get_key_matches.value_of("key").unwrap();
+                commands::kv::get_key(&project, &user, id, key)?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
This PR closes #349.

This GET behavior is used as such:

Success case
```
$ wrangler kv read-key 06779da6940b431db6e566b4846d64db gabbi
fisher
```
NOTE the lack of emoji in this output, in case someone wants to pipe the get output from wrangler into the stdin of another process.

Failure case
```
$ wrangler kv read-key 06779da6940b431db6e566b4846d63db gabbi
 Error 10013: namespace not found
 Run `wrangler kv list` to see your existing namespaces with IDs
```
^ There is the standard emoji logic here, it just doesn't show up in Ubuntu for now...

In a future PR, we'll use cloudflare-rs for this; its usage is unfortunately blocked due to https://github.com/cloudflare/cloudflare-rs/pull/27 (cloudflare-rs doesn't support non-json API responses, and the GET operation for Workers KV keys returns raw text on success).