### PR TITLE
Remove link to 000000000000000000.cloudflareworkers.com

### DIFF
--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -101,8 +101,6 @@ fn open_browser(url: &str) -> Result<(), failure::Error> {
 
 fn get(cookie: String, client: &reqwest::Client) -> Result<String, failure::Error> {
     let res = client.get(PREVIEW_ADDRESS).header("Cookie", cookie).send();
-    let msg = format!("GET {}", PREVIEW_ADDRESS);
-    message::preview(&msg);
     Ok(res?.text()?)
 }
 


### PR DESCRIPTION
This PR removes confusing output from `wrangler preview` that links to the preview endpoint