### PR TITLE
Alewis/root toml

### DIFF
--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -10,22 +10,22 @@ use crate::commands::build::wranglerjs::output::WranglerjsOutput;
 
 // Directory where we should write the {Bundle}. It represents the built
 // artifact.
-const BUNDLE_OUT: &str = "./worker";
+const BUNDLE_OUT: &str = "worker";
 pub struct Bundle {
-    out: String,
+    out: PathBuf,
 }
 
 // We call a {Bundle} the output of a {Bundler}; representing what {Webpack}
 // produces.
 impl Bundle {
-    pub fn new() -> Bundle {
+    pub fn new(build_dir: &PathBuf) -> Bundle {
         Bundle {
-            out: BUNDLE_OUT.to_string(),
+            out: build_dir.join(BUNDLE_OUT),
         }
     }
 
     #[cfg(test)]
-    fn new_at(out: String) -> Bundle {
+    fn new_at(out: PathBuf) -> Bundle {
         Bundle { out }
     }
 
@@ -81,7 +81,7 @@ impl Bundle {
 mod tests {
     use super::*;
 
-    fn create_temp_dir(name: &str) -> String {
+    fn create_temp_dir(name: &str) -> PathBuf {
         let mut dir = env::temp_dir();
         dir.push(name);
         if dir.exists() {
@@ -89,7 +89,7 @@ mod tests {
         }
         fs::create_dir(&dir).expect("could not create temp dir");
 
-        dir.to_str().unwrap().to_string()
+        dir
     }
 
     #[test]
@@ -137,7 +137,7 @@ mod tests {
         assert!(wranglerjs_output.get_errors() == "a\nb");
     }
 
-    fn cleanup(name: String) {
+    fn cleanup(name: PathBuf) {
         let current_dir = env::current_dir().unwrap();
         let path = Path::new(&current_dir).join(name);
         fs::remove_dir_all(path).unwrap();

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -127,8 +127,8 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
         env_dep_installed(tool)?;
     }
 
-    let current_dir = env::current_dir()?;
-    run_npm_install(current_dir).expect("could not run `npm install`");
+    let build_dir = target.build_dir()?;
+    run_npm_install(&build_dir.to_path_buf()).expect("could not run `npm install`");
 
     let node = which::which("node").unwrap();
     let mut command = Command::new(node);
@@ -149,7 +149,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
         temp_file.clone().to_str().unwrap().to_string()
     ));
 
-    let bundle = Bundle::new();
+    let bundle = Bundle::new(&build_dir);
 
     command.arg(format!("--wasm-binding={}", bundle.get_wasm_binding()));
 
@@ -164,9 +164,8 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     // {package.json} file and pass it to {wranglerjs}.
     // https://github.com/cloudflare/wrangler/issues/98
     if !bundle.has_webpack_config(&webpack_config_path) {
-        let package = Package::new("./")?;
-        let current_dir = env::current_dir()?;
-        let package_main = current_dir
+        let package = Package::new(&build_dir)?;
+        let package_main = build_dir
             .join(package.main()?)
             .to_str()
             .unwrap()
@@ -185,7 +184,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
 
 // Run {npm install} in the specified directory. Skips the install if a
 // {node_modules} is found in the directory.
-fn run_npm_install(dir: PathBuf) -> Result<(), failure::Error> {
+fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
     let flock_path = dir.join(&".install.lock");
     let flock = File::create(&flock_path)?;
     // avoid running multiple {npm install} at the same time (eg. in tests)
@@ -263,7 +262,7 @@ fn install() -> Result<PathBuf, failure::Error> {
         wranglerjs_path.path()
     };
 
-    run_npm_install(wranglerjs_path.clone()).expect("could not install wranglerjs dependencies");
+    run_npm_install(&wranglerjs_path.clone()).expect("could not install wranglerjs dependencies");
     Ok(wranglerjs_path)
 }
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -4,8 +4,9 @@ pub mod preview;
 mod route;
 mod upload_form;
 
-use crate::settings::target::kv_namespace::KvNamespace;
 pub use package::Package;
+
+use crate::settings::target::kv_namespace::KvNamespace;
 use route::Route;
 
 use upload_form::build_script_upload_form;

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{self, Deserialize};
 
@@ -26,11 +26,11 @@ impl Package {
 }
 
 impl Package {
-    pub fn new(pkg_path: &str) -> Result<Package, failure::Error> {
-        let manifest_path = Path::new(pkg_path).join("package.json");
+    pub fn new(pkg_path: &PathBuf) -> Result<Package, failure::Error> {
+        let manifest_path = pkg_path.join("package.json");
         if !manifest_path.is_file() {
             failure::bail!(
-                "Your JavaScript project is missing a `package.json` file; is `{}` the \
+                "Your JavaScript project is missing a `package.json` file; is `{:?}` the \
                  wrong directory?",
                 pkg_path
             )

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -40,7 +40,8 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
         }
         TargetType::JavaScript => {
             log::info!("JavaScript project detected. Publishing...");
-            let package = Package::new("./")?;
+            let build_dir = target.build_dir()?;
+            let package = Package::new(&build_dir)?;
 
             let script_path = package.main()?;
 
@@ -51,7 +52,8 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
         TargetType::Webpack => {
             log::info!("Webpack project detected. Publishing...");
             // FIXME(sven): shouldn't new
-            let bundle = wranglerjs::Bundle::new();
+            let build_dir = target.build_dir()?;
+            let bundle = wranglerjs::Bundle::new(&build_dir);
 
             let script_path = bundle.script_path();
 

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -36,6 +36,8 @@ pub struct Target {
     pub site: Option<Site>,
 }
 
+const SITE_BUILD_DIR: &str = "./workers-site";
+
 impl Target {
     pub fn kv_namespaces(&self) -> Vec<KvNamespace> {
         self.kv_namespaces.clone().unwrap_or_else(Vec::new)
@@ -48,7 +50,15 @@ impl Target {
     }
 
     pub fn build_dir(&self) -> Result<PathBuf, std::io::Error> {
-        env::current_dir()
+        let current_dir = env::current_dir()?;
+        // if `site` is configured, we want to isolate worker code
+        // and build artifacts from static site application code.
+        match &self.site {
+            Some(_site_config) => Ok(current_dir.join(
+                SITE_BUILD_DIR.to_string(),
+            )),
+            None => Ok(current_dir),
+        }
     }
 }
 

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -5,6 +5,7 @@ pub use kv_namespace::KvNamespace;
 pub use target_type::TargetType;
 
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -44,6 +45,10 @@ impl Target {
         let mut updated_namespaces = self.kv_namespaces();
         updated_namespaces.push(kv_namespace);
         self.kv_namespaces = Some(updated_namespaces);
+    }
+
+    pub fn build_dir(&self) -> Result<PathBuf, std::io::Error> {
+        env::current_dir()
     }
 }
 

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -18,6 +18,8 @@ use crate::terminal::message;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Site {
     pub bucket: String,
+    #[serde(rename = "entry-point")]
+    pub entry_point: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -53,9 +55,15 @@ impl Target {
         let current_dir = env::current_dir()?;
         // if `site` is configured, we want to isolate worker code
         // and build artifacts from static site application code.
+        // if the user has configured `site.entry-point`, use that
+        // as the build directory. Otherwise use our the default
+        // stored as the const SITE_BUILD_DIR
         match &self.site {
-            Some(_site_config) => Ok(current_dir.join(
-                SITE_BUILD_DIR.to_string(),
+            Some(site_config) => Ok(current_dir.join(
+                site_config
+                    .entry_point
+                    .to_owned()
+                    .unwrap_or(SITE_BUILD_DIR.to_string()),
             )),
             None => Ok(current_dir),
         }


### PR DESCRIPTION
This is a PR in two steps:

The first step refactors the wranglerjs build code to take an out directory as an argument to `Bundle::new`, and moves the logic about what that directory should be to a method on `Target` called `build_dir`.

The second step adds an `entry-point` key to the `site` configuration table that allows users to configure the build directory for a site project. this defaults to `workers-site` if the site key is present at all.