### PR TITLE
Add individual write subcommand for Workers KV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ exitfailure = "0.5.1"
 prettytable-rs = "0.8.0"
 notify = "4.0.12"
 ws = "0.9.0"
+url = "2.1.0"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -10,13 +10,13 @@ mod create_namespace;
 mod delete_namespace;
 mod list_namespaces;
 mod rename_namespace;
-mod set_key;
+mod write_key;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
 pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
-pub use set_key::set_key;
+pub use write_key::write_key;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -10,11 +10,13 @@ mod create_namespace;
 mod delete_namespace;
 mod list_namespaces;
 mod rename_namespace;
+mod set_key;
 
 pub use create_namespace::create_namespace;
 pub use delete_namespace::delete_namespace;
 pub use list_namespaces::list_namespaces;
 pub use rename_namespace::rename_namespace;
+pub use set_key::set_key;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;

--- a/src/commands/kv/set_key.rs
+++ b/src/commands/kv/set_key.rs
@@ -1,0 +1,71 @@
+// todo(gabbi): This file should use cloudflare-rs instead of our http::auth_client
+// when https://github.com/cloudflare/cloudflare-rs/issues/26 is handled (this is
+// because the SET key request body is not json--it is the raw value).
+
+use std::fs;
+
+use cloudflare::framework::response::ApiFailure;
+use url::Url;
+
+use crate::http;
+use crate::settings::global_user::GlobalUser;
+use crate::settings::project::Project;
+use crate::terminal::message;
+
+pub fn set_key(
+    project: &Project,
+    user: &GlobalUser,
+    id: &str,
+    key: &str,
+    value: &str,
+    is_file: bool,
+    expiration: Option<&str>,
+    expiration_ttl: Option<&str>,
+    base64: bool,
+) -> Result<(), failure::Error> {
+    let api_endpoint = format!(
+        "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
+        project.account_id, id, key
+    );
+
+    // Add expiration, expiration_ttl, and base64 query options as necessary.
+    let mut vector: Vec<(&str, &str)> = vec![];
+    match expiration {
+        Some(exp) => vector.push(("expiration", exp)),
+        None => (),
+    }
+    match expiration_ttl {
+        Some(ttl) => vector.push(("expiration_ttl", ttl)),
+        None => (),
+    }
+    if base64 {
+        vector.push(("base64", "true"));
+    }
+    let url = Url::parse_with_params(&api_endpoint, vector);
+
+    // If is_file is true, overwrite value to be the contents of the given
+    // filename in the 'value' arg.
+    let mut body_text: String;
+    if is_file {
+        body_text = fs::read_to_string(value)?;
+    } else {
+        body_text = value.to_string();
+    }
+
+    let client = http::auth_client(user);
+
+    let url_into_str = url?.into_string();
+    let mut res = client.put(&url_into_str).body(body_text).send()?;
+
+    if res.status().is_success() {
+        message::success("Success")
+    } else {
+        // This is logic pulled from cloudflare-rs for pretty error formatting right now;
+        // it will be redundant when we switch to using cloudflare-rs for all API requests.
+        let parsed = res.json();
+        let errors = parsed.unwrap_or_default();
+        super::print_error(ApiFailure::Error(res.status(), errors));
+    }
+
+    Ok(())
+}

--- a/src/commands/kv/set_key.rs
+++ b/src/commands/kv/set_key.rs
@@ -29,19 +29,19 @@ pub fn set_key(
     );
 
     // Add expiration, expiration_ttl, and base64 query options as necessary.
-    let mut vector: Vec<(&str, &str)> = vec![];
+    let mut query_params: Vec<(&str, &str)> = vec![];
     match expiration {
-        Some(exp) => vector.push(("expiration", exp)),
+        Some(exp) => query_params.push(("expiration", exp)),
         None => (),
     }
     match expiration_ttl {
-        Some(ttl) => vector.push(("expiration_ttl", ttl)),
+        Some(ttl) => query_params.push(("expiration_ttl", ttl)),
         None => (),
     }
     if base64 {
-        vector.push(("base64", "true"));
+        query_params.push(("base64", "true"));
     }
-    let url = Url::parse_with_params(&api_endpoint, vector);
+    let url = Url::parse_with_params(&api_endpoint, query_params);
 
     // If is_file is true, overwrite value to be the contents of the given
     // filename in the 'value' arg.

--- a/src/commands/kv/write_key.rs
+++ b/src/commands/kv/write_key.rs
@@ -12,7 +12,7 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Project;
 use crate::terminal::message;
 
