### PR TITLE
Fix asset manifest logic to ensure uploaded files remain on Workers KV remote

### DIFF
--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -60,7 +60,12 @@ fn directory_keys_only(directory: &Path) -> Result<Vec<String>, failure::Error> 
         let entry = entry.unwrap();
         let path = entry.path();
         if path.is_file() {
-            let (key, _) = generate_key(path, directory, None)?;
+            let value = std::fs::read(path)?;
+
+            // Need to base64 encode value
+            let b64_value = base64::encode(&value);
+
+            let (_, key) = generate_key(path, directory, Some(b64_value.clone()))?;
 
             upload_vec.push(key);
         }

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -65,7 +65,7 @@ fn directory_keys_only(directory: &Path) -> Result<Vec<String>, failure::Error> 
             // Need to base64 encode value
             let b64_value = base64::encode(&value);
 
-            let (_, key) = generate_key(path, directory, Some(b64_value.clone()))?;
+            let (_, key) = generate_key(path, directory, Some(b64_value))?;
 
             upload_vec.push(key);
         }


### PR DESCRIPTION
This PR fixes the bug observed yesterday, where `wrangler publish --site` seemed to publish nothing to the Workers KV remote.

The bug was a missing patch of logic related to `wrangler publish --site`'s calling of `sync()`.

When sync is called, it does two things:
1. first, upload keys (using the asset manifest logic, file paths with their value hash appended)
2. second, delete keys that exist on remote but not on local.

The bug was that during the second step, the local keys did not have the file's value hash appended, and wrangler perceived the keys on the local machine as JUST their pathnames. this means that during the second delete step of sync, all the files on the remote (which had just been uploaded) were deleted!
I have now successfully deployed a site from scratch using the wrangler init and wrangler publish --site logic. I made sure to nuke my old static assets namespace and start TOTALLY from scratch to ensure it works as expected.