### PR TITLE
Fix javascript live preview for linux

### DIFF
--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -14,6 +14,7 @@ use std::thread;
 use std::time::Duration;
 
 pub const COOLDOWN_PERIOD: Duration = Duration::from_millis(2000);
+const JAVASCRIPT_PATH: &str = "./";
 
 /// watch a project for changes and re-build it when necessary,
 /// outputting a build event to tx.
@@ -24,17 +25,12 @@ pub fn watch_and_build(
     let project_type = &project.project_type;
     match project_type {
         ProjectType::JavaScript => {
-            let path = "./";
-            let package = Package::new(path)?;
-            // Confirm entrypoint is provided
-            package.main()?;
-
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
                 let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
-                watcher.watch(&path, RecursiveMode::Recursive).unwrap();
-                message::info(&format!("watching {:?}", &path));
+                watcher.watch(JAVASCRIPT_PATH, RecursiveMode::Recursive).unwrap();
+                message::info(&format!("watching {:?}", &JAVASCRIPT_PATH));
 
                 loop {
                     match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -24,14 +24,17 @@ pub fn watch_and_build(
     let project_type = &project.project_type;
     match project_type {
         ProjectType::JavaScript => {
-            let package = Package::new("./")?;
-            let entry = package.main()?;
+            let path = "./";
+            let package = Package::new(path)?;
+            // Confirm entrypoint is provided
+            package.main()?;
+
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
                 let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
-                watcher.watch(&entry, RecursiveMode::Recursive).unwrap();
-                message::info(&format!("watching {:?}", &entry));
+                watcher.watch(&path, RecursiveMode::Recursive).unwrap();
+                message::info(&format!("watching {:?}", &path));
 
                 loop {
                     match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -29,7 +29,9 @@ pub fn watch_and_build(
                 let (watcher_tx, watcher_rx) = mpsc::channel();
                 let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
-                watcher.watch(JAVASCRIPT_PATH, RecursiveMode::Recursive).unwrap();
+                watcher
+                    .watch(JAVASCRIPT_PATH, RecursiveMode::Recursive)
+                    .unwrap();
                 message::info(&format!("watching {:?}", &JAVASCRIPT_PATH));
 
                 loop {

--- a/src/commands/build/watch/watcher.rs
+++ b/src/commands/build/watch/watcher.rs
@@ -8,7 +8,7 @@ use failure::{format_err, Error};
 use crate::terminal::message;
 use log::info;
 
-///Add cooldown for all types of events to watching logic
+/// Add cooldown for all types of events to watching logic
 pub fn wait_for_changes(
     rx: &Receiver<DebouncedEvent>,
     cooldown: Duration,
@@ -18,15 +18,12 @@ pub fn wait_for_changes(
         match get_changed_path_from_event(event) {
             Ok(Some(path)) => {
                 message::working("Detected changes...");
-                //wait for cooldown
-                while let Ok(_) = rx.recv_timeout(cooldown) {
-                    message::working("Detected change during cooldown...");
-                }
-                message::working("Cooldown over, propogating changes...");
+                // wait for cooldown
+                while let Ok(_) = rx.recv_timeout(cooldown) {}
                 return Ok(path);
             }
             Ok(None) => {
-                continue; //was an event type we don't care about, continue
+                continue; // was an event type we don't care about, continue
             }
             Err(error) => {
                 message::user_error(&format!("WatchError {:?}", error));


### PR DESCRIPTION
Closes #517. 

This was a fun one to investigate. The bug, at its core, was the fact that different editors have different approaches to saving files--some, like vim, actually delete and re-create an entire file when saving its contents. Different file notification APIs across different operating systems track changes to files differently; in the case of the Linux file watcher in the notify crate (inotify) this watcher will stop watching a file once it has been deleted; vim deletes files regularly when saving new contents (https://unix.stackexchange.com/questions/188873/using-inotifywait-along-with-vim). 

I wasn't familiar with the live preview code, so I spent time reading through it. Ultimately I couldn't find any bugs that could cause the behavior I observed. Something we noticed was that webpack workers watch directories and worked just fine with vim, implying that watching a directory for javascript workers would also work (inotify would continue to watch the index.js file even if vim deleted and re-created it).

This PR may also need to be replicated for #522, given that the Rust live preview service also watches an individual javascript file.

This PR also reduces noisy output by the live preview service. Notifying over directories produced a large amount of repeated `"Detected change during cooldown..."` terminal output.