### PR TITLE
Refactor kv::print_error to kv::format_error and hoist error printing out of private kv functions

### DIFF
--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -48,7 +48,11 @@ pub fn delete(
 
     let keys: Vec<String> = pairs?.iter().map(|kv| kv.key.to_owned()).collect();
 
-    delete_bulk(target, user, namespace_id, keys)
+    match delete_bulk(target, user, namespace_id, keys) {
+        Ok(_) => message::success("Success"),
+        Err(e) => print!("{}", e),
+    }
+    Ok(())
 }
 
 fn delete_bulk(
@@ -75,9 +79,7 @@ fn delete_bulk(
     });
 
     match response {
-        Ok(_) => message::success("Success"),
-        Err(e) => kv::print_error(e),
+        Ok(_) => Ok(()),
+        Err(e) => failure::bail!("{}", kv::format_error(e)),
     }
-
-    Ok(())
 }

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -34,7 +34,11 @@ pub fn put(
         Err(e) => failure::bail!("{}", e),
     };
 
-    put_bulk(target, user, namespace_id, pairs?)
+    match put_bulk(target, user, namespace_id, pairs?) {
+        Ok(_) => message::success("Success"),
+        Err(e) => print!("{}", e),
+    }
+    Ok(())
 }
 
 fn put_bulk(
@@ -61,9 +65,7 @@ fn put_bulk(
     });
 
     match response {
-        Ok(_) => message::success("Success"),
-        Err(e) => kv::print_error(e),
+        Ok(_) => Ok(()),
+        Err(e) => failure::bail!("{}", kv::format_error(e)),
     }
-
-    Ok(())
 }

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -34,7 +34,7 @@ pub fn delete(
 
     match response {
         Ok(_) => message::success("Success"),
-        Err(e) => kv::print_error(e),
+        Err(e) => print!("{}", kv::format_error(e)),
     }
 
     Ok(())

--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -32,7 +32,10 @@ pub fn get(target: &Target, user: GlobalUser, id: &str, key: &str) -> Result<(),
         // it will be redundant when we switch to using cloudflare-rs for all API requests.
         let parsed = res.json();
         let errors = parsed.unwrap_or_default();
-        kv::print_error(ApiFailure::Error(res.status(), errors));
+        print!(
+            "{}",
+            kv::format_error(ApiFailure::Error(res.status(), errors))
+        );
     }
 
     Ok(())

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -33,7 +33,7 @@ pub fn list(
 
                 print!("{}", serde_json::to_string(&key)?);
             }
-            Err(e) => kv::print_error(e),
+            Err(e) => print!("{}", kv::format_error(e)),
         }
     }
 

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -68,7 +68,10 @@ pub fn put(
         // it will be redundant when we switch to using cloudflare-rs for all API requests.
         let parsed = res.json();
         let errors = parsed.unwrap_or_default();
-        kv::print_error(ApiFailure::Error(res.status(), errors));
+        print!(
+            "{}",
+            kv::format_error(ApiFailure::Error(res.status(), errors))
+        );
     }
 
     Ok(())

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -71,7 +71,6 @@ fn format_error(e: ApiFailure) -> String {
             give_status_code_context(status);
             let mut complete_err = "".to_string();
             for error in api_errors.errors {
-                // message::warn(&format!("Error {}: {}", error.code, error.message));
                 let error_msg =
                     format!("{} Error {}: {}\n", emoji::WARN, error.code, error.message);
 

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -6,6 +6,7 @@ use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
+use crate::terminal::emoji;
 use crate::terminal::message;
 
 use std::collections::HashSet;
@@ -64,20 +65,27 @@ fn api_client(user: GlobalUser) -> Result<HttpApiClient, failure::Error> {
     Ok(HttpApiClient::new(Credentials::from(user)))
 }
 
-fn print_error(e: ApiFailure) {
+fn format_error(e: ApiFailure) -> String {
     match e {
         ApiFailure::Error(status, api_errors) => {
             give_status_code_context(status);
+            let mut complete_err = "".to_string();
             for error in api_errors.errors {
-                message::warn(&format!("Error {}: {}", error.code, error.message));
+                // message::warn(&format!("Error {}: {}", error.code, error.message));
+                let error_msg =
+                    format!("{} Error {}: {}\n", emoji::WARN, error.code, error.message);
 
                 let suggestion = help(error.code);
                 if !suggestion.is_empty() {
-                    message::help(suggestion);
+                    let help_msg = format!("{} {}\n", emoji::SLEUTH, suggestion);
+                    complete_err.push_str(&format!("{}{}", error_msg, help_msg));
+                } else {
+                    complete_err.push_str(&error_msg)
                 }
             }
+            complete_err
         }
-        ApiFailure::Invalid(reqwest_err) => message::warn(&format!("Error: {}", reqwest_err)),
+        ApiFailure::Invalid(reqwest_err) => format!("{} Error: {}", emoji::WARN, reqwest_err),
     }
 }
 

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -66,7 +66,7 @@ pub fn create(
                 }
             }
         }
-        Err(e) => kv::print_error(e),
+        Err(e) => print!("{}", kv::format_error(e)),
     }
 
     Ok(())

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -36,7 +36,7 @@ pub fn delete(target: &Target, user: GlobalUser, id: &str) -> Result<(), failure
                 "Make sure to remove this \"kv-namespace\" entry from your wrangler.toml!",
             )
         }
-        Err(e) => kv::print_error(e),
+        Err(e) => print!("{}", kv::format_error(e)),
     }
 
     Ok(())

--- a/src/commands/kv/namespace/list.rs
+++ b/src/commands/kv/namespace/list.rs
@@ -17,7 +17,7 @@ pub fn list(target: &Target, user: GlobalUser) -> Result<(), failure::Error> {
             let result = serde_json::to_string(&success.result)?;
             println!("{}", result);
         }
-        Err(e) => kv::print_error(e),
+        Err(e) => print!("{}", kv::format_error(e)),
     }
 
     Ok(())


### PR DESCRIPTION
This PR closes #608. It will ensure that building bucket functionality on top of API calling functions is cleaner; that is, API calling functions that are private functions should not print the result of an API call, but its caller should.