### PR TITLE
Fix panic when `kv: ` command does not have subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn run() -> Result<(), failure::Error> {
                     "{} Interact with your Workers KV Namespaces",
                     emoji::KV
                 ))
-                .setting(AppSettings::SubcommandRequiredElseHelp)
+                .setting(AppSettings::SubcommandRequired)
                 .subcommand(
                     SubCommand::with_name("create")
                         .about("Create a new namespace")
@@ -119,26 +119,7 @@ fn run() -> Result<(), failure::Error> {
                     "{} Individually manage Workers KV key-value pairs",
                     emoji::KV
                 ))
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                // We use custom error messages because we don't want the global
-                // --binding/--namespace-id/--env options to be used with
-                // kv:key; they should live within the subcommand (e.g. put).
-                .help(&*format!("{} Individually manage Workers KV key-value pairs
-
-USAGE:
-    wrangler kv:key [OPTIONS] <SUBCOMMAND>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
-    delete    Delete a key and its value from a namespace
-    get       Get a key's value from a namespace
-    help      Prints this message or the help of the given subcommand(s)
-    list      List all keys in a namespace. Produces JSON output
-    put       Put a key-value pair into a namespace
-", emoji::KV))
+                .setting(AppSettings::SubcommandRequired)
                 .arg(
                     Arg::with_name("binding")
                     .help("The binding of the namespace this action applies to")
@@ -260,24 +241,7 @@ SUBCOMMANDS:
                     "{} Interact with multiple Workers KV key-value pairs at once",
                     emoji::KV
                 ))
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                // We use custom error messages because we don't want the global
-                // --binding/--namespace-id/--env options to be used with
-                // kv:bulk; they should live within the subcommand (e.g. put).
-                .help(&*format!("{} Interact with multiple Workers KV key-value pairs at once
-
-USAGE:
-    wrangler kv:bulk [OPTIONS] <SUBCOMMAND>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
-    delete    Delete multiple keys and their values from a namespace
-    help      Prints this message or the help of the given subcommand(s)
-    put       Upload multiple key-value pairs to a namespace
-", emoji::KV))
+                .setting(AppSettings::SubcommandRequired)
                 .arg(
                     Arg::with_name("binding")
                     .help("The binding of the namespace this action applies to")


### PR DESCRIPTION
This PR closes #572.

I have to provide alternative help messages for `kv:key` and `kv:bulk` because we don't want folks to specify `--binding` or `--namespace-id` anywhere but the last subcommand in the sequence; this is because Clap doesn't allow us to place `.global()` on ArgGroups yet, so we can't enforce logic requiring one of `--binding` or `--namespace-id` in `kv:` subcommands; instead, we can only place them in the final subcommand :(

Let me know if this doesn't make sense. 