### PR TITLE
Gabbi/add interactive delete

### DIFF
--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -30,6 +30,8 @@ $ wrangler kv:namespace create "new kv namespace"
 
 ```sh
 $ wrangler kv:namespace delete f7b02e7fc70443149ac906dd81ec1791
+Are you sure you want to delete namespace f7b02e7fc70443149ac906dd81ec1791? [y/n]
+yes
 🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791 🌀 
 ✨  Success
 ```
@@ -91,6 +93,10 @@ Removes a single key value pair from the given namespace.
 
 ```sh
 $ wrangler kv:key delete f7b02e7fc70443149ac906dd81ec1791 "key"
+Are you sure you want to delete key "key"? [y/n]
+yes
+🌀  Deleting key "key" 🌀
+✨  Success
 ```
 
 ### `list`
@@ -144,5 +150,8 @@ Deletes all specified keys within a given namespace.
 
 ```sh
 $ wrangler kv:bulk delete f7b02e7fc70443149ac906dd81ec1791 ./allthethings.json
+Are you sure you want to delete all keys in ./allthethings.json? [y/n]
+yes
+✨  Success
 ```
 

--- a/docs/content/kv_commands.md
+++ b/docs/content/kv_commands.md
@@ -17,7 +17,7 @@ Creates a new namespace.
 
 ```sh
 $ wrangler kv:namespace create "new kv namespace"
-🌀  Creating namespace with title "new kv namespace" 🌀 
+🌀  Creating namespace with title "new kv namespace"
 ✨  Success: WorkersKVNamespace {
     id: "f7b02e7fc70443149ac906dd81ec1791",
     title: "new kv namespace",
@@ -32,7 +32,7 @@ $ wrangler kv:namespace create "new kv namespace"
 $ wrangler kv:namespace delete f7b02e7fc70443149ac906dd81ec1791
 Are you sure you want to delete namespace f7b02e7fc70443149ac906dd81ec1791? [y/n]
 yes
-🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791 🌀 
+🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791
 ✨  Success
 ```
 
@@ -54,7 +54,7 @@ Outputs a list of all KV namespaces associated with your account id.
 
 ```sh
 $ wrangler kv:namespace list
-🌀  Retrieving namespaces 🌀 
+🌀  Retrieving namespaces
 ✨  Success:
 +------------------+----------------------------------+
 | TITLE            | ID                               |
@@ -95,7 +95,7 @@ Removes a single key value pair from the given namespace.
 $ wrangler kv:key delete f7b02e7fc70443149ac906dd81ec1791 "key"
 Are you sure you want to delete key "key"? [y/n]
 yes
-🌀  Deleting key "key" 🌀
+🌀  Deleting key "key"
 ✨  Success
 ```
 
