### PR TITLE
Custom webpack configuration behavior

### DIFF
--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -160,11 +160,12 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     command.arg(format!("--wasm-binding={}", bundle.get_wasm_binding()));
 
     let webpack_config_path = if let Some(webpack_config) = &target.webpack_config {
-        Some(PathBuf::from(webpack_config.clone()))
+        Some(PathBuf::from(&webpack_config))
     } else if target.site.is_none() {
         message::warn("In Wrangler v1.6.0, you will need to include a webpack_config field in your wrangler.toml to build with a custom webpack configuration.");
         Some(PathBuf::from("webpack.config.js".to_string()))
     } else {
+        // don't use `webpack.config.js` if this project is a site
         None
     };
 

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -159,7 +159,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
 
     command.arg(format!("--wasm-binding={}", bundle.get_wasm_binding()));
 
-    let webpack_config_path: Option<PathBuf> = if let Some(webpack_config) = &target.webpack_config {
+    let webpack_config_path = if let Some(webpack_config) = &target.webpack_config {
         // require webpack_config in wrangler.toml to use it in sites
         Some(PathBuf::from(&webpack_config))
     } else if target.site.is_none() {


### PR DESCRIPTION
This PR does two things:

1) If users are deploying a non-site project and have a `webpack.config.js` file, we use it to build their worker. This will be deprecated in 1.6.0 in favor of specifying a `webpack_config` field in `wrangler.toml`.

2) If users are deploying a site project and have a `webpack.config.js` file, we will not use it to build their worker. This is because it's probably for their react app and not the worker.

Fixes #296