### PR TITLE
Ensure KV subcommands check for presence of required fields in wrangler.toml

### DIFF
--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -19,6 +19,8 @@ pub fn sync(
     path: &Path,
     verbose: bool,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
+
     // First, upload all existing files in given directory
     if verbose {
         message::info("Preparing to upload updated files...");

--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -20,6 +20,8 @@ pub fn delete(
     namespace_id: &str,
     filename: &Path,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
+
     match kv::interactive_delete(&format!(
         "Are you sure you want to delete all keys in {}?",
         filename.display()

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -20,6 +20,8 @@ pub fn put(
     namespace_id: &str,
     filename: &Path,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
+
     let pairs: Result<Vec<KeyValuePair>, failure::Error> = match &metadata(filename) {
         Ok(file_type) if file_type.is_file() => {
             let data = fs::read_to_string(filename)?;

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -12,6 +12,7 @@ pub fn delete(
     id: &str,
     key: &str,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 
     match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {

--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -11,6 +11,7 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 
 pub fn get(target: &Target, user: GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
         target.account_id,

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -14,6 +14,7 @@ pub fn list(
     namespace_id: &str,
     prefix: Option<&str>,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
     let key_list = KeyList::new(target, user, namespace_id, prefix)?;
 
     print!("["); // Open json list bracket

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -24,6 +24,8 @@ pub fn put(
     expiration: Option<&str>,
     expiration_ttl: Option<&str>,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
+
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",
         target.account_id,

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -148,21 +148,6 @@ pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
         missing_fields.push("account_id")
     };
 
-    match &target.kv_namespaces {
-        Some(kv_namespaces) => {
-            for kv in kv_namespaces {
-                if kv.binding.is_empty() {
-                    missing_fields.push("kv-namespace binding")
-                }
-
-                if kv.id.is_empty() {
-                    missing_fields.push("kv-namespace id")
-                }
-            }
-        }
-        None => {}
-    }
-
     if !missing_fields.is_empty() {
         failure::bail!(
             "Your wrangler.toml is missing the following field(s): {:?}",

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -168,7 +168,7 @@ pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
 
     if !missing_fields.is_empty() {
         failure::bail!(
-            "Your wrangler.toml is missing the following field(s): {:?}" ,
+            "Your wrangler.toml is missing the following field(s): {:?}",
             missing_fields
         )
     } else {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -121,6 +121,9 @@ fn give_status_code_context(status_code: StatusCode) {
 fn help(error_code: u16) -> &'static str {
     // https://api.cloudflare.com/#workers-kv-namespace-errors
     match error_code {
+        7003 | 7000 => {
+            "Your wrangler.toml is likely missing the field \"account_id\", which is required to write to Workers KV."
+        }
         // namespace errors
         10010 | 10011 | 10012 | 10013 | 10014 | 10018 => {
             "Run `wrangler kv:namespace list` to see your existing namespaces with IDs"
@@ -135,6 +138,41 @@ fn help(error_code: u16) -> &'static str {
         // cloudflare account errors
         10017 | 10026 => "Workers KV is a paid feature, please upgrade your account (https://www.cloudflare.com/products/workers-kv/)",
         _ => "",
+    }
+}
+
+pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
+    let mut missing_fields = Vec::new();
+
+    if target.account_id.is_empty() {
+        missing_fields.push("account_id")
+    };
+    if target.name.is_empty() {
+        missing_fields.push("name")
+    };
+
+    match &target.kv_namespaces {
+        Some(kv_namespaces) => {
+            for kv in kv_namespaces {
+                if kv.binding.is_empty() {
+                    missing_fields.push("kv-namespace binding")
+                }
+
+                if kv.id.is_empty() {
+                    missing_fields.push("kv-namespace id")
+                }
+            }
+        }
+        None => {}
+    }
+
+    if !missing_fields.is_empty() {
+        failure::bail!(
+            "Your wrangler.toml is missing the following field(s): {:?}" ,
+            missing_fields
+        )
+    } else {
+        Ok(())
     }
 }
 

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -147,9 +147,6 @@ pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
     if target.account_id.is_empty() {
         missing_fields.push("account_id")
     };
-    if target.name.is_empty() {
-        missing_fields.push("name")
-    };
 
     match &target.kv_namespaces {
         Some(kv_namespaces) => {

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -13,6 +13,8 @@ pub fn create(
     user: GlobalUser,
     binding: &str,
 ) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
+
     let client = kv::api_client(user)?;
 
     if !validate_binding(binding) {

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -7,6 +7,7 @@ use crate::settings::target::Target;
 use crate::terminal::message;
 
 pub fn delete(target: &Target, user: GlobalUser, id: &str) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 
     match kv::interactive_delete(&format!(

--- a/src/commands/kv/namespace/list.rs
+++ b/src/commands/kv/namespace/list.rs
@@ -6,6 +6,7 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 
 pub fn list(target: &Target, user: GlobalUser) -> Result<(), failure::Error> {
+    kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 
     let response = client.request(&ListNamespaces {

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -11,6 +11,7 @@ use crate::settings::target::Target;
 use crate::terminal::message;
 
 pub fn site(target: &Target, user: &GlobalUser) -> Result<WorkersKvNamespace, failure::Error> {
+    kv::validate_target(target)?;
     let client = kv::api_client(user.to_owned())?;
 
     let title = format!("__{}-{}", target.name, "workers_sites_assets");


### PR DESCRIPTION
This PR closes #607.

UPDATE: this PR is no longer WIP; we do not need to validate account_id anymore (scope of ticket has changed as per maintainer meeting 09.23.19).

previously:
It is still considered a WIP given that this only checks for the absence of required fields like account_id for KV subcommands; it does not implement things like account_id validity checking. Do we still want to implement account_id validity checking? I am still keen to get this logic in before 1.4.0 because I don't want KV users to get confused about the error messages referenced in #607; so, I'm okay without account_id validity checking for now.