### PR TITLE
Alewis/refactor key list

### DIFF
--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -1,0 +1,120 @@
+use cloudflare::endpoints::workerskv::list_namespace_keys::ListNamespaceKeys;
+use cloudflare::endpoints::workerskv::list_namespace_keys::ListNamespaceKeysParams;
+use cloudflare::endpoints::workerskv::Key;
+use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::ApiFailure;
+use cloudflare::framework::HttpApiClient;
+
+use serde_json::value::Value as JsonValue;
+
+use crate::settings::project::Project;
+
+pub struct KeyList {
+    keys_result: Option<Vec<Key>>,
+    prefix: Option<String>,
+    client: HttpApiClient,
+    project: Project,
+    namespace_id: String,
+    cursor: Option<String>,
+    error: Option<ApiFailure>,
+}
+
+impl KeyList {
+    pub fn fetch(
+        project: &Project,
+        client: HttpApiClient,
+        namespace_id: &str,
+        prefix: Option<&str>,
+    ) -> Result<KeyList, failure::Error> {
+        let key_list = KeyList {
+            keys_result: None,
+            prefix: prefix.map(str::to_string),
+            client,
+            project: project.to_owned(),
+            namespace_id: namespace_id.to_string(),
+            cursor: None,
+            error: None,
+        };
+
+        Ok(key_list)
+    }
+
+    fn request_params(&self) -> ListNamespaceKeys {
+        ListNamespaceKeys {
+            account_identifier: &self.project.account_id,
+            namespace_identifier: &self.namespace_id,
+            params: self.params(),
+        }
+    }
+
+    fn params(&self) -> ListNamespaceKeysParams {
+        ListNamespaceKeysParams {
+            limit: None, // Defaults to 1000 (the maximum)
+            cursor: None,
+            prefix: self.prefix.to_owned(),
+        }
+    }
+
+    fn get_batch(&mut self) -> Option<Key> {
+        let response = self.client.request(&self.request_params());
+
+        let mut result;
+
+        match response {
+            Ok(success) => {
+                result = success.result;
+                self.cursor = extract_cursor(success.result_info.clone());
+            }
+            Err(e) => {
+                result = Vec::new();
+                self.error = Some(e);
+            }
+        };
+
+        if self.error.is_some() {
+            None
+        } else {
+            let key = result.pop();
+            self.keys_result = Some(result);
+
+            key
+        }
+    }
+}
+
+impl Iterator for KeyList {
+    type Item = Key;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.keys_result.to_owned() {
+            Some(mut keys) => {
+                let key = keys.pop();
+                self.keys_result = Some(keys);
+
+                if key.is_none() {
+                    if self.cursor.is_none() {
+                        None
+                    } else {
+                        self.get_batch()
+                    }
+                } else {
+                    key
+                }
+            }
+            // if this is None, we have not made a request yet
+            None => self.get_batch(),
+        }
+    }
+}
+
+// Returns Some(cursor) if cursor is non-empty, otherwise returns None.
+fn extract_cursor(result_info: Option<JsonValue>) -> Option<String> {
+    let result_info = result_info.unwrap();
+    let returned_cursor_value = &result_info["cursor"];
+    let returned_cursor = returned_cursor_value.as_str().unwrap().to_string();
+    if returned_cursor.is_empty() {
+        None
+    } else {
+        Some(returned_cursor)
+    }
+}

--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -16,7 +16,7 @@ pub struct KeyList {
     project: Project,
     namespace_id: String,
     cursor: Option<String>,
-    error: Option<ApiFailure>,
+    pub error: Option<ApiFailure>,
 }
 
 impl KeyList {

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -33,5 +33,9 @@ pub fn list(
     }
     print!("]"); // Close json list bracket
 
+    if let Some(error) = key_list.error {
+        failure::bail!("There was an error downloading your keys: {}", error);
+    }
+
     Ok(())
 }

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -20,15 +20,15 @@ pub fn list(
 
     print!("["); // Open json list bracket
 
-    let mut first_page = true;
+    let mut first_key = true;
 
     for key_result in key_list {
         match key_result {
             Ok(key) => {
-                if !(first_page) {
-                    print!(",");
+                if first_key {
+                    first_key = false;
                 } else {
-                    first_page = false;
+                    print!(",");
                 }
 
                 print!("{}", serde_json::to_string(&key)?);

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -16,26 +16,28 @@ pub fn list(
 ) -> Result<(), failure::Error> {
     let client = kv::api_client(user)?;
 
-    let key_list = KeyList::fetch(project, client, namespace_id, prefix)?;
+    let key_list = KeyList::fetch(project, client, namespace_id, prefix);
 
     print!("["); // Open json list bracket
 
     let mut first_page = true;
 
-    for key in key_list {
-        if !(first_page) {
-            print!(",");
-        } else {
-            first_page = false;
+    for key_result in key_list {
+        match key_result {
+            Ok(key) => {
+                if !(first_page) {
+                    print!(",");
+                } else {
+                    first_page = false;
+                }
+
+                print!("{}", serde_json::to_string(&key)?);
+            }
+            Err(e) => kv::print_error(e),
         }
-
-        print!("{}", serde_json::to_string(&key)?);
     }
+
     print!("]"); // Close json list bracket
-
-    if let Some(error) = key_list.error {
-        failure::bail!("There was an error downloading your keys: {}", error);
-    }
 
     Ok(())
 }

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -16,7 +16,7 @@ pub fn list(
 ) -> Result<(), failure::Error> {
     let client = kv::api_client(user)?;
 
-    let key_list = KeyList::fetch(project, client, namespace_id, prefix);
+    let key_list = KeyList::new(project, client, namespace_id, prefix);
 
     print!("["); // Open json list bracket
 

--- a/src/commands/kv/key/mod.rs
+++ b/src/commands/kv/key/mod.rs
@@ -1,9 +1,11 @@
 mod delete;
 mod get;
+mod key_list;
 mod list;
 mod put;
 
 pub use delete::delete;
 pub use get::get;
+pub use key_list::KeyList;
 pub use list::list;
 pub use put::put;


### PR DESCRIPTION
Closes #447 

This extracts the logic of fetching all of the keys for a given KV namespace into an iterator, which will allow us to either print to standard out, or collect the keys as needed for other operations, without repeating all the fetch cursor logic. This is handy for implementing `sync`, which will need to collect a list of uploaded keys from the API to compare to local keys in order to decide what to delete.