### PR TITLE
Add message for ignoring files

### DIFF
--- a/src/commands/kv/bucket/manifest.rs
+++ b/src/commands/kv/bucket/manifest.rs
@@ -1,0 +1,3 @@
+use std::collections::HashMap;
+
+pub type AssetManifest = HashMap<String, String>;

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -1,14 +1,15 @@
 extern crate base64;
 
+mod manifest;
 mod sync;
 mod upload;
 
 use data_encoding::HEXLOWER;
 use sha2::{Digest, Sha256};
 
+pub use manifest::AssetManifest;
 pub use sync::sync;
 
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -22,11 +23,9 @@ use crate::terminal::message;
 pub fn directory_keys_values(
     directory: &Path,
     verbose: bool,
-) -> Result<(Vec<KeyValuePair>, HashMap<String, String>), failure::Error> {
+) -> Result<(Vec<KeyValuePair>, AssetManifest), failure::Error> {
     let mut upload_vec: Vec<KeyValuePair> = Vec::new();
-    let mut key_manifest: HashMap<String, String> = HashMap::new();
-
-    log::info!("entering directory keys values");
+    let mut asset_manifest: AssetManifest = AssetManifest::new();
 
     for entry in WalkDir::new(directory)
         .into_iter()
@@ -54,10 +53,10 @@ pub fn directory_keys_values(
                 base64: Some(true),
             });
 
-            key_manifest.insert(url_safe_path, key);
+            asset_manifest.insert(url_safe_path, key);
         }
     }
