### PR TITLE
Remove logic for uploading directories from bulk

### DIFF
--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -1,6 +1,7 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
+use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;
@@ -13,27 +14,33 @@ use crate::terminal::message;
 
 const MAX_PAIRS: usize = 10000;
 
-pub fn delete_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
-    let client = super::api_client()?;
-    let account_id = super::account_id()?;
-
+pub fn delete_json(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
     let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {
         Ok(ref file_type) if file_type.is_file() => {
             let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(_file_type) => {
-            // any other file types (namely, symlinks)
-            bail!(
-                "{} should be a file or directory, but is a symlink",
-                filename.display()
-            )
-        }
+        Ok(_) => bail!("{} should be a JSON file, but is not", filename.display()),
         Err(e) => bail!(e),
     };
 
-    // Validate that bulk delete is within API constraints
-    let keys = keys?;
+    delete_bulk(namespace_id, keys?)
+}
+
+pub fn delete_directory(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
+    let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {
+        Ok(ref file_type) if file_type.is_dir() => parse_directory(filename),
+        Ok(_) => bail!("{} should be a directory, but is not", filename.display()),
+        Err(e) => bail!(e),
+    };
+
+    delete_bulk(namespace_id, keys?)
+}
+
+fn delete_bulk(namespace_id: &str, keys: Vec<String>) -> Result<(), failure::Error> {
+    let client = super::api_client()?;
+    let account_id = super::account_id()?;
+
     // Check number of pairs is under limit
     if keys.len() > MAX_PAIRS {
         bail!(
@@ -55,4 +62,19 @@ pub fn delete_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::E
     }
 
     Ok(())
+}
+
+fn parse_directory(directory: &Path) -> Result<Vec<String>, failure::Error> {
+    let mut delete_vec: Vec<String> = Vec::new();
+    for entry in WalkDir::new(directory) {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            let key = super::generate_key(path, directory)?;
+
+            message::working(&format!("Going to delete {}...", key.clone()));
+            delete_vec.push(key);
+        }
+    }
+    Ok(delete_vec)
 }

--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -1,7 +1,6 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
-use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;

--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -27,16 +27,6 @@ pub fn delete_json(namespace_id: &str, filename: &Path) -> Result<(), failure::E
     delete_bulk(namespace_id, keys?)
 }
 
-pub fn delete_directory(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
-    let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {
-        Ok(ref file_type) if file_type.is_dir() => parse_directory(filename),
-        Ok(_) => bail!("{} should be a directory, but is not", filename.display()),
-        Err(e) => bail!(e),
-    };
-
-    delete_bulk(namespace_id, keys?)
-}
-
 fn delete_bulk(namespace_id: &str, keys: Vec<String>) -> Result<(), failure::Error> {
     let client = super::api_client()?;
     let account_id = super::account_id()?;
@@ -62,19 +52,4 @@ fn delete_bulk(namespace_id: &str, keys: Vec<String>) -> Result<(), failure::Err
     }
 
     Ok(())
-}
-
-fn parse_directory(directory: &Path) -> Result<Vec<String>, failure::Error> {
-    let mut delete_vec: Vec<String> = Vec::new();
-    for entry in WalkDir::new(directory) {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.is_file() {
-            let key = super::generate_key(path, directory)?;
-
-            message::working(&format!("Going to delete {}...", key.clone()));
-            delete_vec.push(key);
-        }
-    }
-    Ok(delete_vec)
 }

--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -1,7 +1,6 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
-use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;
@@ -18,16 +17,11 @@ pub fn delete_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::E
     let client = super::api_client()?;
     let account_id = super::account_id()?;
 
