### PR TITLE
New Environments Design

### DIFF
--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -3,15 +3,15 @@ pub mod wranglerjs;
 mod watch;
 pub use watch::watch_and_build;
 
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::{ProjectType, Target};
 use crate::terminal::message;
 use crate::{commands, install};
 
 use std::path::PathBuf;
 use std::process::Command;
 
-pub fn build(project: &Project) -> Result<(), failure::Error> {
-    let project_type = &project.project_type;
+pub fn build(target: &Target) -> Result<(), failure::Error> {
+    let project_type = &target.project_type;
     match project_type {
         ProjectType::JavaScript => {
             message::info("JavaScript project found. Skipping unnecessary build!")
@@ -27,7 +27,7 @@ pub fn build(project: &Project) -> Result<(), failure::Error> {
             commands::run(command, &command_name)?;
         }
         ProjectType::Webpack => {
-            wranglerjs::run_build(project)?;
+            wranglerjs::run_build(target)?;
         }
     }
 

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -3,7 +3,7 @@ pub use watcher::wait_for_changes;
 
 use crate::commands::build::{command, wranglerjs};
 use crate::commands::publish::Package;
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::{ProjectType, Target};
 use crate::terminal::message;
 use crate::{commands, install};
 
@@ -18,10 +18,10 @@ pub const COOLDOWN_PERIOD: Duration = Duration::from_millis(2000);
 /// watch a project for changes and re-build it when necessary,
 /// outputting a build event to tx.
 pub fn watch_and_build(
-    project: &Project,
+    target: &Target,
     tx: Option<mpsc::Sender<()>>,
 ) -> Result<(), failure::Error> {
-    let project_type = &project.project_type;
+    let project_type = &target.project_type;
     match project_type {
         ProjectType::JavaScript => {
             let package = Package::new("./")?;
@@ -81,7 +81,7 @@ pub fn watch_and_build(
             });
         }
         ProjectType::Webpack => {
-            wranglerjs::run_build_and_watch(project, tx)?;
+            wranglerjs::run_build_and_watch(target, tx)?;
         }
     }
 

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -20,7 +20,7 @@ use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::settings::project::Project;
+use crate::settings::project::Target;
 use crate::terminal::message;
 
 use notify::{self, RecursiveMode, Watcher};
@@ -34,8 +34,8 @@ use std::time::Duration;
 // executable and wait for completion. The file will receive the a serialized
 // {WranglerjsOutput} struct.
 // Note that the ability to pass a fd is platform-specific
-pub fn run_build(project: &Project) -> Result<(), failure::Error> {
-    let (mut command, temp_file, bundle) = setup_build(project)?;
+pub fn run_build(target: &Target) -> Result<(), failure::Error> {
+    let (mut command, temp_file, bundle) = setup_build(target)?;
 
     info!("Running {:?}", command);
 
@@ -53,11 +53,8 @@ pub fn run_build(project: &Project) -> Result<(), failure::Error> {
     }
 }
 
-pub fn run_build_and_watch(
-    project: &Project,
-    tx: Option<Sender<()>>,
-) -> Result<(), failure::Error> {
-    let (mut command, temp_file, bundle) = setup_build(project)?;
+pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<(), failure::Error> {
+    let (mut command, temp_file, bundle) = setup_build(target)?;
     command.arg("--watch=1");
 
     info!("Running {:?} in watch mode", command);
@@ -125,7 +122,7 @@ fn write_wranglerjs_output(
 }
 
 //setup a build to run wranglerjs, return the command, the ipc temp file, and the bundle
-fn setup_build(project: &Project) -> Result<(Command, PathBuf, Bundle), failure::Error> {
+fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::Error> {
     for tool in &["node", "npm"] {
         env_dep_installed(tool)?;
     }
@@ -157,7 +154,7 @@ fn setup_build(project: &Project) -> Result<(Command, PathBuf, Bundle), failure:
     command.arg(format!("--wasm-binding={}", bundle.get_wasm_binding()));
 
     let webpack_config_path = PathBuf::from(
-        &project
+        &target
             .webpack_config
             .clone()
             .unwrap_or_else(|| "webpack.config.js".to_string()),

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,4 +1,4 @@
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::{Manifest, ProjectType};
 use crate::{commands, install};
 use std::path::PathBuf;
 use std::process::Command;
@@ -16,7 +16,7 @@ pub fn generate(name: &str, template: &str, pt: Option<ProjectType>) -> Result<(
     let command_name = format!("{:?}", command);
 
     commands::run(command, &command_name)?;
-    Project::generate(name.to_string(), pt, false)?;
+    Manifest::generate(name.to_string(), pt, false)?;
     Ok(())
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,4 +1,4 @@
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::{Manifest, ProjectType};
 use crate::terminal::message;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ pub fn init(name: Option<&str>, project_type: Option<ProjectType>) -> Result<(),
     let dirname = get_current_dirname()?;
     let name = name.unwrap_or_else(|| &dirname);
     let project_type = project_type.unwrap_or_default();
-    Project::generate(name.to_string(), project_type, true)?;
+    Manifest::generate(name.to_string(), project_type, true)?;
     message::success("Succesfully created a `wrangler.toml`");
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,6 @@ pub use init::init;
 pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;
 pub use publish::publish;
-pub use publish::publish_environment;
 pub use subdomain::subdomain;
 pub use whoami::whoami;
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -58,6 +58,9 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
         route.pattern
     } else {
         info!("publishing to subdomain");
+        if target.route.is_some() || target.zone_id.is_some() {
+            message::warn("Your environment should only include `workers_dot_dev` or both `route` and `zone_id`");
+        }
         publish_to_subdomain(target, user)?
     };
     info!("{}", &pattern);

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -15,7 +15,7 @@ use crate::commands::subdomain::Subdomain;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Target;
-use crate::terminal::{emoji, message};
+use crate::terminal::message;
 
 pub fn publish(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
     info!("workers_dot_dev = {}", target.workers_dot_dev);
@@ -51,20 +51,16 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
         )
     }
 
-    let pattern = if target.route.is_some() {
+    let pattern = if !target.workers_dot_dev {
         let route = Route::new(&target)?;
         Route::publish(&user, &target, &route)?;
         info!("publishing to route");
         route.pattern
-    } else if target.workers_dot_dev {
+    } else {
         info!("publishing to subdomain");
         publish_to_subdomain(target, user)?
-    } else {
-        failure::bail!(format!(
-            "{} you must either define a route or make workers_dot_dev true",
-            emoji::WARN
-        ))
     };
+
     info!("{}", &pattern);
     message::success(&format!(
         "Success! Your worker was successfully published. You can view it at {}",

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -62,7 +62,7 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
     };
     info!("{}", &pattern);
     message::success(&format!(
-        "Success! Your worker was successfully published. You can view it at {}.",
+        "Success! Your worker was successfully published. You can view it at {}",
         &pattern
     ));
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -61,7 +61,10 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
         publish_to_subdomain(target, user)?
     };
     info!("{}", &pattern);
-    message::success(&format!("Success! Your worker was successfully published. You can view it at {}.", &pattern));
+    message::success(&format!(
+        "Success! Your worker was successfully published. You can view it at {}.",
+        &pattern
+    ));
 
     Ok(())
 }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -15,7 +15,7 @@ use crate::commands::subdomain::Subdomain;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::project::Target;
-use crate::terminal::message;
+use crate::terminal::{emoji, message};
 
 pub fn publish(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
     info!("workers_dot_dev = {}", target.workers_dot_dev);
@@ -51,14 +51,19 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
         )
     }
 
-    let pattern = if !target.workers_dot_dev {
+    let pattern = if target.route.is_some() {
         let route = Route::new(&target)?;
         Route::publish(&user, &target, &route)?;
         info!("publishing to route");
         route.pattern
-    } else {
+    } else if target.workers_dot_dev {
         info!("publishing to subdomain");
         publish_to_subdomain(target, user)?
+    } else {
+        failure::bail!(format!(
+            "{} you must either define a route or make workers_dot_dev true",
+            emoji::WARN
+        ))
     };
     info!("{}", &pattern);
     message::success(&format!(

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -58,9 +58,6 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
         route.pattern
     } else {
         info!("publishing to subdomain");
-        if target.route.is_some() || target.zone_id.is_some() {
-            message::warn("Your environment should only include `workers_dot_dev` or both `route` and `zone_id`");
-        }
         publish_to_subdomain(target, user)?
     };
     info!("{}", &pattern);

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -17,7 +17,7 @@ use log::info;
 
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::settings::project::Project;
+use crate::settings::project::Target;
 use crate::terminal::message;
 
 use std::sync::mpsc::channel;
@@ -28,14 +28,14 @@ use ws::{Sender, WebSocket};
 const PREVIEW_ADDRESS: &str = "https://00000000000000000000000000000000.cloudflareworkers.com";
 
 pub fn preview(
-    project: Project,
+    target: Target,
     user: Option<GlobalUser>,
     method: HTTPMethod,
     body: Option<String>,
     livereload: bool,
 ) -> Result<(), failure::Error> {
-    commands::build(&project)?;
-    let script_id = upload_and_get_id(&project, user.as_ref())?;
+    commands::build(&target)?;
+    let script_id = upload_and_get_id(&target, user.as_ref())?;
 
     let session = Uuid::new_v4().to_simple();
     let preview_host = "example.com";
@@ -58,7 +58,7 @@ pub fn preview(
 
         let broadcaster = server.broadcaster();
         thread::spawn(move || server.run());
-        watch_for_changes(&project, user.as_ref(), session.to_string(), broadcaster)?;
+        watch_for_changes(&target, user.as_ref(), session.to_string(), broadcaster)?;
     } else {
         open_browser(&format!(
             "https://cloudflareworkers.com/?hide_editor#{0}:{1}{2}",
@@ -125,16 +125,16 @@ fn post(
 }
 
 fn watch_for_changes(
-    project: &Project,
+    target: &Target,
     user: Option<&GlobalUser>,
     session_id: String,
     broadcaster: Sender,
 ) -> Result<(), failure::Error> {
     let (tx, rx) = channel();
-    commands::watch_and_build(&project, Some(tx))?;
+    commands::watch_and_build(&target, Some(tx))?;
 
     while let Ok(_e) = rx.recv() {
-        if let Ok(new_id) = upload_and_get_id(project, user) {
+        if let Ok(new_id) = upload_and_get_id(target, user) {
             let msg = FiddleMessage {
                 session_id: session_id.clone(),
                 data: FiddleMessageData::LiveReload { new_id },

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -1,7 +1,7 @@
 use crate::commands::publish;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::settings::project::Project;
+use crate::settings::project::Target;
 use crate::terminal::message;
 use reqwest::Client;
 use serde::Deserialize;
@@ -33,19 +33,19 @@ struct V4ApiResponse {
 }
 
 pub fn upload_and_get_id(
-    project: &Project,
+    target: &Target,
     user: Option<&GlobalUser>,
 ) -> Result<String, failure::Error> {
     let preview = match &user {
         Some(user) => {
             log::info!("GlobalUser set, running with authentication");
 
-            let missing_fields = validate(&project);
+            let missing_fields = validate(&target);
 
             if missing_fields.is_empty() {
                 let client = http::auth_client(&user);
 
-                authenticated_upload(&client, &project)?
+                authenticated_upload(&client, &target)?
             } else {
                 message::warn(&format!(
                     "Your wrangler.toml is missing the following fields: {:?}",
@@ -54,7 +54,7 @@ pub fn upload_and_get_id(
                 message::warn("Falling back to unauthenticated preview.");
 
                 let client = http::client();
-                unauthenticated_upload(&client, &project)?
+                unauthenticated_upload(&client, &target)?
             }
         }
         None => {
@@ -67,24 +67,24 @@ pub fn upload_and_get_id(
 
             let client = http::client();
 
-            unauthenticated_upload(&client, &project)?
+            unauthenticated_upload(&client, &target)?
         }
     };
 
     Ok(preview.id)
 }
 
-fn validate(project: &Project) -> Vec<&str> {
+fn validate(target: &Target) -> Vec<&str> {
     let mut missing_fields = Vec::new();
 
-    if project.account_id.is_empty() {
+    if target.account_id.is_empty() {
         missing_fields.push("account_id")
     };
-    if project.name.is_empty() {
+    if target.name.is_empty() {
         missing_fields.push("name")
     };
 
-    match &project.kv_namespaces {
+    match &target.kv_namespaces {
         Some(kv_namespaces) => {
             for kv in kv_namespaces {
                 if kv.binding.is_empty() {
@@ -102,14 +102,14 @@ fn validate(project: &Project) -> Vec<&str> {
     missing_fields
 }
 
-fn authenticated_upload(client: &Client, project: &Project) -> Result<Preview, failure::Error> {
+fn authenticated_upload(client: &Client, target: &Target) -> Result<Preview, failure::Error> {
     let create_address = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}/preview",
-        project.account_id, project.name
+        target.account_id, target.name
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_script_upload_form(&project)?;
+    let script_upload_form = publish::build_script_upload_form(&target)?;
 
     let mut res = client
         .post(&create_address)
@@ -126,22 +126,22 @@ fn authenticated_upload(client: &Client, project: &Project) -> Result<Preview, f
     Ok(Preview::from(response.result))
 }
 
-fn unauthenticated_upload(client: &Client, project: &Project) -> Result<Preview, failure::Error> {
+fn unauthenticated_upload(client: &Client, target: &Target) -> Result<Preview, failure::Error> {
     let create_address = "https://cloudflareworkers.com/script";
     log::info!("address: {}", create_address);
 
     // KV namespaces are not supported by the preview service unless you authenticate
     // so we omit them and provide the user with a little guidance. We don't error out, though,
     // because there are valid workarounds for this for testing purposes.
-    let script_upload_form = if project.kv_namespaces.is_some() {
+    let script_upload_form = if target.kv_namespaces.is_some() {
         message::warn(
             "KV Namespaces are not supported in preview without setting API credentials and account_id",
         );
-        let mut project = project.clone();
-        project.kv_namespaces = None;
-        publish::build_script_upload_form(&project)?
+        let mut target = target.clone();
+        target.kv_namespaces = None;
+        publish::build_script_upload_form(&target)?
     } else {
-        publish::build_script_upload_form(&project)?
+        publish::build_script_upload_form(&target)?
     };
 
     let mut res = client

--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -1,6 +1,6 @@
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::settings::project::Project;
+use crate::settings::project::Target;
 use crate::terminal::emoji;
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
@@ -19,8 +19,8 @@ struct RoutesResponse {
 }
 
 impl Route {
-    pub fn new(project: &Project) -> Result<Route, failure::Error> {
-        if project
+    pub fn new(target: &Target) -> Result<Route, failure::Error> {
+        if target
             .route
             .clone()
             .expect("You must provide a zone_id in your wrangler.toml before publishing!")
@@ -30,24 +30,24 @@ impl Route {
         }
         let msg_config_error = format!("{} Your project config has an error, check your `wrangler.toml`: `route` must be provided.", emoji::WARN);
         Ok(Route {
-            script: Some(project.name.to_string()),
-            pattern: project.route.clone().expect(&msg_config_error),
+            script: Some(target.name.to_string()),
+            pattern: target.route.clone().expect(&msg_config_error),
         })
     }
 
     pub fn publish(
         user: &GlobalUser,
-        project: &Project,
+        target: &Target,
         route: &Route,
     ) -> Result<(), failure::Error> {
-        if route.exists(user, project)? {
+        if route.exists(user, target)? {
             return Ok(());
         }
-        create(user, project, route)
+        create(user, target, route)
     }
 
-    pub fn exists(&self, user: &GlobalUser, project: &Project) -> Result<bool, failure::Error> {
-        let routes = get_routes(user, project)?;
+    pub fn exists(&self, user: &GlobalUser, target: &Target) -> Result<bool, failure::Error> {
+        let routes = get_routes(user, target)?;
 
         for route in routes {
             if route.matches(self) {
@@ -62,8 +62,8 @@ impl Route {
     }
 }
 
-fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failure::Error> {
-    let routes_addr = get_routes_addr(project)?;
+fn get_routes(user: &GlobalUser, target: &Target) -> Result<Vec<Route>, failure::Error> {
+    let routes_addr = get_routes_addr(target)?;
 
     let client = http::auth_client(user);
 
@@ -84,11 +84,11 @@ fn get_routes(user: &GlobalUser, project: &Project) -> Result<Vec<Route>, failur
     Ok(routes_response.result)
 }
 
-fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), failure::Error> {
+fn create(user: &GlobalUser, target: &Target, route: &Route) -> Result<(), failure::Error> {
     let client = http::auth_client(user);
     let body = serde_json::to_string(&route)?;
 
-    let routes_addr = get_routes_addr(project)?;
+    let routes_addr = get_routes_addr(target)?;
 
     info!("Creating your route {:#?}", &route.pattern,);
     let mut res = client
@@ -109,8 +109,8 @@ fn create(user: &GlobalUser, project: &Project, route: &Route) -> Result<(), fai
     Ok(())
 }
 
-fn get_routes_addr(project: &Project) -> Result<String, failure::Error> {
-    if let Some(zone_id) = &project.zone_id {
+fn get_routes_addr(target: &Target) -> Result<String, failure::Error> {
+    if let Some(zone_id) = &target.zone_id {
         return Ok(format!(
             "https://api.cloudflare.com/client/v4/zones/{}/workers/routes",
             zone_id

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -11,16 +11,16 @@ use crate::commands::build::wranglerjs;
 use crate::settings::binding;
 use crate::settings::metadata::Metadata;
 use crate::settings::project::kv_namespace;
-use crate::settings::project::{Project, ProjectType};
+use crate::settings::project::{ProjectType, Target};
 
 use project_assets::ProjectAssets;
 use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_upload_form(project: &Project) -> Result<Form, failure::Error> {
-    let project_type = &project.project_type;
-    let kv_namespaces = project.kv_namespaces();
+pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error> {
+    let project_type = &target.project_type;
+    let kv_namespaces = target.kv_namespaces();
     match project_type {
         ProjectType::Rust => {
             info!("Rust project detected. Publishing...");

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -1,6 +1,6 @@
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::settings::project::Project;
+use crate::settings::project::Target;
 use crate::terminal::{emoji, message};
 
 use serde::{Deserialize, Serialize};
@@ -58,8 +58,8 @@ fn subdomain_addr(account_id: &str) -> String {
     )
 }
 
-pub fn subdomain(name: &str, user: &GlobalUser, project: &Project) -> Result<(), failure::Error> {
-    if project.account_id.is_empty() {
+pub fn subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+    if target.account_id.is_empty() {
         failure::bail!(format!(
             "{} You must provide an account_id in your wrangler.toml before creating a subdomain!",
             emoji::WARN
@@ -70,7 +70,7 @@ pub fn subdomain(name: &str, user: &GlobalUser, project: &Project) -> Result<(),
         name
     );
     message::working(&msg);
-    let account_id = &project.account_id;
+    let account_id = &target.account_id;
     let addr = subdomain_addr(account_id);
     let sd = Subdomain {
         subdomain: name.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn run() -> Result<(), failure::Error> {
                     Arg::with_name("env")
                         .help("environment to preview")
                         .short("e")
-                        .long("environment")
+                        .long("env")
                         .takes_value(true)
                 )
                 .arg(
@@ -144,13 +144,13 @@ fn run() -> Result<(), failure::Error> {
                     Arg::with_name("release")
                         .long("release")
                         .takes_value(false)
-                        .help("[this will be deprecated, use --environment instead]\nshould this be published to a workers.dev subdomain or a domain name you have registered"),
+                        .help("[this will be deprecated, use --env instead]\nshould this be published to a workers.dev subdomain or a domain name you have registered"),
                 )
                 .arg(
                     Arg::with_name("env")
                         .help("environments to publish to")
                         .short("e")
-                        .long("environment")
+                        .long("env")
                         .takes_value(true)
                 ),
         )

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -127,18 +127,15 @@ impl Manifest {
             },
             // top level (legacy)
             None => {
-                match release {
-                    true => {
-                        message::warn(deprecate_warning);
-                        false // --release means not workers.dev
-                    }
-                    false => {
-                        match self.workers_dot_dev {
-                            Some(wdd) => wdd,
-                            None => {
-                                message::warn(deprecate_warning);
-                                true // no --release means workers.dev
-                            }
+                if release {
+                    message::warn(deprecate_warning);
+                    false // --release means not workers.dev
+                } else {
+                    match self.workers_dot_dev {
+                        Some(wdd) => wdd,
+                        None => {
+                            message::warn(deprecate_warning);
+                            true // no --release means workers.dev
                         }
                     }
                 }

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -204,16 +204,18 @@ impl Manifest {
             None => self.zone_id.clone(),
         };
 
+        let project_type = self.project_type.clone();
+
         Ok(Target {
-            account_id,                              // inherit
-            kv_namespaces,                           // enforce explicit definition per environment
-            name,                                    // don't inherit
-            project_type: self.project_type.clone(), // enforce inheritance
-            route,                                   // don't inherit
-            routes,                                  // don't inherit
-            webpack_config,                          // inherit
-            workers_dot_dev,                         // don't inherit,
-            zone_id,                                 // inherit
+            project_type,    // MUST inherit
+            account_id,      // MAY inherit
+            webpack_config,  // MAY inherit
+            zone_id,         // MAY inherit
+            kv_namespaces,   // MUST NOT inherit
+            name,            // MUST NOT inherit
+            route,           // MUST NOT inherit
+            routes,          // MUST NOT inherit
+            workers_dot_dev, // MUST NOT inherit,
         })
     }
 

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -175,7 +175,7 @@ impl Manifest {
     ) -> Result<Manifest, failure::Error> {
         let manifest = Manifest {
             account_id: String::new(),
-            env: Some(HashMap::new()),
+            env: None,
             kv_namespaces: None,
             name: name.clone(),
             private: None,
@@ -183,7 +183,7 @@ impl Manifest {
             route: Some(String::new()),
             routes: None,
             webpack_config: None,
-            workers_dot_dev: Some(false),
+            workers_dot_dev: Some(true),
             zone_id: Some(String::new()),
         };
 

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -8,50 +8,152 @@ use crate::terminal::emoji;
 use crate::terminal::message;
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use log::info;
 
-use config::{Config, Environment, File, Value};
+use config::{Config, File};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Project {
+pub struct Target {
+    pub account_id: String,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<KvNamespace>>,
     pub name: String,
     #[serde(rename = "type")]
     pub project_type: ProjectType,
-    pub zone_id: Option<String>,
-    pub private: Option<bool>,
-    pub webpack_config: Option<String>,
-    pub account_id: String,
     pub route: Option<String>,
     pub routes: Option<HashMap<String, String>>,
-    #[serde(rename = "kv-namespaces")]
-    pub kv_namespaces: Option<Vec<KvNamespace>>,
+    pub webpack_config: Option<String>,
+    pub workers_dot_dev: bool,
+    pub zone_id: Option<String>,
 }
 
-impl Project {
+impl Target {
+    pub fn kv_namespaces(&self) -> Vec<KvNamespace> {
+        self.kv_namespaces.clone().unwrap_or_else(Vec::new)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Environment {
+    pub account_id: Option<String>,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<KvNamespace>>,
+    pub name: Option<String>,
+    pub route: Option<String>,
+    pub routes: Option<HashMap<String, String>>,
+    pub webpack_config: Option<String>,
+    pub workers_dot_dev: Option<bool>,
+    pub zone_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Manifest {
+    pub account_id: String,
+    pub environments: HashMap<String, Environment>,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<KvNamespace>>,
+    pub name: String,
+    pub private: Option<bool>,
+    #[serde(rename = "type")]
+    pub project_type: ProjectType,
+    pub route: Option<String>,
+    pub routes: Option<HashMap<String, String>>,
+    pub webpack_config: Option<String>,
+    pub workers_dot_dev: Option<bool>,
+    pub zone_id: Option<String>,
+}
+
+impl Manifest {
+    pub fn new() -> Result<Self, failure::Error> {
+        get_manifest(Path::new("./wrangler.toml"))
+    }
+
+    pub fn get_target(
+        &self,
+        environment_name: Option<&str>,
+        release: bool,
+    ) -> Result<Target, failure::Error> {
+        if release && self.workers_dot_dev.is_some() {
+            failure::bail!("The --release flag is deprecated with use of the workers_dot_dev field")
+        }
+        let environment = if environment_name.is_none() {
+            None
+        } else {
+            let environment_name = environment_name.unwrap();
+            let environment = self.environments.get(environment_name);
+            if environment.is_none() {
+                failure::bail!(format!(
+                    "{} Could not find environment with name {}",
+                    emoji::WARN,
+                    environment_name
+                ))
+            }
+            Some(environment.unwrap())
+        };
+        let workers_dot_dev = if environment.is_none() {
+            // wrangler publish --release
+            if release {
+                // not workers.dev
+                false
+            // wrangler publish
+            } else {
+                if self.workers_dot_dev.is_none() {
+                    // workers.dev
+                    true
+                } else {
+                    // use .toml value
+                    self.workers_dot_dev.unwrap()
+                }
+            }
+        } else {
+            // wrangler publish --env foo
+            let environment = environment.unwrap();
+            if environment.workers_dot_dev.is_none() {
+                // not workers.dev
+                false
+            } else {
+                // use .toml value
+                environment.workers_dot_dev.unwrap()
+            }
+        };
+
+        Ok(Target {
+            account_id: self.account_id,
+            kv_namespaces: self.kv_namespaces,
+            name: self.name,
+            project_type: self.project_type,
+            route: self.route,
+            routes: self.routes,
+            webpack_config: self.webpack_config,
+            workers_dot_dev,
+            zone_id: self.zone_id,
+        })
+    }
+
     pub fn generate(
         name: String,
         project_type: ProjectType,
         init: bool,
-    ) -> Result<Project, failure::Error> {
-        let project = Project {
-            name: name.clone(),
-            project_type: project_type.clone(),
-            private: Some(false),
-            zone_id: Some(String::new()),
+    ) -> Result<Manifest, failure::Error> {
+        let manifest = Manifest {
             account_id: String::new(),
+            environments: HashMap::new(),
+            kv_namespaces: None,
+            name: name.clone(),
+            private: None,
+            project_type: project_type.clone(),
             route: Some(String::new()),
             routes: None,
-            kv_namespaces: None,
             webpack_config: None,
+            workers_dot_dev: Some(false),
+            zone_id: Some(String::new()),
         };
 
-        let toml = toml::to_string(&project)?;
+        let toml = toml::to_string(&manifest)?;
         let config_path = if init {
             PathBuf::from("./")
         } else {
@@ -61,41 +163,27 @@ impl Project {
 
         info!("Writing a wrangler.toml file at {}", config_file.display());
         fs::write(&config_file, &toml)?;
-        Ok(project)
-    }
-
-    pub fn new() -> Result<Self, failure::Error> {
-        let config_path = Path::new("./wrangler.toml");
-        get_project_config(None, config_path)
-    }
-
-    pub fn new_from_environment(environment: &str) -> Result<Self, failure::Error> {
-        let config_path = Path::new("./wrangler.toml");
-        get_project_config(Some(environment), config_path)
-    }
-
-    pub fn kv_namespaces(&self) -> Vec<KvNamespace> {
-        self.kv_namespaces.clone().unwrap_or_else(Vec::new)
+        Ok(manifest)
     }
 }
 
-fn get_project_config(
-    environment_name: Option<&str>,
-    config_path: &Path,
-) -> Result<Project, failure::Error> {
-    let mut s = Config::new();
+fn read_config(config_path: &Path) -> Result<Config, failure::Error> {
+    let mut config = Config::new();
 
     let config_str = config_path
         .to_str()
         .expect("project config path should be a string");
-    s.merge(File::with_name(config_str))?;
+    config.merge(File::with_name(config_str))?;
 
     // Eg.. `CF_ACCOUNT_AUTH_KEY=farts` would set the `account_auth_key` key
-    s.merge(Environment::with_prefix("CF"))?;
+    config.merge(config::Environment::with_prefix("CF"))?;
 
-    // check for pre 1.1.0 KV namespace format
-    let kv_namespaces: Result<Vec<config::Value>, config::ConfigError> = s.get("kv-namespaces");
+    Ok(config)
+}
 
+fn validate_kv_namespaces_config(
+    kv_namespaces: Result<Vec<config::Value>, config::ConfigError>,
+) -> Result<(), failure::Error> {
     if let Ok(values) = kv_namespaces {
         let old_format = values.iter().any(|val| val.clone().into_str().is_ok());
 
@@ -118,35 +206,20 @@ id = "0f2ac74b498b48028cb68387c421e279"
             failure::bail!(msg)
         }
     }
+    Ok(())
+}
 
-    let environments = s.get_table("env");
-    if environments.is_err() {
-        let project: Result<Project, config::ConfigError> = s.try_into();
-        return project.map_err(|e| {
-            let msg = format!(
-                "{} Your project config has an error, check your `wrangler.toml`: {}",
-                emoji::WARN,
-                e
-            );
-            failure::err_msg(msg)
-        });
-    }
-    if environment_name.is_none() {
-        failure::bail!("There are no environments in your `wrangler.toml`!")
-    }
-    let environments = environments.unwrap();
-    let environment_name = environment_name.unwrap();
-    let environment = match environments.get(environment_name) {
-        Some(e) => e,
-        None => failure::bail!(format!(
-            "{0} Your `wrangler.toml` does not contain a `{1}` environment {0}",
-            emoji::WARN,
-            environment_name
-        )),
-    };
+fn get_manifest(config_path: &Path) -> Result<Manifest, failure::Error> {
+    let mut config = read_config(config_path)?;
 
-    let project = environment.clone().try_into()?;
-    Ok(project)
+    // check for pre 1.1.0 KV namespace format
+    let kv_namespaces: Result<Vec<config::Value>, config::ConfigError> =
+        config.get("kv-namespaces");
+
+    validate_kv_namespaces_config(kv_namespaces)?;
+
+    let manifest = config.try_into()?;
+    Ok(manifest)
 }
 
 #[cfg(test)]

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -78,6 +78,7 @@ impl Manifest {
         validate_kv_namespaces_config(kv_namespaces)?;
 
         let manifest = config.try_into()?;
+        println!("{:#?}", manifest);
         Ok(manifest)
     }
 
@@ -109,13 +110,12 @@ impl Manifest {
                         )),
                     }
                 }
-                None => {
-                    failure::bail!(format!(
-                        "{} There are no environments specified in your wrangler.toml",
-                        emoji::WARN))
-                },
+                None => failure::bail!(format!(
+                    "{} There are no environments specified in your wrangler.toml",
+                    emoji::WARN
+                )),
             },
-            None => None
+            None => None,
         };
 
         let release_deprecate_warning =
@@ -152,7 +152,7 @@ impl Manifest {
                 Some(kv) => Some(kv.clone()),
                 None => None,
             },
-            None => None,
+            None => self.kv_namespaces.clone(),
         };
 
         Ok(Target {

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -167,7 +167,10 @@ impl Manifest {
                     }
                     name
                 }
-                None => failure::bail!("You must specify `name` in your wrangler.toml"),
+                None => match environment_name {
+                    Some(environment_name) => format!("{}-{}", self.name, environment_name),
+                    None => failure::bail!("You must specify `name` in your wrangler.toml"),
+                },
             },
             None => self.name.clone(),
         };
@@ -207,12 +210,14 @@ impl Manifest {
         let project_type = self.project_type.clone();
 
         Ok(Target {
-            project_type,    // MUST inherit
-            account_id,      // MAY inherit
-            webpack_config,  // MAY inherit
-            zone_id,         // MAY inherit
+            project_type,   // MUST inherit
+            account_id,     // MAY inherit
+            webpack_config, // MAY inherit
+            zone_id,        // MAY inherit
+            // importantly, the top level name will be modified
+            // to include the name of the environment
+            name,            // MAY inherit
             kv_namespaces,   // MUST NOT inherit
-            name,            // MUST NOT inherit
             route,           // MUST NOT inherit
             routes,          // MUST NOT inherit
             workers_dot_dev, // MUST NOT inherit,

--- a/src/settings/project/mod.rs
+++ b/src/settings/project/mod.rs
@@ -144,7 +144,6 @@ impl Manifest {
                             wdd
                         }
                         None => {
-                            println!("{:#?}", "wrangler publish with base environment");
                             message::warn(deprecate_warning);
                             true // no --release means workers.dev
                         }

--- a/src/settings/project/tests/mod.rs
+++ b/src/settings/project/tests/mod.rs
@@ -9,7 +9,7 @@ fn it_builds_from_config() {
 
     let manifest = Manifest::new(&toml_path).unwrap();
 
-    let target = Manifest::get_target(None).unwrap();
+    let target = manifest.get_target(None, false).unwrap();
     assert!(target.kv_namespaces.is_none());
 }
 
@@ -18,10 +18,10 @@ fn it_builds_from_environments_config() {
     let toml_path = toml_fixture_path("environments");
     let manifest = Manifest::new(&toml_path).unwrap();
 
-    let target = Manifest::get_target(None).unwrap();
+    let target = manifest.get_target(None, false).unwrap();
     assert!(target.kv_namespaces.is_none());
 
-    let target = Manifest::get_target(Some("production".to_string())).unwrap();
+    let target = manifest.get_target(Some("production"), false).unwrap();
     assert!(target.kv_namespaces.is_none());
 }
 
@@ -31,11 +31,45 @@ fn it_builds_from_environments_config_with_kv() {
 
     let manifest = Manifest::new(&toml_path).unwrap();
 
-    let target = Manifest::get_target(None).unwrap();
+    let target = manifest.get_target(None, false).unwrap();
     assert!(target.kv_namespaces.is_none());
 
-    let target = Manifest::get_target(Some("production".to_string())).unwrap();
-    assert!(target.kv_namespaces.is_none());
+    let target = manifest.get_target(Some("production"), false).unwrap();
+    let kv_1 = KvNamespace {
+        id: "somecrazylongidentifierstring".to_string(),
+        binding: "prodKV-1".to_string(),
+    };
+    let kv_2 = KvNamespace {
+        id: "anotherwaytoolongidstring".to_string(),
+        binding: "prodKV-2".to_string(),
+    };
+
+    match target.kv_namespaces {
+        Some(kv_namespaces) => {
+            assert!(kv_namespaces.len() == 2);
+            assert!(kv_namespaces.contains(&kv_1));
+            assert!(kv_namespaces.contains(&kv_2));
+        }
+        None => assert!(false),
+    }
+
+    let target = manifest.get_target(Some("staging"), false).unwrap();
+    let kv_1 = KvNamespace {
+        id: "somecrazylongidentifierstring".to_string(),
+        binding: "stagingKV-1".to_string(),
+    };
+    let kv_2 = KvNamespace {
+        id: "anotherwaytoolongidstring".to_string(),
+        binding: "stagingKV-2".to_string(),
+    };
+    match target.kv_namespaces {
+        Some(kv_namespaces) => {
+            assert!(kv_namespaces.len() == 2);
+            assert!(kv_namespaces.contains(&kv_1));
+            assert!(kv_namespaces.contains(&kv_2));
+        }
+        None => assert!(false),
+    }
 }
 
 #[test]
@@ -43,7 +77,7 @@ fn it_builds_from_legacy_config() {
     let toml_path = legacy_toml_fixture_path("default");
 
     let manifest = Manifest::new(&toml_path).unwrap();
-    let target = Manifest::get_target(None).unwrap();
+    let target = manifest.get_target(None, false).unwrap();
 
     assert!(target.kv_namespaces.is_none());
 }
@@ -53,7 +87,7 @@ fn it_builds_from_legacy_config_with_kv() {
     let toml_path = legacy_toml_fixture_path("kv_namespaces");
 
     let manifest = Manifest::new(&toml_path).unwrap();
-    let target = Manifest::get_target(None).unwrap();
+    let target = manifest.get_target(None, false).unwrap();
 
     let kv_1 = KvNamespace {
         id: "somecrazylongidentifierstring".to_string(),

--- a/src/settings/project/tests/mod.rs
+++ b/src/settings/project/tests/mod.rs
@@ -5,48 +5,55 @@ use std::path::{Path, PathBuf};
 
 #[test]
 fn it_builds_from_config() {
-    const NAME: &str = "default";
-    let toml_path = toml_fixture_path(NAME);
+    let toml_path = toml_fixture_path("default");
 
-    let project = get_project_config(Some(NAME), &toml_path).unwrap();
+    let manifest = Manifest::new(&toml_path).unwrap();
 
-    assert!(project.kv_namespaces.is_none());
+    let target = Manifest::get_target(None).unwrap();
+    assert!(target.kv_namespaces.is_none());
 }
 
 #[test]
 fn it_builds_from_environments_config() {
-    const NAME: &str = "environments";
-    let toml_path = toml_fixture_path(NAME);
+    let toml_path = toml_fixture_path("environments");
+    let manifest = Manifest::new(&toml_path).unwrap();
 
-    let project = get_project_config(Some(NAME), &toml_path).unwrap();
+    let target = Manifest::get_target(None).unwrap();
+    assert!(target.kv_namespaces.is_none());
 
-    assert!(project.kv_namespaces.is_none());
+    let target = Manifest::get_target(Some("production".to_string())).unwrap();
+    assert!(target.kv_namespaces.is_none());
 }
 
 #[test]
 fn it_builds_from_environments_config_with_kv() {
-    const NAME: &str = "kv_namespaces";
-    let toml_path = toml_fixture_path(NAME);
+    let toml_path = toml_fixture_path("kv_namespaces");
 
-    let project = get_project_config(Some(NAME), &toml_path).unwrap();
+    let manifest = Manifest::new(&toml_path).unwrap();
 
-    assert!(project.kv_namespaces.is_none());
+    let target = Manifest::get_target(None).unwrap();
+    assert!(target.kv_namespaces.is_none());
+
+    let target = Manifest::get_target(Some("production".to_string())).unwrap();
+    assert!(target.kv_namespaces.is_none());
 }
 
 #[test]
 fn it_builds_from_legacy_config() {
     let toml_path = legacy_toml_fixture_path("default");
 
-    let project = get_project_config(None, &toml_path).unwrap();
+    let manifest = Manifest::new(&toml_path).unwrap();
+    let target = Manifest::get_target(None).unwrap();
 
-    assert!(project.kv_namespaces.is_none());
+    assert!(target.kv_namespaces.is_none());
 }
 
 #[test]
 fn it_builds_from_legacy_config_with_kv() {
     let toml_path = legacy_toml_fixture_path("kv_namespaces");
 
-    let project = get_project_config(None, &toml_path).unwrap();
+    let manifest = Manifest::new(&toml_path).unwrap();
+    let target = Manifest::get_target(None).unwrap();
 
     let kv_1 = KvNamespace {
         id: "somecrazylongidentifierstring".to_string(),
@@ -57,7 +64,7 @@ fn it_builds_from_legacy_config_with_kv() {
         binding: "stagingKV".to_string(),
     };
 
-    match project.kv_namespaces {
+    match target.kv_namespaces {
         Some(kv_namespaces) => {
             assert!(kv_namespaces.len() == 2);
             assert!(kv_namespaces.contains(&kv_1));

--- a/src/settings/project/tests/tomls/default.toml
+++ b/src/settings/project/tests/tomls/default.toml
@@ -1,4 +1,3 @@
-[env.default]
 type = "webpack"
 name = "worker"
 zone_id = ""

--- a/src/settings/project/tests/tomls/invalid_environments.toml
+++ b/src/settings/project/tests/tomls/invalid_environments.toml
@@ -1,4 +1,3 @@
-[env.default]
 type = "webpack"
 name = "worker"
 zone_id = ""
@@ -6,10 +5,32 @@ private = false
 account_id = ""
 route = ""
 
-[env.staging]
+[env.name_conflict]
+name = "worker"
+zone_id = ""
+private = false
+account_id = ""
+route = ""
+
+[env.has_private]
+name = "worker"
+zone_id = ""
+private = false
+account_id = ""
+route = ""
+
+[env.has_type]
 type = "webpack"
 name = "worker"
 zone_id = ""
 private = false
 account_id = ""
 route = ""
+
+[env.route_and_dot_dev]
+name = "worker"
+zone_id = ""
+private = false
+account_id = ""
+route = "example.com/*"
+workersdotdev = true

--- a/src/settings/project/tests/tomls/kv_namespaces.toml
+++ b/src/settings/project/tests/tomls/kv_namespaces.toml
@@ -9,22 +9,25 @@ name = "staging-worker"
 zone_id = ""
 account_id = ""
 route = ""
-    [[kv-namespaces]]
-    id = "somecrazylongidentifierstring"
-    binding = "prodKV-1"
-    [[kv-namespaces]]
-    id = "anotherwaytoolongidstring"
-    binding = "prodKV-2"
 
+[[env.production.kv-namespaces]]
+id = "somecrazylongidentifierstring"
+binding = "prodKV-1"
+
+[[env.production.kv-namespaces]]
+id = "anotherwaytoolongidstring"
+binding = "prodKV-2"
 
 [env.staging]
 name = "staging-worker"
 zone_id = ""
 account_id = ""
 route = ""
-    [[kv-namespaces]]
-    id = "somecrazylongidentifierstring"
-    binding = "stagingKV-1"
-    [[kv-namespaces]]
-    id = "anotherwaytoolongidstring"
-    binding = "stagingKV-2"
+
+[[env.staging.kv-namespaces]]
+id = "somecrazylongidentifierstring"
+binding = "stagingKV-1"
+
+[[env.staging.kv-namespaces]]
+id = "anotherwaytoolongidstring"
+binding = "stagingKV-2"

--- a/src/settings/project/tests/tomls/kv_namespaces.toml
+++ b/src/settings/project/tests/tomls/kv_namespaces.toml
@@ -1,19 +1,15 @@
-[env.default]
 type = "webpack"
 name = "worker"
 zone_id = ""
-private = false
 account_id = ""
 route = ""
     [[kv-namespaces]]
     id = "somecrazylongidentifierstring"
     binding = "prodKV"
 
-[env.kv_namespaces]
-type = "webpack"
+[env.production]
 name = "staging-worker"
 zone_id = ""
-private = false
 account_id = ""
 route = ""
     [[kv-namespaces]]

--- a/src/settings/project/tests/tomls/kv_namespaces.toml
+++ b/src/settings/project/tests/tomls/kv_namespaces.toml
@@ -3,9 +3,6 @@ name = "worker"
 zone_id = ""
 account_id = ""
 route = ""
-    [[kv-namespaces]]
-    id = "somecrazylongidentifierstring"
-    binding = "prodKV"
 
 [env.production]
 name = "staging-worker"
@@ -13,5 +10,21 @@ zone_id = ""
 account_id = ""
 route = ""
     [[kv-namespaces]]
+    id = "somecrazylongidentifierstring"
+    binding = "prodKV-1"
+    [[kv-namespaces]]
     id = "anotherwaytoolongidstring"
-    binding = "stagingKV"
+    binding = "prodKV-2"
+
+
+[env.staging]
+name = "staging-worker"
+zone_id = ""
+account_id = ""
+route = ""
+    [[kv-namespaces]]
+    id = "somecrazylongidentifierstring"
+    binding = "stagingKV-1"
+    [[kv-namespaces]]
+    id = "anotherwaytoolongidstring"
+    binding = "stagingKV-2"

--- a/src/settings/project/tests/tomls/no_default.toml
+++ b/src/settings/project/tests/tomls/no_default.toml
@@ -1,10 +1,12 @@
+[env.production]
 type = "webpack"
-name = "worker"
+name = "staging-worker"
 zone_id = ""
+private = false
 account_id = ""
 route = ""
 
-[env.production]
+[env.staging]
 type = "webpack"
 name = "staging-worker"
 zone_id = ""

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -10,29 +10,6 @@ use std::str;
 
 const BUNDLE_OUT: &str = "./worker";
 
-macro_rules! multiple_env_settings {
-    ( $f:expr, $x:expr ) => {
-        let file_path = fixture_path($f).join("wrangler.toml");
-        let mut file = File::create(file_path).unwrap();
-        let content = format!(
-            r#"
-            [env.default]
-            name = "prod-test"
-            zone_id = ""
-            account_id = ""
-            {}
-            [env.staging]
-            name = "staging-test"
-            zone_id = ""
-            account_id = ""
-            {}
-        "#,
-            $x, $x
-        );
-        file.write_all(content.as_bytes()).unwrap();
-    };
-}
-
 macro_rules! single_env_settings {
     ( $f:expr, $x:expr ) => {
         let file_path = fixture_path($f).join("wrangler.toml");


### PR DESCRIPTION
Parse .toml into `Manifest` with `Environments` - these are dummy structs, and are only used to parse the toml. 

Rename `Project` to `Target` - this is what is actually used.
Handling zoneless/zoned deploys is now in `Manifest::get_target`

Deprecate `private`
Generate includes `workers_dot_dev`

Fixes #481, #474, #442