### PR TITLE
fix suggested value for kv-namespaces in wrangler.toml to use equals sign, not colons

### DIFF
--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -60,7 +60,7 @@ pub fn create(
                         None => message::success("Add the following to your wrangler.toml's \"kv-namespaces\" array:"),
                     };
                     println!(
-                        "{{ binding: \"{}\", id: \"{}\" }}",
+                        "{{ binding = \"{}\", id = \"{}\" }}",
                         binding, success.result.id
                     );
                 }


### PR DESCRIPTION
This PR is a tiny fix to ensure that `kv:namespace create` tells users to use equals signs (correct) instead of colons (incorrect) when putting a new namespace binding into `wrangler.toml`.