### PR TITLE
remove duplicate namespace-id and binding args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,10 +160,6 @@ fn run() -> Result<(), failure::Error> {
                         .arg(kv_namespace_id_arg.clone())
                         .group(kv_namespace_specifier_group.clone())
                         .arg(environment_arg.clone())
-                        .group(ArgGroup::with_name("namespace-specifier")
-                            .args(&["binding", "namespace-id"])
-                            .required(true)
-                        )
                         .arg(
                             Arg::with_name("key")
                             .help("Key whose value to get")


### PR DESCRIPTION
don't add this to the changelog. 

This PR fixes usage for `kv:key get`

**Before**

```console
$ wrangler kv:key get -b KV
error: The following required arguments were not provided:
    <key>

USAGE:
    wrangler kv:key get <key> <--binding <BINDING NAME>|--namespace-id <ID>|--binding <BINDING NAME>|--namespace-id <ID>>

For more information try --help
```

**After**

```console
$ wrangler kv:key get -b KV
error: The following required arguments were not provided:
    <key>

USAGE:
    wrangler kv:key get <key> <--binding <BINDING NAME>|--namespace-id <ID>>

For more information try --help
```