### PR TITLE
Implement crude version of `kv:bucket sync` that does not use hashes to determine changed files yet

### DIFF
--- a/src/commands/kv/bucket/delete.rs
+++ b/src/commands/kv/bucket/delete.rs
@@ -5,6 +5,7 @@ use crate::commands::kv::bucket::directory_keys_only;
 use crate::commands::kv::bulk::delete::delete_bulk;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
+use crate::terminal::message;
 
 pub fn delete(
     target: &Target,
@@ -18,5 +19,9 @@ pub fn delete(
         Err(e) => failure::bail!("{}", e),
     };
 
-    delete_bulk(target, user, namespace_id, keys?)
+    match delete_bulk(target, user, namespace_id, keys?) {
+        Ok(_) => message::success("Success"),
+        Err(e) => print!("{}", e),
+    }
+    Ok(())
 }

--- a/src/commands/kv/bucket/delete.rs
+++ b/src/commands/kv/bucket/delete.rs
@@ -10,11 +10,11 @@ pub fn delete(
     target: &Target,
     user: GlobalUser,
     namespace_id: &str,
-    filename: &Path,
+    path: &Path,
 ) -> Result<(), failure::Error> {
-    let keys: Result<Vec<String>, failure::Error> = match &metadata(filename) {
-        Ok(file_type) if file_type.is_dir() => directory_keys_only(filename),
-        Ok(_) => failure::bail!("{} should be a directory", filename.display()),
+    let keys: Result<Vec<String>, failure::Error> = match &metadata(path) {
+        Ok(file_type) if file_type.is_dir() => directory_keys_only(path),
+        Ok(_) => failure::bail!("{} should be a directory", path.display()),
         Err(e) => failure::bail!("{}", e),
     };
 

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -1,9 +1,11 @@
 extern crate base64;
 
 mod delete;
+mod sync;
 mod upload;
 
 pub use delete::delete;
+pub use sync::sync;
 pub use upload::upload;
 
 use std::ffi::OsString;

--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -19,12 +19,11 @@ pub fn sync(
     path: &Path,
 ) -> Result<(), failure::Error> {
     // First get local keys
-    let local_keys_vec: Result<Vec<String>, failure::Error> = match &metadata(path) {
+    let local_keys_vec: Vec<String> = match &metadata(path) {
         Ok(file_type) if file_type.is_dir() => directory_keys_only(path),
         Ok(_) => failure::bail!("{} should be a directory", path.display()),
         Err(e) => failure::bail!("{}", e),
-    };
-    let local_keys_vec = local_keys_vec?;
+    }?;
     let local_keys: HashSet<_> = HashSet::from_iter(local_keys_vec.iter());
 
     // Then get remote keys

--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -1,0 +1,62 @@
+use std::collections::HashSet;
+use std::fs::metadata;
+use std::iter::FromIterator;
+use std::path::Path;
+
+use crate::commands::kv;
+use crate::commands::kv::bucket::directory_keys_only;
+use crate::commands::kv::bucket::upload::upload;
+use crate::commands::kv::bulk::delete::delete_bulk;
+use crate::commands::kv::key::KeyList;
+use crate::settings::global_user::GlobalUser;
+use crate::settings::target::Target;
+use crate::terminal::message;
+
+pub fn sync(
+    target: &Target,
+    user: GlobalUser,
+    namespace_id: &str,
+    path: &Path,
+) -> Result<(), failure::Error> {
+    // First get local keys
+    let local_keys_vec: Result<Vec<String>, failure::Error> = match &metadata(path) {
+        Ok(file_type) if file_type.is_dir() => directory_keys_only(path),
+        Ok(_) => failure::bail!("{} should be a directory", path.display()),
+        Err(e) => failure::bail!("{}", e),
+    };
+    let local_keys_vec = local_keys_vec?;
+    let local_keys: HashSet<_> = HashSet::from_iter(local_keys_vec.iter());
+
+    // Then get remote keys
+    let remote_keys = KeyList::new(target, user.clone(), namespace_id, None)?;
+
+    // Find keys that are present in remote but not present in local, and
+    // stage them for deletion. This is done by iterating over the remote_keys and checking for
+    // remote_keys that do not exist in local_keys. This logic is similar to that of the
+    // difference() method in https://doc.rust-lang.org/src/std/collections/hash/set.rs.html,
+    // but saves us the trouble and overhead memory of converting remote_keys into a HashSet.
+    let mut keys_to_delete: Vec<String> = Vec::new();
+    for remote_key in remote_keys {
+        match remote_key {
+            Ok(remote_key) => {
+                let name = remote_key.name;
+                if !local_keys.contains(&name) {
+                    keys_to_delete.push(name);
+                }
+            }
+            Err(e) => print!("{}", kv::format_error(e)),
+        }
+    }
+
+    if !keys_to_delete.is_empty() {
+        message::info("Deleting stale files...");
+        delete_bulk(target, user.clone(), namespace_id, keys_to_delete)?;
+    }
+
+    // After deleting remote keys, upload all existing files in given directory
+    message::info("Preparing to upload updated files...");
+    upload(target, user, namespace_id, path)?;
+
+    message::success("Success");
+    Ok(())
+}

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -12,10 +12,10 @@ pub fn upload(
     target: &Target,
     user: GlobalUser,
     namespace_id: &str,
-    filename: &Path,
+    path: &Path,
 ) -> Result<(), failure::Error> {
-    let pairs: Result<Vec<KeyValuePair>, failure::Error> = match &metadata(filename) {
-        Ok(file_type) if file_type.is_dir() => directory_keys_values(filename),
+    let pairs: Result<Vec<KeyValuePair>, failure::Error> = match &metadata(path) {
+        Ok(file_type) if file_type.is_dir() => directory_keys_values(path),
         Ok(_file_type) => {
             // any other file types (files, symlinks)
             failure::bail!("wrangler kv:bucket upload takes a directory")

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -7,6 +7,7 @@ use crate::commands::kv::bucket::directory_keys_values;
 use crate::commands::kv::bulk::put::put_bulk;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
+use crate::terminal::message;
 
 pub fn upload(
     target: &Target,
@@ -23,5 +24,9 @@ pub fn upload(
         Err(e) => failure::bail!("{}", e),
     };
 
-    put_bulk(target, user, namespace_id, pairs?)
+    match put_bulk(target, user, namespace_id, pairs?) {
+        Ok(_) => message::success("Success"),
+        Err(e) => print!("{}", e),
+    }
+    Ok(())
 }

--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -5,6 +5,9 @@ use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::HttpApiClient;
 
+use crate::commands::kv;
+use crate::settings::global_user::GlobalUser;
+
 use serde_json::value::Value as JsonValue;
 
 use crate::settings::target::Target;
@@ -22,19 +25,20 @@ pub struct KeyList {
 impl KeyList {
     pub fn new(
         target: &Target,
-        client: HttpApiClient,
+        user: GlobalUser,
         namespace_id: &str,
         prefix: Option<&str>,
-    ) -> KeyList {
-        KeyList {
+    ) -> Result<KeyList, failure::Error> {
+        let iter = KeyList {
             keys_result: None,
             prefix: prefix.map(str::to_string),
-            client,
+            client: kv::api_client(user)?,
             account_id: target.account_id.to_owned(),
             namespace_id: namespace_id.to_string(),
             cursor: None,
             init_fetch: false,
-        }
+        };
+        Ok(iter)
     }
 
     fn request_params(&self) -> ListNamespaceKeys {

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -14,9 +14,7 @@ pub fn list(
     namespace_id: &str,
     prefix: Option<&str>,
 ) -> Result<(), failure::Error> {
-    let client = kv::api_client(user)?;
-
-    let key_list = KeyList::new(target, client, namespace_id, prefix);
+    let key_list = KeyList::new(target, user, namespace_id, prefix)?;
 
     print!("["); // Open json list bracket
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,20 @@ fn run() -> Result<(), failure::Error> {
                             .index(1),
                         )
                 )
+                .subcommand(
+                    SubCommand::with_name("sync")
+                        .about("Sync the contents of a directory keyed on path (ensures local and remote directories are the same)")
+                        .arg(kv_binding_arg.clone())
+                        .arg(kv_namespace_id_arg.clone())
+                        .group(kv_namespace_specifier_group.clone())
+                        .arg(environment_arg.clone())
+                        .arg(
+                            Arg::with_name("path")
+                            .help("the directory to be synced to KV")
+                            .required(true)
+                            .index(1),
+                        )
+                )
         )
         .subcommand(
             SubCommand::with_name("generate")
@@ -669,6 +683,10 @@ fn run() -> Result<(), failure::Error> {
             ("delete", Some(delete_matches)) => {
                 let path = delete_matches.value_of("path").unwrap();
                 commands::kv::bucket::delete(&target, user, &namespace_id, Path::new(path))?;
+            }
+            ("sync", Some(sync_matches)) => {
+                let path = sync_matches.value_of("path").unwrap();
+                commands::kv::bucket::sync(&target, user, &namespace_id, Path::new(path))?;
             }
             ("", None) => message::warn("kv:bucket expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
This PR implements a crude version of #484. (Fixes #484).

This implementation does two things:
1. It deletes all keys/filenames in the remote KV namespace whose keys/filenames no longer exist in the given local directory.
2. It uploads all files in the given local directory.

Ideally, we only update files in the remote directory if we know they have changed (e.g. do a hash comparison). We will wait for manifest work to be complete before we move to that step.

Usage cases:
When stale files (exist in remote but not in local) are deleted:
```console
$ wrangler kv:bucket sync -b=BUTTS abc/
 Deleting stale files...
 Preparing to upload updated files...
 Parsing a.txt...
 Parsing b/c.txt...
 Success
```

When no stale files exist:
```console
$ wrangler kv:bucket sync -b=BUTTS abc/
 Preparing to upload updated files...
 Parsing a.txt...
 Parsing b/c.txt...
 Success
```