-pub fn set_key(
+pub fn write_key(
     project: &Project,
     user: &GlobalUser,
     id: &str,
@@ -21,7 +21,6 @@ pub fn set_key(
     is_file: bool,
     expiration: Option<&str>,
     expiration_ttl: Option<&str>,
-    base64: bool,
 ) -> Result<(), failure::Error> {
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
@@ -37,9 +36,6 @@ pub fn set_key(
     match expiration_ttl {
         Some(ttl) => query_params.push(("expiration_ttl", ttl)),
         None => (),
-    }
-    if base64 {
-        query_params.push(("base64", "true"));
     }
     let url = Url::parse_with_params(&api_endpoint, query_params);
 

--- a/src/commands/kv/write_key.rs
+++ b/src/commands/kv/write_key.rs
@@ -27,7 +27,7 @@ pub fn write_key(
         project.account_id, id, key
     );
 
-    // Add expiration, expiration_ttl, and base64 query options as necessary.
+    // Add expiration and expiration_ttl query options as necessary.
     let mut query_params: Vec<(&str, &str)> = vec![];
     match expiration {
         Some(exp) => query_params.push(("expiration", exp)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn run() -> Result<(), failure::Error> {
                     SubCommand::with_name("list")
                 )
                 .subcommand(
-                    SubCommand::with_name("set-key")
+                    SubCommand::with_name("write-key")
                         .arg(
                             Arg::with_name("id")
                         )
@@ -103,13 +103,6 @@ fn run() -> Result<(), failure::Error> {
                             .value_name("SECONDS")
                             .takes_value(true)
                             .help("the number of seconds for which the entries should be visible before they expire. At least 60"),
-                        )
-                        .arg(
-                            Arg::with_name("base64")
-                            .short("b64")
-                            .long("base64")
-                            .takes_value(false)
-                            .help("the server should base64 decode the value before storing it. Useful for writing values that wouldn't otherwise be valid JSON strings, such as images."),	
                         )
                         .arg(
                             Arg::with_name("file")
@@ -340,25 +333,21 @@ fn run() -> Result<(), failure::Error> {
             ("list", Some(_create_matches)) => {
                 commands::kv::list_namespaces()?;
             }
-            ("set-key", Some(set_key_matches)) => {
+            ("write-key", Some(write_key_matches)) => {
                 let project = settings::project::Project::new()?;
                 let user = settings::global_user::GlobalUser::new()?;
-                let id = set_key_matches.value_of("id").unwrap();
-                let key = set_key_matches.value_of("key").unwrap();
-                let value = set_key_matches.value_of("value").unwrap();
-                let is_file = match set_key_matches.occurrences_of("file") {
+                let id = write_key_matches.value_of("id").unwrap();
+                let key = write_key_matches.value_of("key").unwrap();
+                let value = write_key_matches.value_of("value").unwrap();
+                let is_file = match write_key_matches.occurrences_of("file") {
                     1 => true,
                     _ => false,
                 };
-                let expiration = set_key_matches.value_of("expiration");
-                let ttl = set_key_matches.value_of("expiration-ttl");
-                let base64 = match set_key_matches.occurrences_of("base64") {
-                    1 => true,
-                    _ => false,
-                };
+                let expiration = write_key_matches.value_of("expiration");
+                let ttl = write_key_matches.value_of("expiration-ttl");
 
-                commands::kv::set_key(
-                    &project, &user, id, key, value, is_file, expiration, ttl, base64,
+                commands::kv::write_key(
+                    &project, &user, id, key, value, is_file, expiration, ttl,
                 )?;
             }
             ("", None) => message::warn("kv expects a subcommand"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,9 +346,7 @@ fn run() -> Result<(), failure::Error> {
                 let expiration = write_key_matches.value_of("expiration");
                 let ttl = write_key_matches.value_of("expiration-ttl");
 
-                commands::kv::write_key(
-                    &project, &user, id, key, value, is_file, expiration, ttl,
-                )?;
+                commands::kv::write_key(&project, &user, id, key, value, is_file, expiration, ttl)?;
             }
             ("", None) => message::warn("kv expects a subcommand"),
             _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,7 +347,7 @@ fn run() -> Result<(), failure::Error> {
                 let user = settings::global_user::GlobalUser::new()?;
                 let id = read_key_matches.value_of("id").unwrap();
                 let key = read_key_matches.value_of("key").unwrap();
-              
+
                 commands::kv::read_key(&project, &user, id, key)?;
             }
             ("write-key", Some(write_key_matches)) => {


### PR DESCRIPTION
This PR closes #343. 

The SET behavior is used the following way:

Success case (set string value):
```
$ wrangler kv set-key 06779da6940b431db6e566b4846d64db taylor swift --ttl 60
 Success
```

Success case (set value from file contents)
```
$ wrangler kv write-key 06779da6940b431db6e566b4846d64db my_file abc/a.txt --ttl 60 -f
 Success
```

Failure cases 
```
$ wrangler kv write-key 06779da6940b431db6e566b4846d63db --ttl 60 -f my_file abc/a.txt
 Error 10013: namespace not found
 Run `wrangler kv list` to see your existing namespaces with IDs
```
```
$ wrangler kv write-key 06779da6940b431db6e566b4846d64db --ttl 60 -f my_file abc/ab.txt
Error: No such file or directory (os error 2)
```
^ There is the standard emoji logic here, it just doesn't show up in Ubuntu for now...

In a future PR, we'll use cloudflare-rs for this; its usage is unfortunately blocked due to cloudflare/cloudflare-rs#27 (cloudflare-rs doesn't support non-json API responses, and the GET operation for Workers KV keys returns raw text on success).