-    Ok((upload_vec, key_manifest))
+    Ok((upload_vec, asset_manifest))
 }
 
 // Returns only the hashed keys for a directory's files.

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -26,6 +26,8 @@ pub fn directory_keys_values(
     let mut upload_vec: Vec<KeyValuePair> = Vec::new();
     let mut key_manifest: HashMap<String, String> = HashMap::new();
 
+    log::info!("entering directory keys values");
+
     for entry in WalkDir::new(directory)
         .into_iter()
         .filter_entry(|e| !is_ignored(e))
@@ -92,6 +94,7 @@ fn is_ignored(entry: &DirEntry) -> bool {
     for prefix in KNOWN_UNNECESSARY_FILE_PREFIXES {
         if stem.starts_with(prefix) {
             // Just need to check prefix
+            message::info(&format!("ignoring file {}", stem));
             return true;
         }
     }
@@ -100,6 +103,7 @@ fn is_ignored(entry: &DirEntry) -> bool {
     for dir in KNOWN_UNNECESSARY_DIRS {
         if stem == *dir {
             // Need to check for full equality here
+            message::info(&format!("ignoring directory {}", dir));
             return true;
         }
     }

--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -3,6 +3,8 @@ use std::fs::metadata;
 use std::iter::FromIterator;
 use std::path::Path;
 
+use super::manifest::AssetManifest;
+
 use crate::commands::kv;
 use crate::commands::kv::bucket::directory_keys_only;
 use crate::commands::kv::bucket::upload::upload_files;
@@ -18,7 +20,7 @@ pub fn sync(
     namespace_id: &str,
     path: &Path,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<AssetManifest, failure::Error> {
     kv::validate_target(target)?;
     // First, upload all changed files in given local directory (aka replace files
     // in Workers KV that are now stale).
@@ -41,7 +43,7 @@ pub fn sync(
     if verbose {
         message::info("Preparing to upload updated files...");
     }
-    upload_files(
+    let asset_manifest = upload_files(
         target,
         user.clone(),
         namespace_id,
@@ -74,5 +76,5 @@ pub fn sync(
     }
 
     message::success("Success");
-    Ok(())
+    Ok(asset_manifest)
 }

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -1,3 +1,5 @@
+use super::manifest::AssetManifest;
+
 use std::collections::HashSet;
 use std::fs::metadata;
 use std::path::Path;
@@ -25,11 +27,11 @@ pub fn upload_files(
     path: &Path,
     exclude_keys: Option<&HashSet<String>>,
     verbose: bool,
-) -> Result<(), failure::Error> {
-    let mut pairs: Vec<KeyValuePair> = match &metadata(path) {
+) -> Result<AssetManifest, failure::Error> {
+    let (mut pairs, asset_manifest): (Vec<KeyValuePair>, AssetManifest) = match &metadata(path) {
         Ok(file_type) if file_type.is_dir() => {
-            let (p, _) = directory_keys_values(path, verbose)?;
-            Ok(p)
+            let (pairs, asset_manifest) = directory_keys_values(path, verbose)?;
+            Ok((pairs, asset_manifest))
         }
         Ok(_file_type) => {
             // any other file types (files, symlinks)
@@ -78,7 +80,7 @@ pub fn upload_files(
         }
     }
 
-    Ok(())
+    Ok(asset_manifest)
 }
 
 fn call_put_bulk_api(

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -14,6 +14,7 @@ use upload_form::build_script_and_upload_form;
 use std::path::Path;
 
 use crate::commands::kv;
+use crate::commands::kv::bucket::AssetManifest;
 use crate::commands::subdomain::Subdomain;
 use crate::commands::validate_worker_name;
 use crate::http;
@@ -32,8 +33,8 @@ pub fn publish(user: &GlobalUser, target: &mut Target) -> Result<(), failure::Er
         bind_static_site_contents(user, target, &site_config, false)?;
     }
 
-    upload_buckets(target, user)?;
-    build_and_publish_script(&user, &target)?;
+    let asset_manifest = upload_buckets(target, user)?;
+    build_and_publish_script(&user, &target, asset_manifest)?;
 
     Ok(())
 }
@@ -55,7 +56,11 @@ pub fn bind_static_site_contents(
     Ok(())
 }
 
-fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+fn build_and_publish_script(
+    user: &GlobalUser,
+    target: &Target,
+    asset_manifest: Option<AssetManifest>,
+) -> Result<(), failure::Error> {
     let worker_addr = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}",
         target.account_id, target.name,
@@ -63,7 +68,7 @@ fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), fa
 
     let client = http::auth_client(user);
 
-    let script_upload_form = build_script_and_upload_form(target)?;
+    let script_upload_form = build_script_and_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .put(&worker_addr)
@@ -97,7 +102,11 @@ fn build_and_publish_script(user: &GlobalUser, target: &Target) -> Result<(), fa
     Ok(())
 }
 
-pub fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
+pub fn upload_buckets(
+    target: &Target,
+    user: &GlobalUser,
+) -> Result<Option<AssetManifest>, failure::Error> {
+    let mut asset_manifest = None;
     for namespace in &target.kv_namespaces() {
         if let Some(bucket) = &namespace.bucket {
             if bucket.is_empty() {
@@ -120,11 +129,20 @@ pub fn upload_buckets(target: &Target, user: &GlobalUser) -> Result<(), failure:
                     path.display()
                 )
             }
-            kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
+            let manifest_result =
+                kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
+            if target.site.is_some() {
+                if asset_manifest.is_none() {
+                    asset_manifest = Some(manifest_result)
+                } else {
+                    // only site manifest should be returned
+                    unreachable!()
+                }
+            }
         }
     }
 
-    Ok(())
+    Ok(asset_manifest)
 }
 
 fn build_subdomain_request() -> String {

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -1,3 +1,4 @@
+use crate::commands::kv::bucket::AssetManifest;
 use crate::commands::publish;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
@@ -52,8 +53,8 @@ pub fn build_and_upload(
                     publish::bind_static_site_contents(user, target, &site_config, true)?;
                 }
 
-                publish::upload_buckets(target, user)?;
-                authenticated_upload(&client, &target)?
+                let asset_manifest = publish::upload_buckets(target, user)?;
+                authenticated_upload(&client, &target, asset_manifest)?
             } else {
                 message::warn(&format!(
                     "Your wrangler.toml is missing the following fields: {:?}",
@@ -119,14 +120,18 @@ fn validate(target: &Target) -> Vec<&str> {
     missing_fields
 }
 
-fn authenticated_upload(client: &Client, target: &Target) -> Result<Preview, failure::Error> {
+fn authenticated_upload(
+    client: &Client,
+    target: &Target,
+    asset_manifest: Option<AssetManifest>,
+) -> Result<Preview, failure::Error> {
     let create_address = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}/preview",
         target.account_id, target.name
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_script_and_upload_form(target)?;
+    let script_upload_form = publish::build_script_and_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .post(&create_address)
@@ -156,9 +161,9 @@ fn unauthenticated_upload(client: &Client, target: &Target) -> Result<Preview, f
         );
         let mut target = target.clone();
         target.kv_namespaces = None;
-        publish::build_script_and_upload_form(&target)?
+        publish::build_script_and_upload_form(&target, None)?
     } else {
-        publish::build_script_and_upload_form(&target)?
+        publish::build_script_and_upload_form(&target, None)?
     };
 
     let mut res = client

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -105,7 +105,8 @@ fn build_form(assets: &ProjectAssets) -> Result<Form, failure::Error> {
     form = add_metadata(form, assets)?;
     form = add_files(form, assets)?;
 
-    log::info!("{:#?}", &form);
+    log::info!("building form");
+    log::info!("{:?}", &form);
 
     Ok(form)
 }


### PR DESCRIPTION
This should be removed once we have solved #464 and also depends on a refactor by @ashleymichal so we don't call `directory_keys_values` twice.

Current state:

```console
$ wrangler publish
🌀  Creating namespace for Workers Site "__my-site-workers_sites_assets"
💁  ignoring file .DS_Store
💁  ignoring directory node_modules
💁  ignoring file .dont-upload
✨  Success
✨  Built successfully, built project size is 11 KiB.
💁  ignoring file .DS_Store
💁  ignoring directory node_modules
💁  ignoring file .dont-upload
✨  Successfully published your script to https://my-site.avery.workers.dev
```