### PR TITLE
Add live reload for static sites

### DIFF
--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -74,7 +74,7 @@ pub fn watch_and_build(
             });
         }
         TargetType::Webpack => {
-            wranglerjs::run_build_and_watch(&target, tx)?;
+            wranglerjs::run_build_and_watch(target, tx)?;
         }
     }
 

--- a/src/commands/build/watch/mod.rs
+++ b/src/commands/build/watch/mod.rs
@@ -74,7 +74,7 @@ pub fn watch_and_build(
             });
         }
         TargetType::Webpack => {
-            wranglerjs::run_build_and_watch(target, tx)?;
+            wranglerjs::run_build_and_watch(&target, tx)?;
         }
     }
 

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -77,6 +77,8 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
             if Path::new(&bucket).exists() {
                 watcher.watch(&bucket, RecursiveMode::Recursive)?;
                 info!("watching static sites asset file {:?}", &bucket);
+            } else {
+                failure::bail!("Attempting to watch static assets bucket \"{}\" which doesn't exist", bucket);
             }
         }
 

--- a/src/commands/build/wranglerjs/mod.rs
+++ b/src/commands/build/wranglerjs/mod.rs
@@ -78,7 +78,10 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
                 watcher.watch(&bucket, RecursiveMode::Recursive)?;
                 info!("watching static sites asset file {:?}", &bucket);
             } else {
-                failure::bail!("Attempting to watch static assets bucket \"{}\" which doesn't exist", bucket);
+                failure::bail!(
+                    "Attempting to watch static assets bucket \"{}\" which doesn't exist",
+                    bucket
+                );
             }
         }
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -47,6 +47,13 @@ pub fn bind_static_site_contents(
 ) -> Result<(), failure::Error> {
     let site_namespace = kv::namespace::site(target, user, preview)?;
 
+    // Check if namespace already is in namespace list
+    for namespace in target.kv_namespaces() {
+        if namespace.id == site_namespace.id {
+            return Ok(()); // Sites binding already exists; ignore
+        }
+    }
+
     target.add_kv_namespace(KvNamespace {
         binding: "__STATIC_CONTENT".to_string(),
         id: site_namespace.id,

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -52,7 +52,6 @@ pub fn build_and_upload(
                     publish::upload_buckets(target, user)?;
                 }
 
-                publish::upload_buckets(target, user)?;
                 authenticated_upload(&client, &target)?
             } else {
                 message::warn(&format!(

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -50,9 +50,9 @@ pub fn build_and_upload(
 
                 if let Some(site_config) = target.site.clone() {
                     publish::bind_static_site_contents(user, target, &site_config, true)?;
-                    publish::upload_buckets(target, user)?;
                 }
 
+                let asset_manifest = publish::upload_buckets(target, user)?;
                 authenticated_upload(&client, &target, asset_manifest)?
             } else {
                 message::warn(&format!(

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -49,6 +49,7 @@ pub fn build_and_upload(
 
                 if let Some(site_config) = target.site.clone() {
                     publish::bind_static_site_contents(user, target, &site_config, true)?;
+                    publish::upload_buckets(target, user)?;
                 }
 
                 publish::upload_buckets(target, user)?;

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -53,7 +53,6 @@ pub fn build_and_upload(
                     publish::upload_buckets(target, user)?;
                 }
 
-                let asset_manifest = publish::upload_buckets(target, user)?;
                 authenticated_upload(&client, &target, asset_manifest)?
             } else {
                 message::warn(&format!(

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -47,7 +47,6 @@ pub fn build_and_upload(
             if missing_fields.is_empty() {
                 let client = http::auth_client(&user);
 
-                // todo add sites to bucket here
                 if let Some(site_config) = target.site.clone() {
                     publish::bind_static_site_contents(user, target, &site_config, true)?;
                 }


### PR DESCRIPTION
Fixes #653. This PR adds support for `wrangler preview --watch` to work with static assets.

There is still a quirks I want to work out in the future: is the 2000 ms cooldown period enough to account for large static site generator builds that exceed that time? (I think it should be, we can wait to hear otherwise...)