### PR TITLE
Add support for generating and initializing site projects

### DIFF
--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -201,6 +201,8 @@ pub fn scaffold_site_worker(target: &Target) -> Result<(), failure::Error> {
                 &target.target_type,
             )?;
 
+            // This step is to prevent having a git repo within a git repo after
+            // generating the scaffold into an existing project.
             fs::remove_dir_all(&build_dir.join(".git"))?;
         }
     }

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -130,7 +130,9 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
 
     let build_dir = target.build_dir()?;
 
-    scaffold_site_worker(&target)?;
+    if target.site.is_some() {
+        scaffold_site_worker(&target)?;
+    }
 
     run_npm_install(&build_dir).expect("could not run `npm install`");
 
@@ -188,23 +190,20 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
 
 pub fn scaffold_site_worker(target: &Target) -> Result<(), failure::Error> {
     let build_dir = target.build_dir()?;
+    // TODO: this is a placeholder template. Replace with The Real Thing on launch.
+    let template = "https://github.com/ashleymichal/glowing-palm-tree";
 
-    if target.site.is_some() {
-        // TODO: this is a placeholder template. Replace with The Real Thing on launch.
-        let template = "https://github.com/ashleymichal/glowing-palm-tree";
+    if !Path::new(&build_dir).exists() {
+        // TODO: use site.entry_point instead of build_dir explicitly.
+        run_generate(
+            build_dir.file_name().unwrap().to_str().unwrap(),
+            template,
+            &target.target_type,
+        )?;
 
-        if !Path::new(&build_dir).exists() {
-            // TODO: use site.entry_point instead of build_dir explicitly.
-            run_generate(
-                build_dir.file_name().unwrap().to_str().unwrap(),
-                template,
-                &target.target_type,
-            )?;
-
-            // This step is to prevent having a git repo within a git repo after
-            // generating the scaffold into an existing project.
-            fs::remove_dir_all(&build_dir.join(".git"))?;
-        }
+        // This step is to prevent having a git repo within a git repo after
+        // generating the scaffold into an existing project.
+        fs::remove_dir_all(&build_dir.join(".git"))?;
     }
 
     Ok(())

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -3,6 +3,7 @@ pub mod output;
 
 use crate::commands::build::watch::wait_for_changes;
 use crate::commands::build::watch::COOLDOWN_PERIOD;
+use crate::commands::generate::run_generate;
 
 use crate::commands::publish::package::Package;
 use crate::install;
@@ -128,7 +129,10 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     }
 
     let build_dir = target.build_dir()?;
-    run_npm_install(&build_dir.to_path_buf()).expect("could not run `npm install`");
+
+    scaffold_site_worker(&target)?;
+
+    run_npm_install(&build_dir).expect("could not run `npm install`");
 
     let node = which::which("node").unwrap();
     let mut command = Command::new(node);
@@ -166,7 +170,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     if !bundle.has_webpack_config(&webpack_config_path) {
         let package = Package::new(&build_dir)?;
         let package_main = build_dir
-            .join(package.main()?)
+            .join(package.main(&build_dir)?)
             .to_str()
             .unwrap()
             .to_string();
@@ -180,6 +184,28 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     }
 
     Ok((command, temp_file, bundle))
+}
+
+pub fn scaffold_site_worker(target: &Target) -> Result<(), failure::Error> {
+    let build_dir = target.build_dir()?;
+
+    if target.site.is_some() {
+        // TODO: this is a placeholder template. Replace with The Real Thing on launch.
+        let template = "https://github.com/ashleymichal/glowing-palm-tree";
+
+        if !Path::new(&build_dir).exists() {
+            // TODO: use site.entry_point instead of build_dir explicitly.
+            run_generate(
+                build_dir.file_name().unwrap().to_str().unwrap(),
+                template,
+                &target.target_type,
+            )?;
+
+            fs::remove_dir_all(&build_dir.join(".git"))?;
+        }
+    }
+
+    Ok(())
 }
 
 // Run {npm install} in the specified directory. Skips the install if a

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -12,17 +12,10 @@ pub fn generate(
     site: bool,
 ) -> Result<(), failure::Error> {
     let target_type = target_type.unwrap_or_else(|| get_target_type(template));
-    if site {
-        run_generate(name, template, &target_type)?;
-        let config_path = PathBuf::from("./").join(&name);
-        Manifest::generate(name.to_string(), target_type, config_path, site)?;
-        Ok(())
-    } else {
-        run_generate(name, template, &target_type)?;
-        let config_path = PathBuf::from("./").join(&name);
-        Manifest::generate(name.to_string(), target_type, config_path, site)?;
-        Ok(())
-    }
+    run_generate(name, template, &target_type)?;
+    let config_path = PathBuf::from("./").join(&name);
+    Manifest::generate(name.to_string(), target_type, config_path, site)?;
+    Ok(())
 }
 
 pub fn run_generate(

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -5,27 +5,27 @@ use std::process::Command;
 
 use crate::terminal::{emoji, message};
 
-pub fn generate_site(name: &str, target_type: TargetType) -> Result<(), failure::Error> {
-    let template = "https://github.com/cloudflare/worker-sites-template";
-    run_generate(name, template, &target_type)?;
-    let config_path = PathBuf::from("./").join(&name);
-    Manifest::generate_site(name.to_string(), config_path)?;
-    Ok(())
-}
-
 pub fn generate(
     name: &str,
     template: &str,
     target_type: Option<TargetType>,
+    site: bool,
 ) -> Result<(), failure::Error> {
     let target_type = target_type.unwrap_or_else(|| get_target_type(template));
-    run_generate(name, template, &target_type)?;
-    let config_path = PathBuf::from("./").join(&name);
-    Manifest::generate(name.to_string(), target_type, config_path)?;
-    Ok(())
+    if site {
+        run_generate(name, template, &target_type)?;
+        let config_path = PathBuf::from("./").join(&name);
+        Manifest::generate(name.to_string(), target_type, config_path, site)?;
+        Ok(())
+    } else {
+        run_generate(name, template, &target_type)?;
+        let config_path = PathBuf::from("./").join(&name);
+        Manifest::generate(name.to_string(), target_type, config_path, site)?;
+        Ok(())
+    }
 }
 
-fn run_generate(
+pub fn run_generate(
     name: &str,
     template: &str,
     target_type: &TargetType,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -20,7 +20,8 @@ pub fn generate(
     let command_name = format!("{:?}", command);
 
     commands::run(command, &command_name)?;
-    Manifest::generate(name.to_string(), target_type, false)?;
+    let config_path = PathBuf::from("./").join(&name);
+    Manifest::generate(name.to_string(), target_type, config_path)?;
     Ok(())
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use crate::settings::target::{Manifest, TargetType};
 use crate::terminal::message;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn init(name: Option<&str>, target_type: Option<TargetType>) -> Result<(), failure::Error> {
     if Path::new("./wrangler.toml").exists() {
@@ -9,7 +9,8 @@ pub fn init(name: Option<&str>, target_type: Option<TargetType>) -> Result<(), f
     let dirname = get_current_dirname()?;
     let name = name.unwrap_or_else(|| &dirname);
     let target_type = target_type.unwrap_or_default();
-    Manifest::generate(name.to_string(), target_type, true)?;
+    let config_path = PathBuf::from("./");
+    Manifest::generate(name.to_string(), target_type, config_path)?;
     message::success("Succesfully created a `wrangler.toml`");
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,8 +1,13 @@
+use crate::commands;
 use crate::settings::target::{Manifest, TargetType};
 use crate::terminal::message;
 use std::path::{Path, PathBuf};
 
-pub fn init(name: Option<&str>, target_type: Option<TargetType>) -> Result<(), failure::Error> {
+pub fn init(
+    name: Option<&str>,
+    target_type: Option<TargetType>,
+    site: bool,
+) -> Result<(), failure::Error> {
     if Path::new("./wrangler.toml").exists() {
         failure::bail!("A wrangler.toml file already exists! Please remove it before running this command again.");
     }
@@ -10,8 +15,15 @@ pub fn init(name: Option<&str>, target_type: Option<TargetType>) -> Result<(), f
     let name = name.unwrap_or_else(|| &dirname);
     let target_type = target_type.unwrap_or_default();
     let config_path = PathBuf::from("./");
-    Manifest::generate(name.to_string(), target_type, config_path)?;
+    let manifest = Manifest::generate(name.to_string(), target_type, config_path, site)?;
     message::success("Succesfully created a `wrangler.toml`");
+
+    if site {
+        let env = None;
+        let release = false;
+        let target = manifest.get_target(env, release)?;
+        commands::build::wranglerjs::scaffold_site_worker(&target)?;
+    }
     Ok(())
 }
 

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -75,7 +75,7 @@ pub fn upload_files(
             }
 
             // Add the popped key-value pair to the running batch of key-value pair uploads
-            key_count = key_count + 1;
+            key_count += 1;
             key_pair_bytes = key_pair_bytes + pair.key.len() + pair.value.len();
             key_value_batch.push(pair);
         }

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -25,17 +25,10 @@ pub fn site(target: &Target, user: &GlobalUser) -> Result<WorkersKvNamespace, fa
     });
 
     match response {
-        Ok(success) => {
-            return Ok(success.result);
-        }
+        Ok(success) => Ok(success.result),
         Err(e) => match e {
             ApiFailure::Error(_status, api_errors) => {
-                if api_errors
-                    .errors
-                    .iter()
-                    .find(|&e| e.code == 10014)
-                    .is_some()
-                {
+                if api_errors.errors.iter().any(|e| e.code == 10014) {
                     log::info!("Namespace {} already exists.", title);
                     let response = client.request(&ListNamespaces {
                         account_identifier: &target.account_id,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub mod whoami;
 pub use self::config::global_config;
 pub use build::build;
 pub use build::watch_and_build;
-pub use generate::generate;
+pub use generate::{generate, generate_site};
 pub use init::init;
 pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub mod whoami;
 pub use self::config::global_config;
 pub use build::build;
 pub use build::watch_and_build;
-pub use generate::{generate, generate_site};
+pub use generate::generate;
 pub use init::init;
 pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::{self, Deserialize};
 
@@ -9,12 +9,12 @@ pub struct Package {
     main: String,
 }
 impl Package {
-    pub fn main(&self) -> Result<String, failure::Error> {
+    pub fn main(&self, build_dir: &PathBuf) -> Result<String, failure::Error> {
         if self.main == "" {
             failure::bail!(
                 "The `main` key in your `package.json` file is required; please specified the entrypoint of your Worker.",
             )
-        } else if !Path::new(&self.main).exists() {
+        } else if !build_dir.join(&self.main).exists() {
             failure::bail!(
                 "The entrypoint of your Worker ({}) could not be found.",
                 self.main

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -43,7 +43,7 @@ pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error>
             let build_dir = target.build_dir()?;
             let package = Package::new(&build_dir)?;
 
-            let script_path = package.main()?;
+            let script_path = package.main(&build_dir)?;
 
             let assets = ProjectAssets::new(script_path, Vec::new(), kv_namespaces)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,29 +472,31 @@ fn run() -> Result<(), failure::Error> {
         let name = matches.value_of("name").unwrap_or("worker");
         let site = matches.is_present("site");
 
-        let target_type;
-        let template;
-        if site {
+        let (target_type, template) = if site {
             // Workers Sites projects are always Webpack for now
-            target_type = Some(TargetType::Webpack);
+            let target_type = Some(TargetType::Webpack);
             // template = "https://github.com/cloudflare/worker-sites-template";
             // TODO: this is a placeholder template. Replace with The Real Thing (^) on launch.
-            template = "https://github.com/ashleymichal/scaling-succotash";
+            let template = "https://github.com/ashleymichal/scaling-succotash";
+
+            (target_type, template)
         } else {
-            target_type = match matches.value_of("type") {
+            let target_type = match matches.value_of("type") {
                 Some(s) => Some(TargetType::from_str(&s.to_lowercase())?),
                 None => None,
             };
 
             let default_template = "https://github.com/cloudflare/worker-template";
-            template = matches.value_of("template").unwrap_or(match target_type {
+            let template = matches.value_of("template").unwrap_or(match target_type {
                 Some(ref pt) => match pt {
                     TargetType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
                     _ => default_template,
                 },
                 _ => default_template,
             });
-        }
+
+            (target_type, template)
+        };
 
         info!(
             "Generate command called with template {}, and name {}",
@@ -505,17 +507,15 @@ fn run() -> Result<(), failure::Error> {
     } else if let Some(matches) = matches.subcommand_matches("init") {
         let name = matches.value_of("name");
         let site = matches.is_present("site");
-        let target_type;
-
-        if site {
+        let target_type = if site {
             // Workers Sites projects are always Webpack for now
-            target_type = Some(TargetType::Webpack);
+            Some(TargetType::Webpack)
         } else {
-            target_type = match matches.value_of("type") {
+            match matches.value_of("type") {
                 Some(s) => Some(settings::target::TargetType::from_str(&s.to_lowercase())?),
                 None => None,
-            };
-        }
+            }
+        };
 
         commands::init(name, target_type, site)?;
     } else if let Some(matches) = matches.subcommand_matches("build") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ fn run() -> Result<(), failure::Error> {
                         .short("s")
                         .long("site")
                         .takes_value(false)
-                        .help("initializes a Workers Sites project overrides `type` and `template`"),
+                        .help("initializes a Workers Sites project. Overrides `type` and `template`"),
                 ),
         )
         .subcommand(
@@ -352,7 +352,7 @@ fn run() -> Result<(), failure::Error> {
                         .short("s")
                         .long("site")
                         .takes_value(false)
-                        .help("initializes a Workers Sites project overrides `type` and `template`"),
+                        .help("initializes a Workers Sites project. Overrides `type` and `template`"),
                 ),
         )
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,8 @@ fn run() -> Result<(), failure::Error> {
                         .about("List all namespaces on your Cloudflare account")
                 )
         )
-            .subcommand(SubCommand::with_name("kv:key")
+        .subcommand(
+            SubCommand::with_name("kv:key")
                 .about(&*format!(
                     "{} Individually manage Workers KV key-value pairs",
                     emoji::KEY

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,13 @@ fn run() -> Result<(), failure::Error> {
                         .long("type")
                         .takes_value(true)
                         .help("the type of project you want generated"),
+                )
+                .arg(
+                    Arg::with_name("site")
+                        .short("s")
+                        .long("site")
+                        .takes_value(false)
+                        .help("initializes a Workers Sites project overrides `type` and `template`"),
                 ),
         )
         .subcommand(
@@ -455,26 +462,34 @@ fn run() -> Result<(), failure::Error> {
 
         commands::global_config(email, api_key)?;
     } else if let Some(matches) = matches.subcommand_matches("generate") {
-        let name = matches.value_of("name").unwrap_or("worker");
-        let target_type = match matches.value_of("type") {
-            Some(s) => Some(TargetType::from_str(&s.to_lowercase())?),
-            None => None,
-        };
+        if matches.is_present("site") {
+            let name = matches.value_of("name").unwrap_or("workers-site");
 
-        let default_template = "https://github.com/cloudflare/worker-template";
-        let template = matches.value_of("template").unwrap_or(match target_type {
-            Some(ref pt) => match pt {
-                TargetType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
+            // Workers Sites projects are always Webpack for now
+            let target_type = TargetType::Webpack;
+            commands::generate_site(name, target_type)?;
+        } else {
+            let name = matches.value_of("name").unwrap_or("worker");
+            let target_type = match matches.value_of("type") {
+                Some(s) => Some(TargetType::from_str(&s.to_lowercase())?),
+                None => None,
+            };
+
+            let default_template = "https://github.com/cloudflare/worker-template";
+            let template = matches.value_of("template").unwrap_or(match target_type {
+                Some(ref pt) => match pt {
+                    TargetType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
+                    _ => default_template,
+                },
                 _ => default_template,
-            },
-            _ => default_template,
-        });
+            });
 
-        info!(
-            "Generate command called with template {}, and name {}",
-            template, name
-        );
-        commands::generate(name, template, target_type)?;
+            info!(
+                "Generate command called with template {}, and name {}",
+                template, name
+            );
+            commands::generate(name, template, target_type)?;
+        }
     } else if let Some(matches) = matches.subcommand_matches("init") {
         let name = matches.value_of("name");
         let target_type = match matches.value_of("type") {

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::terminal::emoji;
 use crate::terminal::message;
 
+const SITE_ENTRY_POINT: &str = "workers-site";
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Site {
     pub bucket: String,
@@ -26,7 +28,7 @@ impl Default for Site {
     fn default() -> Site {
         Site {
             bucket: String::new(),
-            entry_point: Some(String::from("workers-site")),
+            entry_point: Some(String::from(SITE_ENTRY_POINT)),
         }
     }
 }
@@ -46,8 +48,6 @@ pub struct Target {
     pub zone_id: Option<String>,
     pub site: Option<Site>,
 }
-
-const SITE_BUILD_DIR: &str = "./workers-site";
 
 impl Target {
     pub fn kv_namespaces(&self) -> Vec<KvNamespace> {
@@ -72,7 +72,7 @@ impl Target {
                 site_config
                     .entry_point
                     .to_owned()
-                    .unwrap_or_else(|| SITE_BUILD_DIR.to_string()),
+                    .unwrap_or_else(|| format!("./{}}", SITE_ENTRY_POINT)),
             )),
             None => Ok(current_dir),
         }

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -123,7 +123,7 @@ impl Manifest {
     pub fn generate(
         name: String,
         target_type: TargetType,
-        init: bool,
+        config_path: PathBuf,
     ) -> Result<Manifest, failure::Error> {
         let manifest = Manifest {
             account_id: String::new(),
@@ -141,11 +141,6 @@ impl Manifest {
         };
 
         let toml = toml::to_string(&manifest)?;
-        let config_path = if init {
-            PathBuf::from("./")
-        } else {
-            Path::new("./").join(&name)
-        };
         let config_file = config_path.join("wrangler.toml");
 
         log::info!("Writing a wrangler.toml file at {}", config_file.display());

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -72,7 +72,7 @@ impl Target {
                 site_config
                     .entry_point
                     .to_owned()
-                    .unwrap_or(SITE_BUILD_DIR.to_string()),
+                    .unwrap_or_else(|| SITE_BUILD_DIR.to_string()),
             )),
             None => Ok(current_dir),
         }

--- a/src/settings/target/mod.rs
+++ b/src/settings/target/mod.rs
@@ -72,7 +72,7 @@ impl Target {
                 site_config
                     .entry_point
                     .to_owned()
-                    .unwrap_or_else(|| format!("./{}}", SITE_ENTRY_POINT)),
+                    .unwrap_or_else(|| format!("./{}", SITE_ENTRY_POINT)),
             )),
             None => Ok(current_dir),
         }
@@ -135,19 +135,21 @@ impl Manifest {
         config_path: PathBuf,
         site: bool,
     ) -> Result<Manifest, failure::Error> {
-        let mut manifest = Manifest::default();
-
-        manifest.name = name.clone();
-        manifest.target_type = target_type.clone();
-
-        manifest.route = Some(String::new());
-        manifest.workers_dev = Some(true);
-        manifest.zone_id = Some(String::new());
-
-        if site {
-            let site = Site::default();
-            manifest.site = Some(site);
-        }
+        let site = if site { Some(Site::default()) } else { None };
+        let manifest = Manifest {
+            account_id: String::new(),
+            env: None,
+            kv_namespaces: None,
+            name: name.clone(),
+            private: None,
+            target_type: target_type.clone(),
+            route: Some(String::new()),
+            routes: None,
+            webpack_config: None,
+            workers_dev: Some(true),
+            zone_id: Some(String::new()),
+            site,
+        };
 
         let toml = toml::to_string(&manifest)?;
         let config_file = config_path.join("wrangler.toml");


### PR DESCRIPTION
# `wrangler generate --site`

``` sh
# creates a new directory structure from an external repo (currently not the real thing)
$ wrangler generate --site
$ cd worker
$ tree
.
├── README.md
├── public
│   └── index.html
├── workers-site
│   ├── index.js
│   ├── package-lock.json
│   └── package.json
└── wrangler.toml
# update the wrangler.toml here to have bucket = "./public"
$ wrangler publish
```

# `wrangler init --site`

inside an existing project, run 

```sh 
$ wrangler init --site
tree (in addition to your existing project)
.
├── workers-site
│   ├── index.js
│   ├── package-lock.json
│   └── package.json
└── wrangler.toml
# update the wrangler.toml with your build asset folder
$ wrangler publish
```