### PR TITLE
Use notify-forked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify"
+name = "notify-forked"
 version = "4.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2184,7 +2184,7 @@ dependencies = [
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify-forked 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2372,7 +2372,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "3572d71f13ea8ed41867accd971fd564aa75934cf7a1fae03ddb8c74a8a49943"
+"checksum notify-forked 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f23c70c408d37be38a49336b2243a69304dc6e2eabebc9a6e411c90bb76af294"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ base64 = "0.10.1"
 lazy_static = "1.3.0"
 text_io = "0.1.7"
 exitfailure = "0.5.1"
-notify = "4.0.12"
+notify-forked = "4.0.12"
 ws = "0.9.0"
 
 [dev-dependencies]

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -26,7 +26,8 @@ pub fn watch_and_build(
         TargetType::JavaScript => {
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
-                let mut watcher = notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
+                let mut watcher =
+                    notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
                 watcher
                     .watch(JAVASCRIPT_PATH, RecursiveMode::Recursive)
@@ -52,7 +53,8 @@ pub fn watch_and_build(
 
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
-                let mut watcher = notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
+                let mut watcher =
+                    notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
                 watcher.watch(RUST_PATH, RecursiveMode::Recursive).unwrap();
                 message::info(&format!("watching {:?}", &RUST_PATH));

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -6,7 +6,7 @@ use crate::settings::target::{Target, TargetType};
 use crate::terminal::message;
 use crate::{commands, install};
 
-use notify::{self, RecursiveMode, Watcher};
+use notify_forked::{self, RecursiveMode, Watcher};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -26,7 +26,7 @@ pub fn watch_and_build(
         TargetType::JavaScript => {
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
-                let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
+                let mut watcher = notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
                 watcher
                     .watch(JAVASCRIPT_PATH, RecursiveMode::Recursive)
@@ -52,7 +52,7 @@ pub fn watch_and_build(
 
             thread::spawn(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
-                let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
+                let mut watcher = notify_forked::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
 
                 watcher.watch(RUST_PATH, RecursiveMode::Recursive).unwrap();
                 message::info(&format!("watching {:?}", &RUST_PATH));

--- a/src/commands/build/watch/watcher.rs
+++ b/src/commands/build/watch/watcher.rs
@@ -1,4 +1,4 @@
-use notify::DebouncedEvent;
+use notify_forked::DebouncedEvent;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::time::Duration;

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 use crate::settings::target::Target;
 use crate::terminal::message;
 
-use notify::{self, RecursiveMode, Watcher};
+use notify_forked::{self, RecursiveMode, Watcher};
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
 use std::time::Duration;
@@ -64,7 +64,7 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
         let _command_guard = util::GuardedCommand::spawn(command);
 
         let (watcher_tx, watcher_rx) = channel();
-        let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1))?;
+        let mut watcher = notify_forked::watcher(watcher_tx, Duration::from_secs(1))?;
 
         watcher.watch(&temp_file, RecursiveMode::Recursive)?;
 


### PR DESCRIPTION
The `notify` crate updated its `fsevent-sys` version which broke our builds. @ashleygwilliams forked `notify` and pinned its dependency to a version that works.