### PR TITLE
Alewis/sites interface

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -166,6 +166,7 @@ mod tests {
             webpack_config: None,
             workers_dev: false,
             zone_id: None,
+            site: None,
         };
         assert!(kv::get_namespace_id(&target_with_dup_kv_bindings, "").is_err());
     }

--- a/src/commands/kv/namespace/mod.rs
+++ b/src/commands/kv/namespace/mod.rs
@@ -1,7 +1,9 @@
 mod create;
 mod delete;
 mod list;
+mod site;
 
 pub use create::create;
 pub use delete::delete;
 pub use list::list;
+pub use site::site;

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -1,0 +1,60 @@
+use cloudflare::endpoints::workerskv::create_namespace::CreateNamespace;
+use cloudflare::endpoints::workerskv::create_namespace::CreateNamespaceParams;
+use cloudflare::endpoints::workerskv::list_namespaces::ListNamespaces;
+use cloudflare::endpoints::workerskv::WorkersKvNamespace;
+use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::ApiFailure;
+
+use crate::commands::kv;
+use crate::settings::global_user::GlobalUser;
+use crate::settings::target::Target;
+use crate::terminal::message;
+
+pub fn site(target: &Target, user: &GlobalUser) -> Result<WorkersKvNamespace, failure::Error> {
+    let client = kv::api_client(user.to_owned())?;
+
+    let title = format!("__{}-{}", target.name, "workers_sites_assets");
+    let msg = format!("Creating namespace for Workers Site \"{}\"", title);
+    message::working(&msg);
+
+    let response = client.request(&CreateNamespace {
+        account_identifier: &target.account_id,
+        params: CreateNamespaceParams {
+            title: title.to_owned(),
+        },
+    });
+
+    match response {
+        Ok(success) => {
+            return Ok(success.result);
+        }
+        Err(e) => match e {
+            ApiFailure::Error(_status, api_errors) => {
+                if api_errors
+                    .errors
+                    .iter()
+                    .find(|&e| e.code == 10014)
+                    .is_some()
+                {
+                    log::info!("Namespace {} already exists.", title);
+                    let response = client.request(&ListNamespaces {
+                        account_identifier: &target.account_id,
+                    });
+
+                    match response {
+                        Ok(success) => Ok(success
+                            .result
+                            .iter()
+                            .find(|ns| ns.title == title)
+                            .unwrap()
+                            .to_owned()),
+                        Err(e) => failure::bail!("{:?}", e),
+                    }
+                } else {
+                    failure::bail!("{:?}", api_errors.errors)
+                }
+            }
+            ApiFailure::Invalid(reqwest_err) => failure::bail!("Error: {}", reqwest_err),
+        },
+    }
+}

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -109,7 +109,7 @@ fn authenticated_upload(client: &Client, target: &Target) -> Result<Preview, fai
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_script_upload_form(&target)?;
+    let script_upload_form = publish::build_script_upload_form(target)?;
 
     let mut res = client
         .post(&create_address)

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -1,14 +1,13 @@
 mod project_assets;
 mod wasm_module;
 
-use log::info;
-
 use reqwest::multipart::{Form, Part};
 use std::fs;
 use std::path::Path;
 
 use crate::commands::build::wranglerjs;
 use crate::settings::binding;
+
 use crate::settings::metadata::Metadata;
 use crate::settings::target::kv_namespace;
 use crate::settings::target::{Target, TargetType};
@@ -23,7 +22,7 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
     let kv_namespaces = target.kv_namespaces();
     match target_type {
         TargetType::Rust => {
-            info!("Rust project detected. Publishing...");
+            log::info!("Rust project detected. Publishing...");
             let name = krate::Krate::new("./")?.name.replace("-", "_");
             // TODO: move into build?
             build_generated_dir()?;
@@ -40,7 +39,7 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
             build_form(&assets)
         }
         TargetType::JavaScript => {
-            info!("JavaScript project detected. Publishing...");
+            log::info!("JavaScript project detected. Publishing...");
             let package = Package::new("./")?;
 
             let script_path = package.main()?;
@@ -50,7 +49,7 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
             build_form(&assets)
         }
         TargetType::Webpack => {
-            info!("Webpack project detected. Publishing...");
+            log::info!("Webpack project detected. Publishing...");
             // FIXME(sven): shouldn't new
             let bundle = wranglerjs::Bundle::new();
 
@@ -80,7 +79,7 @@ fn build_form(assets: &ProjectAssets) -> Result<Form, failure::Error> {
     form = add_metadata(form, assets)?;
     form = add_files(form, assets)?;
 
-    info!("{:?}", &form);
+    log::info!("{:?}", &form);
 
     Ok(form)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,7 +494,7 @@ fn run() -> Result<(), failure::Error> {
             failure::bail!("You can only pass --env or --release, not both")
         }
         let manifest = settings::target::Manifest::new(config_path)?;
-        let target;
+        let mut target;
         if matches.is_present("env") {
             target = manifest.get_target(matches.value_of("env"), false)?;
         } else if matches.is_present("release") {
@@ -505,7 +505,7 @@ fn run() -> Result<(), failure::Error> {
 
         let push_worker = !matches.is_present("no-worker");
         let push_bucket = !matches.is_present("no-bucket");
-        commands::publish(&user, &target, push_worker, push_bucket)?;
+        commands::publish(&user, &mut target, push_worker, push_bucket)?;
     } else if let Some(matches) = matches.subcommand_matches("subdomain") {
         info!("Getting project settings");
         let manifest = settings::target::Manifest::new(config_path)?;


### PR DESCRIPTION
This PR establishes a new optional configuration in the Wrangler.toml, `site`, which automatically provisions a "bucket" type KV namespace, and publishes to it on `wrangler publish`. Not yet implemented: generating/building the worker code to serve sites.