### PR TITLE
Add validation for workers names in wrangler init and wrangler generate

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,9 +1,10 @@
-use crate::settings::target::{Manifest, Site, TargetType};
-use crate::{commands, install};
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::commands::validate_worker_name;
+use crate::settings::target::{Manifest, Site, TargetType};
 use crate::terminal::{emoji, message};
+use crate::{commands, install};
 
 pub fn generate(
     name: &str,
@@ -11,6 +12,8 @@ pub fn generate(
     target_type: Option<TargetType>,
     site: bool,
 ) -> Result<(), failure::Error> {
+    validate_worker_name(name)?;
+
     let target_type = target_type.unwrap_or_else(|| get_target_type(template));
     run_generate(name, template, &target_type)?;
     let config_path = PathBuf::from("./").join(&name);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,7 +1,9 @@
+use std::path::{Path, PathBuf};
+
 use crate::commands;
+use crate::commands::validate_worker_name;
 use crate::settings::target::{Manifest, Site, TargetType};
 use crate::terminal::message;
-use std::path::{Path, PathBuf};
 
 pub fn init(
     name: Option<&str>,
@@ -13,6 +15,8 @@ pub fn init(
     }
     let dirname = get_current_dirname()?;
     let name = name.unwrap_or_else(|| &dirname);
+    validate_worker_name(name)?;
+
     let target_type = target_type.unwrap_or_default();
     let config_path = PathBuf::from("./");
     let initialized_site = if site { Some(Site::default()) } else { None };

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -75,9 +75,8 @@ fn validate_binding(binding: &str) -> Result<(), failure::Error> {
         failure::bail!(
             "A binding can only have alphanumeric and _ characters, and cannot begin with a number"
         )
-    } else {
-        Ok(())
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,9 +45,8 @@ pub fn validate_worker_name(name: &str) -> Result<(), failure::Error> {
     let re = Regex::new(r"^[a-z0-9_][a-z0-9-_]*$").unwrap();
     if !re.is_match(&name) {
         failure::bail!("Worker name \"{}\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.", name)
-    } else {
-        Ok(())
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub use init::init;
 pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;
 pub use publish::publish;
+use regex::Regex;
 pub use subdomain::subdomain;
 pub use whoami::whoami;
 
@@ -36,5 +37,36 @@ pub fn run(mut command: Command, command_name: &str) -> Result<(), failure::Erro
             command_name,
             status
         )
+    }
+}
+
+// Ensures that Worker name is valid.
+pub fn validate_worker_name(name: &str) -> Result<(), failure::Error> {
+    let re = Regex::new(r"^[a-z0-9_][a-z0-9-_]*$").unwrap();
+    if !re.is_match(&name) {
+        failure::bail!("Worker name \"{}\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.", name)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_detect_invalid_worker_name() {
+        let invalid_names = vec!["mySite", "nicky.fun"];
+        for name in invalid_names {
+            assert!(validate_worker_name(name).is_err());
+        }
+    }
+
+    #[test]
+    fn it_can_detect_valid_worker_name() {
+        let valid_names = vec!["my-blog", "blog123", "bloggyity_blog"];
+        for name in valid_names {
+            assert!(validate_worker_name(name).is_ok());
+        }
     }
 }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use crate::commands;
 use crate::commands::kv;
 use crate::commands::subdomain::Subdomain;
+use crate::commands::validate_worker_name;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 
@@ -25,7 +26,8 @@ use crate::terminal::{emoji, message};
 pub fn publish(user: &GlobalUser, target: &mut Target) -> Result<(), failure::Error> {
     log::info!("workers_dev = {}", target.workers_dev);
 
-    validate_target(target)?;
+    validate_target_required_fields_present(target)?;
+    validate_worker_name(&target.name)?;
 
     if let Some(site_config) = &target.site {
         let site_namespace = kv::namespace::site(target, user)?;
@@ -129,7 +131,7 @@ fn publish_to_subdomain(target: &Target, user: &GlobalUser) -> Result<String, fa
     Ok(format!("https://{}.{}.workers.dev", target.name, subdomain))
 }
 
-fn validate_target(target: &Target) -> Result<(), failure::Error> {
+fn validate_target_required_fields_present(target: &Target) -> Result<(), failure::Error> {
     let mut missing_fields = Vec::new();
 
     if target.account_id.is_empty() {


### PR DESCRIPTION
Closes #470 

Contains unit tests; has been tested with `wrangler init` and `wrangler generate`.

Also contains minor edits to binding names validation for consistency.