### PR TITLE
Fixes (some) clippy warnings

### DIFF
--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -47,7 +47,7 @@ impl KeyList {
         ListNamespaceKeys {
             account_identifier: &self.account_id,
             namespace_identifier: &self.namespace_id,
-            params: params,
+            params,
         }
     }
 

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -33,28 +33,27 @@ pub fn put(
 
     // Add expiration and expiration_ttl query options as necessary.
     let mut query_params: Vec<(&str, &str)> = vec![];
-    match expiration {
-        Some(exp) => query_params.push(("expiration", exp)),
-        None => (),
-    }
-    match expiration_ttl {
-        Some(ttl) => query_params.push(("expiration_ttl", ttl)),
-        None => (),
-    }
+    if let Some(exp) = expiration {
+        query_params.push(("expiration", exp))
+    };
+    if let Some(ttl) = expiration_ttl {
+        query_params.push(("expiration_ttl", ttl))
+    };
     let url = Url::parse_with_params(&api_endpoint, query_params);
 
     // If is_file is true, overwrite value to be the contents of the given
     // filename in the 'value' arg.
-    let body_text = match is_file {
-        true => match &metadata(value) {
+    let body_text = if is_file {
+        match &metadata(value) {
             Ok(file_type) if file_type.is_file() => fs::read_to_string(value),
             Ok(file_type) if file_type.is_dir() => {
                 failure::bail!("--path argument takes a file, {} is a directory", value)
             }
             Ok(_) => failure::bail!("--path argument takes a file, {} is a symlink", value), // last remaining value is symlink
             Err(e) => failure::bail!("{}", e),
-        },
-        false => Ok(value.to_string()),
+        }
+    } else {
+        Ok(value.to_string())
     };
 
     let client = http::auth_client(&user);

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -104,9 +104,8 @@ fn url_encode_key(key: &str) -> String {
 // For handling cases where the API gateway returns errors via HTTP status codes
 // (no KV error code is given).
 fn give_status_code_context(status_code: StatusCode) {
-    match status_code {
-        StatusCode::PAYLOAD_TOO_LARGE => message::warn("Returned status code 413, Payload Too Large. Make sure your upload is less than 100MB in size"),
-        _ => (),
+    if let StatusCode::PAYLOAD_TOO_LARGE = status_code {
+        message::warn("Returned status code 413, Payload Too Large. Make sure your upload is less than 100MB in size")
     }
 }
 

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -42,9 +42,7 @@ pub fn create(
                             "Add the following to your wrangler.toml under [env.{}]:",
                             env
                         )),
-                        None => {
-                            message::success(&format!("Add the following to your wrangler.toml:"))
-                        }
+                        None => message::success("Add the following to your wrangler.toml:"),
                     };
                     println!(
                         "kv-namespaces = [ \n\
@@ -59,7 +57,7 @@ pub fn create(
                             "Add the following to your wrangler.toml's \"kv-namespaces\" array in [env.{}]:",
                             env
                         )),
-                        None => message::success(&format!("Add the following to your wrangler.toml's \"kv-namespaces\" array:")),
+                        None => message::success("Add the following to your wrangler.toml's \"kv-namespaces\" array:"),
                     };
                     println!(
                         "{{ binding: \"{}\", id: \"{}\" }}",


### PR DESCRIPTION
There are still 2 warnings

```console
$ cargo clippy
   Compiling wrangler v1.2.0 (/Users/averyharnish/Documents/work/wrangler)
warning: this function has too many arguments (8/7)
  --> src/commands/kv/key/put.rs:17:1
   |
17 | / pub fn put(
18 | |     target: &Target,
19 | |     user: GlobalUser,
20 | |     id: &str,
...  |
25 | |     expiration_ttl: Option<&str>,
26 | | ) -> Result<(), failure::Error> {
   | |_______________________________^
   |
   = note: #[warn(clippy::too_many_arguments)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: the function has a cognitive complexity of 36
   --> src/main.rs:45:1
    |
45  | / fn run() -> Result<(), failure::Error> {
46  | |     // Define commonly used arguments and arg groups up front for consistency
47  | |     // The args below are for KV Subcommands
48  | |     let kv_binding_arg = Arg::with_name("binding")
...   |
596 | |     Ok(())
597 | | }
    | |_^
    |
    = note: #[warn(clippy::cognitive_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cognitive_complexity
```