### PR TITLE
Minor formatting fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
     - `route`: This is the route you'd like to use your worker on. You need to include the hostname. Examples:
         - `*example.com/*`
         - `http://example.com/hello`
+        
         This key is optional if you are using a workers.dev subdomain and is only required for `publish --release`.
     - `webpack_config`: This is the path to the webpack configuration file for your worker. This is optional and
         defaults to `webpack.config.js`


### PR DESCRIPTION
Github treats the sentence "This key is optional..." as part of the bullet point from the previous line, which is not what was intended. Inserting a blank line in between fixes the problem.