### PR TITLE
Simplify key list iterator logic

### DIFF
--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -16,7 +16,7 @@ pub fn list(
 ) -> Result<(), failure::Error> {
     let client = kv::api_client(user)?;
 
-    let key_list = KeyList::fetch(project, client, namespace_id, prefix);
+    let key_list = KeyList::new(project, client, namespace_id, prefix);
 
     print!("["); // Open json list bracket
 


### PR DESCRIPTION
This PR does the following:
1. Replaces `fetch` call with more familiar `new` semantics
2. Gets rid of nested `Option<Result<...` return type :D
3. Makes use of `if let` to simplify logic for fetching consequent pages of keys
4. Moves key extraction logic from `get_batch` to `next` to ensure that key extraction only happens in one place.

The functionality on this PR has been tested successfully on my KV namespace of 4060 keys.