### PR TITLE
[WIP][FEAT] add commands for httpie/ http-prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jobserver"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1712,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "shh"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2206,7 @@ dependencies = [
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2191,6 +2216,8 @@ dependencies = [
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shh 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2344,6 +2371,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum is_executable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jobserver 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f74e73053eaf95399bf926e48fc7a2a3ce50bd0eaaa2357d391e95b2dcdd4f10"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -2445,6 +2473,8 @@ dependencies = [
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
+"checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
+"checksum shh 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cff8b151d3d290604d9c93f0400bd4d98e2837a5461532bc6c95d0129ea0964"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ text_io = "0.1.7"
 exitfailure = "0.5.1"
 notify = "4.0.12"
 ws = "0.9.0"
+shh = "1.0.0"
+jobserver = "0.1.16"
+shell-escape = "0.1.4"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub use build::build;
 pub use build::watch_and_build;
 pub use generate::generate;
 pub use init::init;
+pub use publish::preview::httpie::{httpie, httpie_prompt};
 pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;
 pub use publish::publish;

--- a/src/commands/publish/preview/httpie/mod.rs
+++ b/src/commands/publish/preview/httpie/mod.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+use super::upload_and_get_id;
+use crate::commands;
+use uuid::Uuid;
+use log::info;
+use crate::http;
+use crate::settings::{global_user::GlobalUser, project::Project};
+use crate::terminal::message;
+use failure::bail;
+use shh;
+
+use crate::process_builder::process;
+use super::PREVIEW_ADDRESS;
+
+pub fn httpie(
+    project: Project,
+    user: Option<GlobalUser>,
+    preview_host: String,
+    args: &[&str],
+    ) -> Result<(), failure::Error> {
+    commands::build(&project)?;
+
+    let script_id = upload_and_get_id(&project, user.as_ref())?;
+
+    let session = Uuid::new_v4().to_simple();
+    let https = true;
+    let https_str = if https { "https://" } else { "http://" };
+
+    let cookie = format!(
+        "__ew_fiddle_preview={}{}{}{}",
+        script_id, session, https as u8, preview_host
+    );
+
+    process("http")
+        .arg(PREVIEW_ADDRESS)
+        .arg(format!("Cookie:{}", cookie))
+        .exec_replace()
+}
+
+pub fn httpie_prompt(
+    project: Project,
+    user: Option<GlobalUser>,
+    preview_host: String,
+    ) -> Result<(), failure::Error> {
+    commands::build(&project)?;
+
+    let script_id = upload_and_get_id(&project, user.as_ref())?;
+
+    let session = Uuid::new_v4().to_simple();
+    let https = true;
+    let https_str = if https { "https://" } else { "http://" };
+
+    let cookie = format!(
+        "__ew_fiddle_preview={}{}{}{}",
+        script_id, session, https as u8, preview_host
+    );
+
+    process("http-prompt")
+        .arg(PREVIEW_ADDRESS)
+        .arg(format!("Cookie:{}", cookie))
+        .exec_replace()
+}

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -3,11 +3,13 @@ use std::process::Command;
 mod fiddle_messenger;
 use fiddle_messenger::*;
 
+pub mod httpie;
+
 mod http_method;
 pub use http_method::HTTPMethod;
 
 mod upload;
-use upload::upload_and_get_id;
+pub use upload::upload_and_get_id;
 
 use crate::commands;
 
@@ -25,11 +27,12 @@ use std::thread;
 use ws::{Sender, WebSocket};
 
 // Using this instead of just `https://cloudflareworkers.com` returns just the worker response to the CLI
-const PREVIEW_ADDRESS: &str = "https://00000000000000000000000000000000.cloudflareworkers.com";
+pub const PREVIEW_ADDRESS: &str = "https://00000000000000000000000000000000.cloudflareworkers.com";
 
 pub fn preview(
     project: Project,
     user: Option<GlobalUser>,
+    preview_host: String,
     method: HTTPMethod,
     body: Option<String>,
     livereload: bool,
@@ -38,7 +41,6 @@ pub fn preview(
     let script_id = upload_and_get_id(&project, user.as_ref())?;
 
     let session = Uuid::new_v4().to_simple();
-    let preview_host = "example.com";
     let https = true;
     let https_str = if https { "https://" } else { "http://" };
 

--- a/src/process_builder.rs
+++ b/src/process_builder.rs
@@ -1,0 +1,271 @@
+use std::collections::HashMap;
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use failure::{Fail, format_err};
+use jobserver::Client;
+use shell_escape::escape;
+
+/// A builder object for an external process, similar to `std::process::Command`.
+#[derive(Clone, Debug)]
+pub struct ProcessBuilder {
+    /// The program to execute.
+    program: OsString,
+    /// A list of arguments to pass to the program.
+    args: Vec<OsString>,
+    /// Any environment variables that should be set for the program.
+    env: HashMap<String, Option<OsString>>,
+    /// The directory to run the program from.
+    cwd: Option<OsString>,
+    /// The `make` jobserver. See the [jobserver crate][jobserver_docs] for
+    /// more information.
+    ///
+    /// [jobserver_docs]: https://docs.rs/jobserver/0.1.6/jobserver/
+    jobserver: Option<Client>,
+    /// `true` to include environment variable in display.
+    display_env_vars: bool,
+}
+
+impl fmt::Display for ProcessBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "`")?;
+
+        if self.display_env_vars {
+            for (key, val) in self.env.iter() {
+                if let Some(val) = val {
+                    let val = escape(val.to_string_lossy());
+                    if cfg!(windows) {
+                        write!(f, "set {}={}&& ", key, val)?;
+                    } else {
+                        write!(f, "{}={} ", key, val)?;
+                    }
+                }
+            }
+        }
+
+        write!(f, "{}", self.program.to_string_lossy())?;
+
+        for arg in &self.args {
+            write!(f, " {}", escape(arg.to_string_lossy()))?;
+        }
+
+        write!(f, "`")
+    }
+}
+
+impl ProcessBuilder {
+    /// (chainable) Sets the executable for the process.
+    pub fn program<T: AsRef<OsStr>>(&mut self, program: T) -> &mut ProcessBuilder {
+        self.program = program.as_ref().to_os_string();
+        self
+    }
+
+    /// (chainable) Adds `arg` to the args list.
+    pub fn arg<T: AsRef<OsStr>>(&mut self, arg: T) -> &mut ProcessBuilder {
+        self.args.push(arg.as_ref().to_os_string());
+        self
+    }
+
+    /// (chainable) Adds multiple `args` to the args list.
+    pub fn args<T: AsRef<OsStr>>(&mut self, args: &[T]) -> &mut ProcessBuilder {
+        self.args
+            .extend(args.iter().map(|t| t.as_ref().to_os_string()));
+        self
+    }
+
+    /// (chainable) Replaces the args list with the given `args`.
+    pub fn args_replace<T: AsRef<OsStr>>(&mut self, args: &[T]) -> &mut ProcessBuilder {
+        self.args = args.iter().map(|t| t.as_ref().to_os_string()).collect();
+        self
+    }
+
+    /// (chainable) Sets the current working directory of the process.
+    pub fn cwd<T: AsRef<OsStr>>(&mut self, path: T) -> &mut ProcessBuilder {
+        self.cwd = Some(path.as_ref().to_os_string());
+        self
+    }
+
+    /// (chainable) Sets an environment variable for the process.
+    pub fn env<T: AsRef<OsStr>>(&mut self, key: &str, val: T) -> &mut ProcessBuilder {
+        self.env
+            .insert(key.to_string(), Some(val.as_ref().to_os_string()));
+        self
+    }
+
+    /// (chainable) Unsets an environment variable for the process.
+    pub fn env_remove(&mut self, key: &str) -> &mut ProcessBuilder {
+        self.env.insert(key.to_string(), None);
+        self
+    }
+
+    /// Gets the executable name.
+    pub fn get_program(&self) -> &OsString {
+        &self.program
+    }
+
+    /// Gets the program arguments.
+    pub fn get_args(&self) -> &[OsString] {
+        &self.args
+    }
+
+    /// Gets the current working directory for the process.
+    pub fn get_cwd(&self) -> Option<&Path> {
+        self.cwd.as_ref().map(Path::new)
+    }
+
+    /// Gets an environment variable as the process will see it (will inherit from environment
+    /// unless explicitally unset).
+    pub fn get_env(&self, var: &str) -> Option<OsString> {
+        self.env
+            .get(var)
+            .cloned()
+            .or_else(|| Some(env::var_os(var)))
+            .and_then(|s| s)
+    }
+
+    /// Gets all environment variables explicitly set or unset for the process (not inherited
+    /// vars).
+    pub fn get_envs(&self) -> &HashMap<String, Option<OsString>> {
+        &self.env
+    }
+
+    /// Sets the `make` jobserver. See the [jobserver crate][jobserver_docs] for
+    /// more information.
+    ///
+    /// [jobserver_docs]: https://docs.rs/jobserver/0.1.6/jobserver/
+    pub fn inherit_jobserver(&mut self, jobserver: &Client) -> &mut Self {
+        self.jobserver = Some(jobserver.clone());
+        self
+    }
+
+    /// Enables environment variable display.
+    pub fn display_env_vars(&mut self) -> &mut Self {
+        self.display_env_vars = true;
+        self
+    }
+
+    /// Runs the process, waiting for completion, and mapping non-success exit codes to an error.
+    pub fn exec(&self) -> Result<(), failure::Error> {
+        let mut command = self.build_command();
+        let exit = command.status().map_err(|_| {
+            format_err!("could not execute process {}", self)
+        })?;
+
+        if exit.success() {
+            Ok(())
+        } else {
+            Err(format_err!("process didn't exit successfully: {}", self))
+        }
+    }
+
+    /// Replaces the current process with the target process.
+    ///
+    /// On Unix, this executes the process using the Unix syscall `execvp`, which will block
+    /// this process, and will only return if there is an error.
+    ///
+    /// On Windows this isn't technically possible. Instead we emulate it to the best of our
+    /// ability. One aspect we fix here is that we specify a handler for the Ctrl-C handler.
+    /// In doing so (and by effectively ignoring it) we should emulate proxying Ctrl-C
+    /// handling to the application at hand, which will either terminate or handle it itself.
+    /// According to Microsoft's documentation at
+    /// <https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals>.
+    /// the Ctrl-C signal is sent to all processes attached to a terminal, which should
+    /// include our child process. If the child terminates then we'll reap them in Cargo
+    /// pretty quickly, and if the child handles the signal then we won't terminate
+    /// (and we shouldn't!) until the process itself later exits.
+    pub fn exec_replace(&self) -> Result<(), failure::Error> {
+        imp::exec_replace(self)
+    }
+
+    /// Executes the process, returning the stdio output, or an error if non-zero exit status.
+    pub fn exec_with_output(&self) -> Result<Output, failure::Error> {
+        let mut command = self.build_command();
+
+        let output = command.output().map_err(|_| {
+            format_err!("could not execute process {}", self)
+        })?;
+
+        if output.status.success() {
+            Ok(output)
+        } else {
+            Err(format_err!("process didn't exit successfully: {}", self))
+        }
+    }
+
+    /// Converts `ProcessBuilder` into a `std::process::Command`, and handles the jobserver, if
+    /// present.
+    pub fn build_command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+        if let Some(cwd) = self.get_cwd() {
+            command.current_dir(cwd);
+        }
+        for arg in &self.args {
+            command.arg(arg);
+        }
+        for (k, v) in &self.env {
+            match *v {
+                Some(ref v) => {
+                    command.env(k, v);
+                }
+                None => {
+                    command.env_remove(k);
+                }
+            }
+        }
+        if let Some(ref c) = self.jobserver {
+            c.configure(&mut command);
+        }
+        command
+    }
+}
+
+/// A helper function to create a `ProcessBuilder`.
+pub fn process<T: AsRef<OsStr>>(cmd: T) -> ProcessBuilder {
+    ProcessBuilder {
+        program: cmd.as_ref().to_os_string(),
+        args: Vec::new(),
+        cwd: None,
+        env: HashMap::new(),
+        jobserver: None,
+        display_env_vars: false,
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::ProcessBuilder;
+    use failure::format_err;
+    use std::os::unix::process::CommandExt;
+
+    pub fn exec_replace(process_builder: &ProcessBuilder) -> Result<(), failure::Error> {
+        let mut command = process_builder.build_command();
+        let error = command.exec();
+        Err(format_err!("could not execute process {}", process_builder))
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use super::ProcessBuilder;
+    use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+    use winapi::um::consoleapi::SetConsoleCtrlHandler;
+
+    unsafe extern "system" fn ctrlc_handler(_: DWORD) -> BOOL {
+        // Do nothing; let the child process handle it.
+        TRUE
+    }
+
+    pub fn exec_replace(process_builder: &ProcessBuilder) -> Result<(), failure::Error> {
+        unsafe {
+            if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
+                return Err(format_err!("Could not set Ctrl-C handler."));
+            }
+        }
+
+        // Just execute the process as normal.
+        process_builder.exec()
+    }
+}


### PR DESCRIPTION
This PR adds two new commands to wrangler for testing workers. They are conceptually similar to `wrangler preview`, but instead of opening a browser window, they allow you to test using CLI tools.

`wrangler http`, which calls [httpie](https://httpie.org/) with the necessary preview service arguments prefilled
`wrangler http-prompt` which starts a new [http-prompt](http://http-prompt.com/) session with the necessary arguments prefilled.

`wrangler preview` currently makes a test HTTP request before opening the preview in the browser, this PR opens the possibility deprecate that behavior in favor of the two new commands, so `preview` is dedicated for browser preview, and `http`/`http-prompt` are used for making HTTP requests to a worker from CLI.

These still need some code cleanup work, and there is some argument as to whether or not these commands belong in wrangler or not. They could easily be implemented as cargo-style subcommands, using `clap` and the same `process_builder.rs` file that cargo uses for transferring control to the subcommand process.