### PR TITLE
Ignore uploading node_modules

### DIFF
--- a/src/commands/kv/bucket/manifest.rs
+++ b/src/commands/kv/bucket/manifest.rs
@@ -1,0 +1,3 @@
+use std::collections::HashMap;
+
+pub type AssetManifest = HashMap<String, String>;

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -80,10 +80,10 @@ fn directory_keys_only(directory: &Path) -> Result<Vec<String>, failure::Error> 
 
 // todo(gabbi): Replace all the logic below with a proper .wignore implementation
 // when possible.
-const KNOWN_UNNECESSARY_DIRS: &'static [&str] = &[
+const KNOWN_UNNECESSARY_DIRS: &[&str] = &[
     "node_modules", // npm vendoring
 ];
-const KNOWN_UNNECESSARY_FILE_PREFIXES: &'static [&str] = &[
+const KNOWN_UNNECESSARY_FILE_PREFIXES: &[&str] = &[
     ".", // hidden files
 ];
 fn is_ignored(entry: &DirEntry) -> bool {

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -84,8 +84,7 @@ const KNOWN_UNNECESSARY_DIRS: &'static [&str] = &[
     "node_modules", // npm vendoring
 ];
 const KNOWN_UNNECESSARY_FILE_PREFIXES: &'static [&str] = &[
-    "component---", // Gatsby sourcemaps
-    ".",            // hidden files
+    ".", // hidden files
 ];
 fn is_ignored(entry: &DirEntry) -> bool {
     let stem = entry.file_name().to_str().unwrap();

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -26,7 +26,7 @@ pub fn directory_keys_values(
     let mut upload_vec: Vec<KeyValuePair> = Vec::new();
     let mut key_manifest: HashMap<String, String> = HashMap::new();
 
-    for entry in WalkDir::new(directory) {
+    for entry in WalkDir::new(directory).into_iter().filter_entry(|e| !is_ignored(e)) {
         let entry = entry.unwrap();
         let path = entry.path();
         if path.is_file() {
@@ -72,6 +72,21 @@ fn directory_keys_only(directory: &Path) -> Result<Vec<String>, failure::Error> 
         }
     }
     Ok(upload_vec)
+}
+
+// todo(gabbi): Replace all the logic below with a proper .wignore implementation
+// when possible.
+const KNOWN_UNNECESSARY_PREFIXES: &'static [&str] = &[
+    "node_modules/", // npm vendoring
+    "component---",  // Gatsby sourcemaps
+];
+fn is_ignored(key: &str) -> bool {
+    for prefix in KNOWN_UNNECESSARY_PREFIXES {
+        if key.starts_with(prefix) {
+            return true;
+        }
+    }
+    false
 }
 
 // Courtesy of Steve Klabnik's PoC :) Used for bulk operations (write, delete)

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -219,4 +219,29 @@ mod tests {
         let expected_count = 0;
         assert!(actual_count == expected_count);
     }
+
+    #[test]
+    fn it_can_allow_unfiltered_files() {
+        let file_name = "my_file";
+        // If test file already exists, delete it.
+        if fs::metadata(file_name).is_ok() {
+            fs::remove_file(file_name).unwrap();
+        }
+
+        fs::File::create(file_name).unwrap();
+
+        let mut actual_count = 0;
+        for _ in WalkDir::new(file_name)
+            .into_iter()
+            .filter_entry(|e| !is_ignored(e))
+        {
+            actual_count = actual_count + 1;
+        }
+
+        fs::remove_file(file_name).unwrap();
+
+        // No iterations should happen above because dotfiles are ignored.
+        let expected_count = 1;
+        assert!(actual_count == expected_count);
+    }
 }

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -192,11 +192,11 @@ fn generate_path_with_hash(path: &Path, hashed_value: String) -> Result<String, 
 mod tests {
     use super::*;
     use regex::Regex;
-    use std::path::{Path, PathBuf};
     use std::fs;
+    use std::path::{Path, PathBuf};
     use walkdir::WalkDir;
-  
-  #[test]
+
+    #[test]
     fn it_can_ignore_dir() {
         let dir_name = "node_modules";
         // If test dir already exists, delete it.
@@ -270,6 +270,7 @@ mod tests {
         // No iterations should happen above because dotfiles are ignored.
         let expected_count = 1;
         assert!(actual_count == expected_count);
+    }
 
     #[test]
     fn it_inserts_hash_before_extension() {

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -1,14 +1,15 @@
 extern crate base64;
 
+mod manifest;
 mod sync;
 mod upload;
 
 use data_encoding::HEXLOWER;
 use sha2::{Digest, Sha256};
 
+pub use manifest::AssetManifest;
 pub use sync::sync;
 
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -22,9 +23,9 @@ use crate::terminal::message;
 pub fn directory_keys_values(
     directory: &Path,
     verbose: bool,
-) -> Result<(Vec<KeyValuePair>, HashMap<String, String>), failure::Error> {
+) -> Result<(Vec<KeyValuePair>, AssetManifest), failure::Error> {
     let mut upload_vec: Vec<KeyValuePair> = Vec::new();
-    let mut key_manifest: HashMap<String, String> = HashMap::new();
+    let mut asset_manifest: AssetManifest = AssetManifest::new();
 
     for entry in WalkDir::new(directory)
         .into_iter()
@@ -52,10 +53,10 @@ pub fn directory_keys_values(
                 base64: Some(true),
             });
 
-            key_manifest.insert(url_safe_path, key);
+            asset_manifest.insert(url_safe_path, key);
         }
     }
-    Ok((upload_vec, key_manifest))
+    Ok((upload_vec, asset_manifest))
 }
 
 // Returns only the hashed keys for a directory's files.
