### PR TITLE
warn user to remove binding if deleted + check input for bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,6 +2403,7 @@ dependencies = [
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ url = "2.1.0"
 walkdir = "2.2.9"
 percent-encoding = "1.0.1"
 http = "0.1.1"
+regex = "1"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -15,6 +15,10 @@ pub fn create(
 ) -> Result<(), failure::Error> {
     let client = kv::api_client(user)?;
 
+    if !validate_binding(binding) {
+        failure::bail!("A binding can only have alphabetical and _ characters");
+    }
+
     let title = format!("{}-{}", target.name, binding);
     let msg = format!("Creating namespace with title \"{}\"", title);
     message::working(&msg);
@@ -66,4 +70,31 @@ pub fn create(
     }
 
     Ok(())
+}
+
+fn validate_binding(binding: &str) -> bool {
+    use regex::Regex;
+    let re = Regex::new(r"^[a-zA-Z_]+$").unwrap();
+    re.is_match(binding)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_detect_invalid_binding() {
+        let invalid_bindings = vec!["hi there", "1234"];
+        for binding in invalid_bindings {
+            assert!(!validate_binding(binding));
+        }
+    }
+
+    #[test]
+    fn it_can_detect_valid_binding() {
+        let invalid_bindings = vec!["ONE", "TWO_TWO"];
+        for binding in invalid_bindings {
+            assert!(validate_binding(binding));
+        }
+    }
 }

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -30,7 +30,12 @@ pub fn delete(target: &Target, user: GlobalUser, id: &str) -> Result<(), failure
     });
 
     match response {
-        Ok(_) => message::success("Success"),
+        Ok(_) => {
+            message::success("Success");
+            message::warn(
+                "Make sure to remove this \"kv-namespace\" entry from your wrangler.toml!",
+            )
+        }
         Err(e) => kv::print_error(e),
     }
 


### PR DESCRIPTION
This PR does two things:

1. First, it provides a gentle nudge to the user to remove a binding from their wrangler.toml if they call `kv:namespace delete`.
1. Next, it also validates that all bindings passed into wrangler MUST be alphabetical and only have underscores.