### PR TITLE
ensure binding or namespace-id are required in Clap ArgGroup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn run() -> Result<(), failure::Error> {
         .value_name("ID")
         .takes_value(true);
     let kv_namespace_specifier_group =
-        ArgGroup::with_name("namespace-specifier").args(&["binding", "namespace-id"]);
+        ArgGroup::with_name("namespace-specifier").args(&["binding", "namespace-id"])
+        .required(true);
 
     // This arg is for any action that uses environments (e.g. KV subcommands, publish)
     let environment_arg = Arg::with_name("env")

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,8 @@ fn run() -> Result<(), failure::Error> {
         .long("namespace-id")
         .value_name("ID")
         .takes_value(true);
-    let kv_namespace_specifier_group =
-        ArgGroup::with_name("namespace-specifier").args(&["binding", "namespace-id"])
+    let kv_namespace_specifier_group = ArgGroup::with_name("namespace-specifier")
+        .args(&["binding", "namespace-id"])
         .required(true);
 
     // This arg is for any action that uses environments (e.g. KV subcommands, publish)


### PR DESCRIPTION
This is a tiny PR that fixes a big usability problem introduced in the refactoring of Clap commands. It ensures that instead of the following:

```sh
$ wrangler kv:key put "hello!" "i'm a value"
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:347:21
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

We see 
```sh
$ wrangler kv:key put "hello!" "i'm a value"
error: The following required arguments were not provided:
    <--binding <BINDING NAME>|--namespace-id <ID>>

USAGE:
    wrangler kv:key put [FLAGS] [OPTIONS] <key> <value> <--binding <BINDING NAME>|--namespace-id <ID>>

For more information try --help
```
as expected.