@@ -107,7 +107,7 @@ Outputs a list of all KV namespaces associated with your account id.
 
 ```sh
 $ wrangler kv:key list f7b02e7fc70443149ac906dd81ec1791 --prefix="public"
-🌀  Retrieving keys 🌀 
+🌀  Retrieving keys
 ✨  Success:
 +------------------+----------------------------------+
 | KEY              | EXPIRATION                       |

--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -13,19 +13,17 @@ use crate::terminal::message;
 
 const MAX_PAIRS: usize = 10000;
 
-pub fn delete_json(namespace_id: &str, filename: &Path, force: bool) -> Result<(), failure::Error> {
-    if !force {
-        match kv::interactive_delete(&format!(
-            "Are you sure you want to delete all keys in {}?",
-            filename.display()
-        )) {
-            Ok(true) => (),
-            Ok(false) => {
-                message::info(&format!("Not deleting keys in {}", filename.display()));
-                return Ok(());
-            }
-            Err(e) => failure::bail!(e),
+pub fn delete_json(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
+    match kv::interactive_delete(&format!(
+        "Are you sure you want to delete all keys in {}?",
+        filename.display()
+    )) {
+        Ok(true) => (),
+        Ok(false) => {
+            message::info(&format!("Not deleting keys in {}", filename.display()));
+            return Ok(());
         }
+        Err(e) => failure::bail!(e),
     }
 
     let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {

--- a/src/commands/kv/delete_bulk.rs
+++ b/src/commands/kv/delete_bulk.rs
@@ -7,21 +7,34 @@ use std::fs::metadata;
 use std::path::Path;
 
 use cloudflare::endpoints::workerskv::delete_bulk::DeleteBulk;
-use failure::bail;
 
 use crate::commands::kv;
 use crate::terminal::message;
 
 const MAX_PAIRS: usize = 10000;
 
-pub fn delete_json(namespace_id: &str, filename: &Path) -> Result<(), failure::Error> {
+pub fn delete_json(namespace_id: &str, filename: &Path, force: bool) -> Result<(), failure::Error> {
+    if !force {
+        match kv::interactive_delete(&format!(
+            "Are you sure you want to delete all keys in {}?",
+            filename.display()
+        )) {
+            Ok(true) => (),
+            Ok(false) => {
+                message::info(&format!("Not deleting keys in {}", filename.display()));
+                return Ok(());
+            }
+            Err(e) => failure::bail!(e),
+        }
+    }
+
     let keys: Result<Vec<String>, failure::Error> = match metadata(filename) {
         Ok(ref file_type) if file_type.is_file() => {
             let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(_) => bail!("{} should be a JSON file, but is not", filename.display()),
-        Err(e) => bail!(e),
+        Ok(_) => failure::bail!("{} should be a JSON file, but is not", filename.display()),
+        Err(e) => failure::bail!(e),
     };
 
     delete_bulk(namespace_id, keys?)
@@ -33,7 +46,7 @@ fn delete_bulk(namespace_id: &str, keys: Vec<String>) -> Result<(), failure::Err
 
     // Check number of pairs is under limit
     if keys.len() > MAX_PAIRS {
-        bail!(
+        failure::bail!(
             "Number of keys to delete ({}) exceeds max of {}",
             keys.len(),
             MAX_PAIRS

--- a/src/commands/kv/delete_key.rs
+++ b/src/commands/kv/delete_key.rs
@@ -9,7 +9,7 @@ pub fn delete_key(id: &str, key: &str, force: bool) -> Result<(), failure::Error
     let account_id = kv::account_id()?;
 
     if !force {
-        match kv::interactive_delete(&format!("Are you sure you want to delete key {}?", key)) {
+        match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
             Ok(true) => (),
             Ok(false) => {
                 message::info(&format!("Not deleting key \"{}\"", key));

--- a/src/commands/kv/delete_key.rs
+++ b/src/commands/kv/delete_key.rs
@@ -4,9 +4,20 @@ use cloudflare::framework::apiclient::ApiClient;
 use crate::commands::kv;
 use crate::terminal::message;
 
-pub fn delete_key(id: &str, key: &str) -> Result<(), failure::Error> {
+pub fn delete_key(id: &str, key: &str, force: bool) -> Result<(), failure::Error> {
     let client = kv::api_client()?;
     let account_id = kv::account_id()?;
+
+    if !force {
+        match kv::interactive_delete(&format!("Are you sure you want to delete key {}?", key)) {
+            Ok(true) => (),
+            Ok(false) => {
+                message::info(&format!("Not deleting key \"{}\"", key));
+                return Ok(());
+            }
+            Err(e) => failure::bail!(e),
+        }
+    }
 
     let msg = format!("Deleting key \"{}\"", key);
     message::working(&msg);

--- a/src/commands/kv/delete_key.rs
+++ b/src/commands/kv/delete_key.rs
@@ -4,19 +4,17 @@ use cloudflare::framework::apiclient::ApiClient;
 use crate::commands::kv;
 use crate::terminal::message;
 
-pub fn delete_key(id: &str, key: &str, force: bool) -> Result<(), failure::Error> {
+pub fn delete_key(id: &str, key: &str) -> Result<(), failure::Error> {
     let client = kv::api_client()?;
     let account_id = kv::account_id()?;
 
-    if !force {
-        match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
-            Ok(true) => (),
-            Ok(false) => {
-                message::info(&format!("Not deleting key \"{}\"", key));
-                return Ok(());
-            }
-            Err(e) => failure::bail!(e),
+    match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
+        Ok(true) => (),
+        Ok(false) => {
+            message::info(&format!("Not deleting key \"{}\"", key));
+            return Ok(());
         }
+        Err(e) => failure::bail!(e),
     }
 
     let msg = format!("Deleting key \"{}\"", key);

--- a/src/commands/kv/delete_namespace.rs
+++ b/src/commands/kv/delete_namespace.rs
@@ -5,22 +5,20 @@ use cloudflare::endpoints::workerskv::remove_namespace::RemoveNamespace;
 use crate::commands::kv;
 use crate::terminal::message;
 
-pub fn delete_namespace(id: &str, force: bool) -> Result<(), failure::Error> {
+pub fn delete_namespace(id: &str) -> Result<(), failure::Error> {
     let client = kv::api_client()?;
     let account_id = kv::account_id()?;
 
-    if !force {
-        match kv::interactive_delete(&format!(
-            "Are you sure you want to delete namespace {}?",
-            id
-        )) {
-            Ok(true) => (),
-            Ok(false) => {
-                message::info(&format!("Not deleting namespace {}", id));
-                return Ok(());
-            }
-            Err(e) => failure::bail!(e),
+    match kv::interactive_delete(&format!(
+        "Are you sure you want to delete namespace {}?",
+        id
+    )) {
+        Ok(true) => (),
+        Ok(false) => {
+            message::info(&format!("Not deleting namespace {}", id));
+            return Ok(());
         }
+        Err(e) => failure::bail!(e),
     }
 
     let msg = format!("Deleting namespace {}", id);

--- a/src/commands/kv/delete_namespace.rs
+++ b/src/commands/kv/delete_namespace.rs
@@ -5,9 +5,23 @@ use cloudflare::endpoints::workerskv::remove_namespace::RemoveNamespace;
 use crate::commands::kv;
 use crate::terminal::message;
 
-pub fn delete_namespace(id: &str) -> Result<(), failure::Error> {
+pub fn delete_namespace(id: &str, force: bool) -> Result<(), failure::Error> {
     let client = kv::api_client()?;
     let account_id = kv::account_id()?;
+
+    if !force {
+        match kv::interactive_delete(&format!(
+            "Are you sure you want to delete namespace {}?",
+            id
+        )) {
+            Ok(true) => (),
+            Ok(false) => {
+                message::info(&format!("Not deleting namespace {}", id));
+                return Ok(());
+            }
+            Err(e) => failure::bail!(e),
+        }
+    }
 
     let msg = format!("Deleting namespace {}", id);
     message::working(&msg);

--- a/src/commands/kv/list_keys.rs
+++ b/src/commands/kv/list_keys.rs
@@ -4,7 +4,6 @@ use cloudflare::endpoints::workerskv::list_namespace_keys::ListNamespaceKeys;
 use cloudflare::endpoints::workerskv::list_namespace_keys::ListNamespaceKeysParams;
 use cloudflare::endpoints::workerskv::Key;
 use cloudflare::framework::apiclient::ApiClient;
-use failure::bail;
 use serde_json::value::Value as JsonValue;
 
 use crate::commands::kv;
@@ -40,7 +39,7 @@ pub fn list_keys(id: &str, prefix: Option<&str>) -> Result<(), failure::Error> {
                 success.result,
                 get_cursor_from_result_info(success.result_info.clone()),
             ),
-            Err(e) => bail!(e),
+            Err(e) => failure::bail!(e),
         };
 
         match cursor {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -78,7 +78,7 @@ fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
     match response.as_ref() {
         YES => Ok(true),
         NO => Ok(false),
-        _ => failure::bail!("Response must either by \"y\" for yes or \"n\" for no"),
+        _ => failure::bail!("Response must either be \"y\" for yes or \"n\" for no"),
     }
 }
 

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -1,7 +1,6 @@
 use cloudflare::framework::auth::Credentials;
 use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::HttpApiClient;
-use failure::bail;
 use http::status::StatusCode;
 use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
@@ -30,6 +29,11 @@ pub use rename_namespace::rename_namespace;
 pub use write_bulk::write_json;
 pub use write_key::write_key;
 
+// Truncate all "yes", "no" responses for itneractive delete prompt to just "y" or "n".
+const INTERACTIVE_RESPONSE_LEN: usize = 1;
+const YES: &str = "y";
+const NO: &str = "n";
+
 fn api_client() -> Result<HttpApiClient, failure::Error> {
     let user = settings::global_user::GlobalUser::new()?;
 
@@ -40,7 +44,7 @@ fn account_id() -> Result<String, failure::Error> {
     let project = settings::project::Project::new()?;
     // we need to be certain that account id is present to make kv calls
     if project.account_id.is_empty() {
-        bail!("Your wrangler.toml is missing the account_id field which is required to create KV namespaces!");
+        failure::bail!("Your wrangler.toml is missing the account_id field which is required to create KV namespaces!");
     }
     Ok(project.account_id)
 }
@@ -59,6 +63,22 @@ fn print_error(e: ApiFailure) {
             }
         }
         ApiFailure::Invalid(reqwest_err) => message::warn(&format!("Error: {}", reqwest_err)),
+    }
+}
+
+// For interactively handling deletes (and discouraging accidental deletes).
+// Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
+// and lowercasing logic below.
+fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
+    println!("{} [y/n]", prompt_string);
+    let mut response: String = read!("{}\n");
+    response = response.split_whitespace().collect(); // remove whitespace
+    response.make_ascii_lowercase(); // ensure response is all lowercase
+    response.truncate(INTERACTIVE_RESPONSE_LEN); // at this point, all valid input will be "y" or "n"
+    match response.as_ref() {
+        YES => Ok(true),
+        NO => Ok(false),
+        _ => failure::bail!("Response must either by \"y\" for yes or \"n\" for no"),
     }
 }
 

--- a/src/commands/kv/write_bulk.rs
+++ b/src/commands/kv/write_bulk.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 
 use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 use cloudflare::endpoints::workerskv::write_bulk::WriteBulk;
-use failure::bail;
 
 use crate::commands::kv;
 use crate::terminal::message;
@@ -21,8 +20,8 @@ pub fn write_json(namespace_id: &str, filename: &Path) -> Result<(), failure::Er
             let data = fs::read_to_string(filename)?;
             Ok(serde_json::from_str(&data)?)
         }
-        Ok(_) => bail!("{} should be a JSON file, but is not", filename.display()),
-        Err(e) => bail!(e),
+        Ok(_) => failure::bail!("{} should be a JSON file, but is not", filename.display()),
+        Err(e) => failure::bail!(e),
     };
 
     write_bulk(namespace_id, pairs?)
@@ -34,7 +33,7 @@ fn write_bulk(namespace_id: &str, pairs: Vec<KeyValuePair>) -> Result<(), failur
 
     // Validate that bulk upload is within size constraints
     if pairs.len() > MAX_PAIRS {
-        bail!(
+        failure::bail!(
             "Number of key-value pairs to upload ({}) exceeds max of {}",
             pairs.len(),
             MAX_PAIRS

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,13 @@ fn run() -> Result<(), failure::Error> {
                             .help("The ID of the namespace this action applies to")
                             .required(true)
                         )
+                        .arg(
+                            Arg::with_name("force")
+                            .help("Force delete key-value pair")
+                            .short("f")
+                            .long("force")
+                            .takes_value(false)
+                        )
                 )
                 .subcommand(
                     SubCommand::with_name("rename")
@@ -177,6 +184,13 @@ fn run() -> Result<(), failure::Error> {
                             .help("Key whose value to delete")
                             .required(true)
                         )
+                        .arg(
+                            Arg::with_name("force")
+                            .help("Force delete key-value pair")
+                            .short("f")
+                            .long("force")
+                            .takes_value(false)
+                        )
                 )
                 .subcommand(
                     SubCommand::with_name("list")
@@ -241,6 +255,13 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("path")
                             .help("the JSON file of key-value pairs to upload, in form [\"<example-key>\", ...]")
                             .required(true)
+                        )
+                        .arg(
+                            Arg::with_name("force")
+                            .help("Force delete key-value pair")
+                            .short("f")
+                            .long("force")
+                            .takes_value(false)
                         )
                 )
         )
@@ -454,7 +475,11 @@ fn run() -> Result<(), failure::Error> {
             }
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
-                commands::kv::delete_namespace(id)?;
+                let force = match delete_matches.occurrences_of("force") {
+                    1 => true,
+                    _ => false,
+                };
+                commands::kv::delete_namespace(id, force)?;
             }
             ("rename", Some(rename_matches)) => {
                 let id = rename_matches.value_of("namespace-id").unwrap();
@@ -493,7 +518,11 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
                 let key = delete_matches.value_of("key").unwrap();
-                commands::kv::delete_key(id, key)?;
+                let force = match delete_matches.occurrences_of("force") {
+                    1 => true,
+                    _ => false,
+                };
+                commands::kv::delete_key(id, key, force)?;
             }
             ("list", Some(list_keys_matches)) => {
                 let id = list_keys_matches.value_of("namespace-id").unwrap();
@@ -513,7 +542,12 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
                 let path = delete_matches.value_of("path").unwrap();
-                commands::kv::delete_json(id, Path::new(path))?;
+
+                let force = match delete_matches.occurrences_of("force") {
+                    1 => true,
+                    _ => false,
+                };
+                commands::kv::delete_json(id, Path::new(path), force)?;
             }
             ("", None) => message::warn("kv:bulk expects a subcommand"),
             _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,13 +71,6 @@ fn run() -> Result<(), failure::Error> {
                             .help("The ID of the namespace this action applies to")
                             .required(true)
                         )
-                        .arg(
-                            Arg::with_name("force")
-                            .help("Force delete key-value pair")
-                            .short("f")
-                            .long("force")
-                            .takes_value(false)
-                        )
                 )
                 .subcommand(
                     SubCommand::with_name("rename")
@@ -142,10 +135,10 @@ fn run() -> Result<(), failure::Error> {
                             .value_name("SECONDS")
                         )
                         .arg(
-                            Arg::with_name("file")
-                            .help("The value passed in is a filename; open and upload its contents")
-                            .short("f")
-                            .long("file")
+                            Arg::with_name("path")
+                            .help("The value passed in is a path to a file; open and upload its contents")
+                            .short("p")
+                            .long("path")
                             .takes_value(false)
                         )
                 )
@@ -183,13 +176,6 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("key")
                             .help("Key whose value to delete")
                             .required(true)
-                        )
-                        .arg(
-                            Arg::with_name("force")
-                            .help("Force delete key-value pair")
-                            .short("f")
-                            .long("force")
-                            .takes_value(false)
                         )
                 )
                 .subcommand(
@@ -255,13 +241,6 @@ fn run() -> Result<(), failure::Error> {
                             Arg::with_name("path")
                             .help("the JSON file of key-value pairs to upload, in form [\"<example-key>\", ...]")
                             .required(true)
-                        )
-                        .arg(
-                            Arg::with_name("force")
-                            .help("Force delete key-value pair")
-                            .short("f")
-                            .long("force")
-                            .takes_value(false)
                         )
                 )
         )
@@ -475,11 +454,7 @@ fn run() -> Result<(), failure::Error> {
             }
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
-                let force = match delete_matches.occurrences_of("force") {
-                    1 => true,
-                    _ => false,
-                };
-                commands::kv::delete_namespace(id, force)?;
+                commands::kv::delete_namespace(id)?;
             }
             ("rename", Some(rename_matches)) => {
                 let id = rename_matches.value_of("namespace-id").unwrap();
@@ -507,7 +482,7 @@ fn run() -> Result<(), failure::Error> {
                 let id = write_key_matches.value_of("namespace-id").unwrap();
                 let key = write_key_matches.value_of("key").unwrap();
                 let value = write_key_matches.value_of("value").unwrap();
-                let is_file = match write_key_matches.occurrences_of("file") {
+                let is_file = match write_key_matches.occurrences_of("path") {
                     1 => true,
                     _ => false,
                 };
@@ -518,11 +493,7 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
                 let key = delete_matches.value_of("key").unwrap();
-                let force = match delete_matches.occurrences_of("force") {
-                    1 => true,
-                    _ => false,
-                };
-                commands::kv::delete_key(id, key, force)?;
+                commands::kv::delete_key(id, key)?;
             }
             ("list", Some(list_keys_matches)) => {
                 let id = list_keys_matches.value_of("namespace-id").unwrap();
@@ -542,12 +513,7 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let id = delete_matches.value_of("namespace-id").unwrap();
                 let path = delete_matches.value_of("path").unwrap();
-
-                let force = match delete_matches.occurrences_of("force") {
-                    1 => true,
-                    _ => false,
-                };
-                commands::kv::delete_json(id, Path::new(path), force)?;
+                commands::kv::delete_json(id, Path::new(path))?;
             }
             ("", None) => message::warn("kv:bulk expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
This PR closes #410. 

It adds interactive delete checking to 
1. `kv:namespace delete`
2. `kv:key delete`
3. `kv:bulk delete`

Example usage:
```
$ wrangler kv:key delete 06779da6940b431db6e566b4846d64db "gabbi fisher"
Are you sure you want to delete key "gabbi fisher"? [y/n]
yes
 Deleting key "gabbi fisher"
 Success
```
If someone wanted to automate deletion without going through the interactive workflow:
```
$ echo "yes" | wrangler kv:key delete 06779da6940b431db6e566b4846d64db "gabbi fisher"
Are you sure you want to delete key "gabbi fisher"? [y/n]
 Deleting key "gabbi fisher"
 Success
```