-    // If the provided argument for delete_bulk is a json file, parse it
-    // and delete its listed keys. If the argument is a directory, delete key-value
-    // pairs where keys are the relative pathnames of files in the directory.
-    let mut data;
     let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {
         Ok(ref file_type) if file_type.is_file() => {
-            data = fs::read_to_string(filename)?;
+            let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(ref file_type) if file_type.is_dir() => parse_directory(filename),
         Ok(_file_type) => {
             // any other file types (namely, symlinks)
             bail!(
@@ -61,19 +55,4 @@ pub fn delete_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::E
     }
 
     Ok(())
-}
-
-fn parse_directory(directory: &Path) -> Result<Vec<String>, failure::Error> {
-    let mut delete_vec: Vec<String> = Vec::new();
-    for entry in WalkDir::new(directory) {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.is_file() {
-            let key = super::generate_key(path, directory)?;
-
-            message::working(&format!("Deleting {}...", key.clone()));
-            delete_vec.push(key);
-        }
-    }
-    Ok(delete_vec)
 }

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use cloudflare::framework::auth::Credentials;
 use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::HttpApiClient;
-use http::status::StatusCode;
 use failure::bail;
+use http::status::StatusCode;
 
 use crate::settings;
 use crate::terminal::message;

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -22,14 +22,14 @@ mod write_bulk;
 mod write_key;
 
 pub use create_namespace::create_namespace;
-pub use delete_bulk::delete_bulk;
+pub use delete_bulk::delete_json;
 pub use delete_key::delete_key;
 pub use delete_namespace::delete_namespace;
 pub use list_keys::list_keys;
 pub use list_namespaces::list_namespaces;
 pub use read_key::read_key;
 pub use rename_namespace::rename_namespace;
-pub use write_bulk::write_bulk;
+pub use write_bulk::write_json;
 pub use write_key::write_key;
 
 fn api_client() -> Result<HttpApiClient, failure::Error> {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -1,6 +1,3 @@
-use std::ffi::OsString;
-use std::path::Path;
-
 use cloudflare::framework::auth::Credentials;
 use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::HttpApiClient;
@@ -91,31 +88,4 @@ fn help(error_code: u16) -> &'static str {
         10017 | 10026 => "Workers KV is a paid feature, please upgrade your account (https://www.cloudflare.com/products/workers-kv/)",
         _ => "",
     }
-}
-
-// Courtesy of Steve Kalabnik's PoC :) Used for bulk operations (write, delete)
-fn generate_key(path: &Path, directory: &Path) -> Result<String, failure::Error> {
-    let path = path.strip_prefix(directory).unwrap();
-
-    // next, we have to re-build the paths: if we're on Windows, we have paths with
-    // `\` as separators. But we want to use `/` as separators. Because that's how URLs
-    // work.
-    let mut path_with_forward_slash = OsString::new();
-
-    for (i, component) in path.components().enumerate() {
-        // we don't want a leading `/`, so skip that
-        if i > 0 {
-            path_with_forward_slash.push("/");
-        }
-
-        path_with_forward_slash.push(component);
-    }
-
-    // if we have a non-utf8 path here, it will fail, but that's not realistically going to happen
-    let path = path_with_forward_slash.to_str().expect(&format!(
-        "found a non-UTF-8 path, {:?}",
-        path_with_forward_slash
-    ));
-
-    Ok(path.to_string())
 }

--- a/src/commands/kv/write_bulk.rs
+++ b/src/commands/kv/write_bulk.rs
@@ -1,6 +1,7 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
+use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;
@@ -14,21 +15,34 @@ use crate::terminal::message;
 
 const MAX_PAIRS: usize = 10000;
 
-pub fn write_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
-    let client = super::api_client()?;
-    let account_id = super::account_id()?;
-
+pub fn write_json(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
     let pairs: Result<Vec<KeyValuePair>, failure::Error> = match metadata(filename) {
         Ok(ref file_type) if file_type.is_file() => {
             let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(_file_type) => bail!("wrangler kv write-bulk requires a json file",),
+        Ok(_) => bail!("{} should be a JSON file, but is not", filename.display()),
         Err(e) => bail!(e),
     };
 
+    write_bulk(namespace_id, pairs?)
+}
+
+pub fn write_bucket(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
+    let pairs: Result<Vec<KeyValuePair>, failure::Error> = match metadata(filename) {
+        Ok(ref file_type) if file_type.is_dir() => parse_directory(filename),
+        Ok(_) => bail!("{} should be a directory, but is not", filename.display()),
+        Err(e) => bail!(e),
+    };
+
+    write_bulk(namespace_id, pairs?)
+}
+
+fn write_bulk(namespace_id: &str, pairs: Vec<KeyValuePair>) -> Result<(), failure::Error> {
+    let client = super::api_client()?;
+    let account_id = super::account_id()?;
+
     // Validate that bulk upload is within size constraints
-    let pairs = pairs?;
     if pairs.len() > MAX_PAIRS {
         bail!(
             "Number of key-value pairs to upload ({}) exceeds max of {}",
@@ -51,4 +65,29 @@ pub fn write_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::Er
     }
 
     Ok(())
+}
+
+fn parse_directory(directory: &Path) -> Result<Vec<KeyValuePair>, failure::Error> {
+    let mut upload_vec: Vec<KeyValuePair> = Vec::new();
+    for entry in WalkDir::new(directory) {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            let key = super::generate_key(path, directory)?;
+
+            let value = std::fs::read(path)?;
+
+            // Need to base64 encode value
+            let b64_value = base64::encode(&value);
+            message::working(&format!("Parsing {}...", key.clone()));
+            upload_vec.push(KeyValuePair {
+                key: key,
+                value: b64_value,
+                expiration: None,
+                expiration_ttl: None,
+                base64: Some(true),
+            });
+        }
+    }
+    Ok(upload_vec)
 }

--- a/src/commands/kv/write_bulk.rs
+++ b/src/commands/kv/write_bulk.rs
@@ -1,7 +1,6 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
-use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;
@@ -40,8 +39,6 @@ fn write_bulk(namespace_id: &str, pairs: Vec<KeyValuePair>) -> Result<(), failur
             MAX_PAIRS
         );
     }