@@ -92,6 +93,7 @@ fn is_ignored(entry: &DirEntry) -> bool {
     for prefix in KNOWN_UNNECESSARY_FILE_PREFIXES {
         if stem.starts_with(prefix) {
             // Just need to check prefix
+            message::info(&format!("ignoring file {}", stem));
             return true;
         }
     }
@@ -100,6 +102,7 @@ fn is_ignored(entry: &DirEntry) -> bool {
     for dir in KNOWN_UNNECESSARY_DIRS {
         if stem == *dir {
             // Need to check for full equality here
+            message::info(&format!("ignoring directory {}", dir));
             return true;
         }
     }

--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -3,6 +3,8 @@ use std::fs::metadata;
 use std::iter::FromIterator;
 use std::path::Path;
 
+use super::manifest::AssetManifest;
+
 use crate::commands::kv;
 use crate::commands::kv::bucket::directory_keys_only;
 use crate::commands::kv::bucket::upload::upload_files;
@@ -18,7 +20,7 @@ pub fn sync(
     namespace_id: &str,
     path: &Path,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<AssetManifest, failure::Error> {
     kv::validate_target(target)?;
     // First, upload all changed files in given local directory (aka replace files
     // in Workers KV that are now stale).
@@ -41,7 +43,7 @@ pub fn sync(
     if verbose {
         message::info("Preparing to upload updated files...");
     }
-    upload_files(
+    let asset_manifest = upload_files(
         target,
         user.clone(),
         namespace_id,
@@ -74,5 +76,5 @@ pub fn sync(
     }
 
     message::success("Success");
-    Ok(())
+    Ok(asset_manifest)
 }

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -99,26 +99,11 @@ fn call_put_bulk_api(
 fn filter_files(pairs: Vec<KeyValuePair>, already_uploaded: &HashSet<String>) -> Vec<KeyValuePair> {
     let mut filtered_pairs: Vec<KeyValuePair> = Vec::new();
     for pair in pairs {
-        if !already_uploaded.contains(&pair.key) && !contains_ignored_prefix(&pair.key) {
+        if !already_uploaded.contains(&pair.key) {
             filtered_pairs.push(pair);
         }
     }
     filtered_pairs
-}
-
-// todo(gabbi): Replace all the logic below with a proper .wignore implementation
-// when possible.
-const KNOWN_UNNECESSARY_PREFIXES: &'static [&str] = &[
-    "node_modules/", // npm vendoring
-    "component---",  // Gatsby sourcemaps
-];
-fn contains_ignored_prefix(key: &str) -> bool {
-    for prefix in KNOWN_UNNECESSARY_PREFIXES {
-        if key.starts_with(prefix) {
-            return true;
-        }
-    }
-    false
 }
 
 // Ensure that all key-value pairs being uploaded have valid sizes (this ensures that

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -141,9 +141,8 @@ mod tests {
     use std::collections::HashSet;
     use std::path::Path;
 
-    use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
     use crate::commands::kv::bucket::generate_path_and_key;
-
+    use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 
     #[test]
     fn it_can_filter_preexisting_files() {

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -99,7 +99,7 @@ fn call_put_bulk_api(
 fn filter_files(pairs: Vec<KeyValuePair>, already_uploaded: &HashSet<String>) -> Vec<KeyValuePair> {
     let mut filtered_pairs: Vec<KeyValuePair> = Vec::new();
     for pair in pairs {
-        if !already_uploaded.contains(&pair.key) && !if_ignored_prefix(&pair.key) {
+        if !already_uploaded.contains(&pair.key) && !contains_ignored_prefix(&pair.key) {
             filtered_pairs.push(pair);
         }
     }
@@ -112,7 +112,7 @@ const KNOWN_UNNECESSARY_PREFIXES: &'static [&str] = &[
     "node_modules/", // npm vendoring
     "component---",  // Gatsby sourcemaps
 ];
-fn if_ignored_prefix(key: &str) -> bool {
+fn contains_ignored_prefix(key: &str) -> bool {
     for prefix in KNOWN_UNNECESSARY_PREFIXES {
         if key.starts_with(prefix) {
             return true;
@@ -231,7 +231,7 @@ mod tests {
     fn it_can_detect_ignored_prefix() {
         let paths = ["node_modules/file.js", "component---src-pages-post-js-c6d1c3aab5c008b72fa8.js.map-b3fd6703031f027b11dd2dc7e3448fe3838efa53e5c6436c4aa3dd9c721cc7e4"];
         for path in &paths {
-            assert!(if_ignored_prefix(path));
+            assert!(contains_ignored_prefix(path));
         }
     }
 }

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -1,3 +1,5 @@
+use super::manifest::AssetManifest;
+
 use std::collections::HashSet;
 use std::fs::metadata;
 use std::path::Path;
@@ -25,11 +27,11 @@ pub fn upload_files(
     path: &Path,
     exclude_keys: Option<&HashSet<String>>,
     verbose: bool,
-) -> Result<(), failure::Error> {
-    let mut pairs: Vec<KeyValuePair> = match &metadata(path) {
+) -> Result<AssetManifest, failure::Error> {
+    let (mut pairs, asset_manifest): (Vec<KeyValuePair>, AssetManifest) = match &metadata(path) {
         Ok(file_type) if file_type.is_dir() => {
-            let (p, _) = directory_keys_values(path, verbose)?;
-            Ok(p)
+            let (pairs, asset_manifest) = directory_keys_values(path, verbose)?;
+            Ok((pairs, asset_manifest))
         }
         Ok(_file_type) => {
             // any other file types (files, symlinks)
@@ -78,7 +80,7 @@ pub fn upload_files(
         }
     }
 
-    Ok(())
+    Ok(asset_manifest)
 }
 
 fn call_put_bulk_api(

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -211,12 +211,4 @@ mod tests {
             idx = idx + 1;
         }
     }
-
-    #[test]
-    fn it_can_detect_ignored_prefix() {
-        let paths = ["node_modules/file.js", "component---src-pages-post-js-c6d1c3aab5c008b72fa8.js.map-b3fd6703031f027b11dd2dc7e3448fe3838efa53e5c6436c4aa3dd9c721cc7e4"];
-        for path in &paths {
-            assert!(contains_ignored_prefix(path));
-        }
-    }
 }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -14,6 +14,7 @@ use upload_form::build_script_and_upload_form;
 use std::path::Path;
 
 use crate::commands::kv;
+use crate::commands::kv::bucket::AssetManifest;
 use crate::commands::subdomain::Subdomain;
 use crate::commands::validate_worker_name;
 use crate::http;
@@ -32,8 +33,8 @@ pub fn publish(user: &GlobalUser, target: &mut Target) -> Result<(), failure::Er
         bind_static_site_contents(user, target, &site_config, false)?;
     }
 
-    upload_buckets(target, user)?;
-    build_and_publish_script(&user, &target)?;
+    let asset_manifest = upload_buckets(target, user)?;
+    build_and_publish_script(&user, &target, asset_manifest)?;
 
     Ok(())
 }
@@ -55,7 +56,11 @@ pub fn bind_static_site_contents(
     Ok(())
 }
 
-fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+fn build_and_publish_script(
+    user: &GlobalUser,
+    target: &Target,
+    asset_manifest: Option<AssetManifest>,
+) -> Result<(), failure::Error> {
     let worker_addr = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}",
         target.account_id, target.name,
@@ -63,7 +68,7 @@ fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), fa
 
     let client = http::auth_client(user);
 
-    let script_upload_form = build_script_and_upload_form(target)?;
+    let script_upload_form = build_script_and_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .put(&worker_addr)
@@ -97,7 +102,11 @@ fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), fa
     Ok(())
 }
 
-pub fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
+pub fn upload_buckets(
+    target: &Target,
+    user: &GlobalUser,
+) -> Result<Option<AssetManifest>, failure::Error> {
+    let mut asset_manifest = None;
     for namespace in &target.kv_namespaces() {
         if let Some(bucket) = &namespace.bucket {
             if bucket.is_empty() {
@@ -120,11 +129,20 @@ pub fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure:
                     path.display()
                 )
             }
-            kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
+            let manifest_result =
+                kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
+            if target.site.is_some() {
+                if asset_manifest.is_none() {
+                    asset_manifest = Some(manifest_result)
+                } else {
+                    // only site manifest should be returned
+                    unreachable!()
+                }
+            }
         }
     }
 
-    Ok(())
+    Ok(asset_manifest)
 }
 
 fn build_subdomain_request() -> String {

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -1,3 +1,4 @@
+use crate::commands::kv::bucket::AssetManifest;
 use crate::commands::publish;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
@@ -52,8 +53,8 @@ pub fn build_and_upload(
                     publish::bind_static_site_contents(user, target, &site_config, true)?;
                 }
 
-                publish::upload_buckets(target, user)?;
-                authenticated_upload(&client, &target)?
+                let asset_manifest = publish::upload_buckets(target, user)?;
+                authenticated_upload(&client, &target, asset_manifest)?
             } else {
                 message::warn(&format!(
                     "Your wrangler.toml is missing the following fields: {:?}",
@@ -119,14 +120,18 @@ fn validate(target: &Target) -> Vec<&str> {
     missing_fields
 }
 
-fn authenticated_upload(client: &Client, target: &Target) -> Result<Preview, failure::Error> {
+fn authenticated_upload(
+    client: &Client,
+    target: &Target,
+    asset_manifest: Option<AssetManifest>,
+) -> Result<Preview, failure::Error> {
     let create_address = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}/preview",
         target.account_id, target.name
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_script_and_upload_form(target)?;
+    let script_upload_form = publish::build_script_and_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .post(&create_address)
@@ -156,9 +161,9 @@ fn unauthenticated_upload(client: &Client, target: &Target) -> Result<Preview, f
         );
         let mut target = target.clone();
         target.kv_namespaces = None;
-        publish::build_script_and_upload_form(&target)?
+        publish::build_script_and_upload_form(&target, None)?
     } else {
-        publish::build_script_and_upload_form(&target)?
+        publish::build_script_and_upload_form(&target, None)?
     };
 
     let mut res = client

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use crate::commands;
 use crate::commands::build::wranglerjs;
-use crate::commands::kv::bucket::directory_keys_values;
+use crate::commands::kv::bucket::AssetManifest;
 use crate::settings::binding;
 use crate::settings::metadata::Metadata;
 use crate::settings::target::kv_namespace;
@@ -20,7 +20,10 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_and_upload_form(target: &Target) -> Result<Form, failure::Error> {
+pub fn build_script_and_upload_form(
+    target: &Target,
+    asset_manifest: Option<AssetManifest>,
+) -> Result<Form, failure::Error> {
     // Build the script before uploading.
     commands::build(&target)?;
 
@@ -75,11 +78,11 @@ pub fn build_script_and_upload_form(target: &Target) -> Result<Form, failure::Er
 
             let mut text_blobs = Vec::new();
 
-            if let Some(site) = &target.site {
+            if let Some(asset_manifest) = asset_manifest {
                 log::info!("adding __STATIC_CONTENT_MANIFEST");
                 let binding = "__STATIC_CONTENT_MANIFEST".to_string();
-                let asset_manifest = get_asset_manifest(&site.bucket)?;
-                let text_blob = TextBlob::new(asset_manifest, binding)?;
+                let asset_manifest_blob = get_asset_manifest_blob(asset_manifest)?;
+                let text_blob = TextBlob::new(asset_manifest_blob, binding)?;
                 text_blobs.push(text_blob);
             }
 
@@ -90,11 +93,9 @@ pub fn build_script_and_upload_form(target: &Target) -> Result<Form, failure::Er
     }
 }
 
-fn get_asset_manifest(directory: &str) -> Result<String, failure::Error> {
-    let directory = Path::new(&directory);
-    let (_, manifest) = directory_keys_values(directory, false)?;
-    let manifest = serde_json::to_string(&manifest)?;
-    Ok(manifest)
+fn get_asset_manifest_blob(asset_manifest: AssetManifest) -> Result<String, failure::Error> {
+    let asset_manifest = serde_json::to_string(&asset_manifest)?;
+    Ok(asset_manifest)
 }
 
 fn build_form(assets: &ProjectAssets) -> Result<Form, failure::Error> {
@@ -105,7 +106,8 @@ fn build_form(assets: &ProjectAssets) -> Result<Form, failure::Error> {
     form = add_metadata(form, assets)?;
     form = add_files(form, assets)?;
 
-    log::info!("{:#?}", &form);
+    log::info!("building form");
+    log::info!("{:?}", &form);
 
     Ok(form)
 }


### PR DESCRIPTION
This PR closes #667. It is a first overture towards one day handling #464, aka adding `.wignore` functionality.

This PR introduces logic for filtering files the bucket `upload` function traverses. Namely, it creates a base for filtering two types of items:
1. directories
1. files with certain prefixes (like dotfiles).

Directories are entirely filtered if they match a certain directory name, in this case `node_modules`. Files are filtered if their prefix matches one that is intended to be filtered.

This reduces the number of times someone is likely to hit the KV maximum size API error via node_module or Gatsby site sourcemap uploads.