### PR TITLE
Add preview functionality for static assets

### DIFF
--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -10,11 +10,18 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 use crate::terminal::message;
 
-pub fn site(target: &Target, user: &GlobalUser) -> Result<WorkersKvNamespace, failure::Error> {
+pub fn site(
+    target: &Target,
+    user: &GlobalUser,
+    preview: bool,
+) -> Result<WorkersKvNamespace, failure::Error> {
     kv::validate_target(target)?;
     let client = kv::api_client(user.to_owned())?;
 
-    let title = format!("__{}-{}", target.name, "workers_sites_assets");
+    let title = match preview {
+        false => format!("__{}-{}", target.name, "workers_sites_assets"),
+        true => format!("__{}-{}", target.name, "workers_sites_assets_preview"),
+    };
     let msg = format!("Creating namespace for Workers Site \"{}\"", title);
     message::working(&msg);
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -9,7 +9,7 @@ pub use package::Package;
 use crate::settings::target::kv_namespace::KvNamespace;
 use route::Route;
 
-use upload_form::build_script_upload_form;
+use upload_form::build_script_and_upload_form;
 
 use std::path::Path;
 
@@ -30,15 +30,7 @@ pub fn publish(user: &GlobalUser, target: &mut Target) -> Result<(), failure::Er
     validate_worker_name(&target.name)?;
 
     if let Some(site_config) = target.site.clone() {
-        bind_static_site_contents(user, target, site_config, false)?;
-        // let site_namespace = kv::namespace::site(target, user)?;
-
-        // upload_static_site
-        // target.add_kv_namespace(KvNamespace {
-        //     binding: "__STATIC_CONTENT".to_string(),
-        //     id: site_namespace.id,
-        //     bucket: Some(site_config.bucket.to_owned()),
-        // });
+        bind_static_site_contents(user, target, &site_config, false)?;
     }
 
     upload_buckets(target, user)?;
@@ -73,7 +65,7 @@ fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Err
 
     let client = http::auth_client(user);
 
-    let script_upload_form = build_script_upload_form(target)?;
+    let script_upload_form = build_script_and_upload_form(target)?;
 
     let mut res = client
         .put(&worker_addr)

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -13,7 +13,6 @@ use upload_form::build_script_and_upload_form;
 
 use std::path::Path;
 
-use crate::commands;
 use crate::commands::kv;
 use crate::commands::subdomain::Subdomain;
 use crate::commands::validate_worker_name;
@@ -34,8 +33,7 @@ pub fn publish(user: &GlobalUser, target: &mut Target) -> Result<(), failure::Er
     }
 
     upload_buckets(target, user)?;
-    commands::build(&target)?;
-    publish_script(&user, &target)?;
+    build_and_publish_script(&user, &target)?;
 
     Ok(())
 }
@@ -57,7 +55,7 @@ pub fn bind_static_site_contents(
     Ok(())
 }
 
-fn publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
     let worker_addr = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}",
         target.account_id, target.name,

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -33,7 +33,7 @@ struct V4ApiResponse {
 }
 
 pub fn upload_and_get_id(
-    target: &Target,
+    target: &mut Target,
     user: Option<&GlobalUser>,
 ) -> Result<String, failure::Error> {
     let preview = match &user {
@@ -45,6 +45,12 @@ pub fn upload_and_get_id(
             if missing_fields.is_empty() {
                 let client = http::auth_client(&user);
 
+                // todo add sites to bucket here
+                if let Some(site_config) = &target.site {
+                    publish::bind_static_site_contents(user, target, site_config, true);
+                }
+
+                publish::upload_buckets(target, user);
                 authenticated_upload(&client, &target)?
             } else {
                 message::warn(&format!(

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -6,6 +6,7 @@ use reqwest::multipart::{Form, Part};
 use std::fs;
 use std::path::Path;
 
+use crate::commands;
 use crate::commands::build::wranglerjs;
 use crate::commands::kv::bucket::directory_keys_values;
 use crate::settings::binding;
@@ -19,7 +20,10 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_upload_form(target: &Target) -> Result<Form, failure::Error> {
+pub fn build_script_and_upload_form(target: &Target) -> Result<Form, failure::Error> {
+    // Build the script before uploading.
+    commands::build(&target)?;
+
     let target_type = &target.target_type;
     let kv_namespaces = target.kv_namespaces();
     match target_type {


### PR DESCRIPTION
This PR closes #599. 

Its main contribution is that, when a preview is authenticated, it uses a special `*_preview` Workers KV namespace to allow someone to upload their static assets for use by the preview service (this avoids clobbering production and preview workers instances).

As part of this PR, this code does a small refactor of the preview and publication code. Namely, for preview and publish, it bundles the step of building the script's (`commands::build`) next to the step of generating the script's upload form. This function has been renamed `build_script_and_upload_form` to reflect this change accurately. This change ensures that script actions are bundled together. (When asset upload for preview was first implemented, it awkwardly had to happen between code building and code publication. This refactor should better delineate steps.)

This PR also ensures that the response for a static assets worker is not returned to the commandline, because it will be large and unwieldy. Instead, you get 

```console
$ wrangler preview
 Creating namespace for Workers Site "__blog-butt-workers_sites_assets_preview"
 Success
⬇️ Installing wasm-pack...
 Built successfully, built project size is 4 KiB.
 GET https://00000000000000000000000000000000.cloudflareworkers.com
 Your Worker is a Workers Sites preview, please preview on browser window.

```

I have tested that:
1. This static assets preview works; a static site's links can be followed on the preview page.
1. Preview and live reload functionality has remained unchanged for all workers types (JS, webpack, rust)
1. Publish still works as expected for all workers types.

I have noticed the following:
1. The preview service is substantially slower than production. Perhaps we should provide a disclaimer.
1. Live reload for the preview service doesn't work yet. This can be implemented by putting the assets upload logic in `watch_for_changes()`. Tracked in #653.