### PR TITLE
Add error messages for improperly configured buckets

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -98,7 +98,7 @@ fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Err
             let path = Path::new(&bucket);
             if !path.exists() {
                 failure::bail!(
-                    "{} directory for bucket does not exist at \"{}\"",
+                    "{} bucket directory \"{}\" does not exist",
                     emoji::WARN,
                     path.to_string_lossy()
                 )

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -99,12 +99,19 @@ fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Err
             if !path.exists() {
                 if let Some(path_str) = path.to_str() {
                     failure::bail!(
-                        "{} could not find a directory for bucket \"{}\"",
+                        "{} directory for bucket does not exist at \"{}\"",
                         emoji::WARN,
                         path_str
                     )
+                } else {
+                    failure::bail!("{} bucket does not exist")
                 }
-                failure::bail!("{} bucket path is not valid UTF-8")
+            } else if !path.is_dir() {
+                if let Some(path_str) = path.to_str() {
+                    failure::bail!("{} bucket \"{}\" is not a directory", emoji::WARN, path_str)
+                } else {
+                    failure::bail!("{} bucket is not a directory", emoji::WARN)
+                }
             }
             kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
         }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -97,21 +97,17 @@ fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Err
             }
             let path = Path::new(&bucket);
             if !path.exists() {
-                if let Some(path_str) = path.to_str() {
-                    failure::bail!(
-                        "{} directory for bucket does not exist at \"{}\"",
-                        emoji::WARN,
-                        path_str
-                    )
-                } else {
-                    failure::bail!("{} bucket does not exist")
-                }
+                failure::bail!(
+                    "{} directory for bucket does not exist at \"{}\"",
+                    emoji::WARN,
+                    path.to_string_lossy()
+                )
             } else if !path.is_dir() {
-                if let Some(path_str) = path.to_str() {
-                    failure::bail!("{} bucket \"{}\" is not a directory", emoji::WARN, path_str)
-                } else {
-                    failure::bail!("{} bucket is not a directory", emoji::WARN)
-                }
+                failure::bail!(
+                    "{} bucket \"{}\" is not a directory",
+                    emoji::WARN,
+                    path.to_string_lossy()
+                )
             }
             kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
         }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -89,7 +89,23 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
 fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
     for namespace in &target.kv_namespaces() {
         if let Some(bucket) = &namespace.bucket {
+            if bucket.is_empty() {
+                failure::bail!(
+                    "{} You need to specify a bucket directory in your wrangler.toml",
+                    emoji::WARN
+                )
+            }
             let path = Path::new(&bucket);
+            if !path.exists() {
+                if let Some(path_str) = path.to_str() {
+                    failure::bail!(
+                        "{} could not find a directory for bucket \"{}\"",
+                        emoji::WARN,
+                        path_str
+                    )
+                }
+                failure::bail!("{} bucket path is not valid UTF-8")
+            }
             kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
         }
     }


### PR DESCRIPTION
This PR checks if `bucket` is a valid `path` and gives the user an actionable error message if it is not :)

```console
$ wrangler publish                     
🌀  Creating namespace for Workers Site "__my-new-site-workers_sites_assets"
Error: ⚠️  You need to specify a bucket directory in your wrangler.toml                                                                                                                                                                                       
$ wrangler publish
🌀  Creating namespace for Workers Site "__my-new-site-workers_sites_assets"
Error: ⚠️  directory for bucket does not exist at "./no"                                                                                                                                                                                   
$ wrangler publish
🌀  Creating namespace for Workers Site "__my-new-site-workers_sites_assets"
Error: ⚠️  bucket "./public/index.html" is not a directory
```

Fixes #644 