-
-    message::working("Parsing successful. Uploading all files above");
 
     let response = client.request(&WriteBulk {
         account_identifier: &account_id,

--- a/src/commands/kv/write_bulk.rs
+++ b/src/commands/kv/write_bulk.rs
@@ -1,7 +1,6 @@
 extern crate base64;
 
 use cloudflare::framework::apiclient::ApiClient;
-use walkdir::WalkDir;
 
 use std::fs;
 use std::fs::metadata;
@@ -19,24 +18,12 @@ pub fn write_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::Er
     let client = super::api_client()?;
     let account_id = super::account_id()?;
 
-    // If the provided argument for write_bulk is a json file, parse it
-    // and upload its contents. If the argument is a directory, create key-value
-    // pairs where keys are the relative pathnames of files in the directory, and
-    // values are the base64-encoded contents of those files.
-    let mut data;
     let pairs: Result<Vec<KeyValuePair>, failure::Error> = match metadata(filename) {
         Ok(ref file_type) if file_type.is_file() => {
-            data = fs::read_to_string(filename)?;
+            let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(ref file_type) if file_type.is_dir() => parse_directory(filename),
-        Ok(_file_type) => {
-            // any other file types (namely, symlinks)
-            bail!(
-                "Cannot upload a file that is a symlink: {}",
-                filename.display()
-            )
-        }
+        Ok(_file_type) => bail!("wrangler kv write-bulk requires a json file",),
         Err(e) => bail!(e),
     };
 
@@ -64,29 +51,4 @@ pub fn write_bulk(namespace_id: &str, filename: &Path) -> Result<(), failure::Er
     }
 
     Ok(())
-}
-
-fn parse_directory(directory: &Path) -> Result<Vec<KeyValuePair>, failure::Error> {
-    let mut upload_vec: Vec<KeyValuePair> = Vec::new();
-    for entry in WalkDir::new(directory) {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.is_file() {
-            let key = super::generate_key(path, directory)?;
-
-            let value = std::fs::read(path)?;
-
-            // Need to base64 encode value
-            let b64_value = base64::encode(&value);
-            message::working(&format!("Parsing {}...", key.clone()));
-            upload_vec.push(KeyValuePair {
-                key: key,
-                value: b64_value,
-                expiration: None,
-                expiration_ttl: None,
-                base64: Some(true),
-            });
-        }
-    }
-    Ok(upload_vec)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn run() -> Result<(), failure::Error> {
                         )
                         .arg(
                             Arg::with_name("path")
-                            .help("the json file of key-value pairs to upload, in form [{\"key\":..., \"value\":...}\"...] OR the directory of files to upload.")
+                            .help("the json file of key-value pairs to upload, in form [{\"key\":..., \"value\":...}\"...].")
                             .required(true)
                             .index(2),
                         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,7 +429,7 @@ fn run() -> Result<(), failure::Error> {
             ("write-bulk", Some(write_bulk_matches)) => {
                 let id = write_bulk_matches.value_of("namespace-id").unwrap();
                 let path = write_bulk_matches.value_of("path").unwrap();
-                commands::kv::write_bulk(id, Path::new(path))?;
+                commands::kv::write_json(id, Path::new(path))?;
             }
             ("delete-key", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
@@ -439,7 +439,7 @@ fn run() -> Result<(), failure::Error> {
             ("delete-bulk", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
                 let path = delete_matches.value_of("path").unwrap();
-                commands::kv::delete_bulk(id, Path::new(path))?;
+                commands::kv::delete_json(id, Path::new(path))?;
             }
             ("list-keys", Some(list_keys_matches)) => {
                 let id = list_keys_matches.value_of("namespace-id").unwrap();


### PR DESCRIPTION
Closes #459 

We will be re-implementing this work for the KV Additions milestone, but under a separate subcommand. This PR will assert that `wrangler kv:bulk put` and `wrangler kv:bulk delete` specify a properly formatted JSON file, rather than matching on json file OR directory.