### PR TITLE
Provide closed error path for unauthed preview with sites

### DIFF
--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -33,8 +33,9 @@ struct V4ApiResponse {
     pub result: ApiPreview,
 }
 
-const SITES_UNAUTH_PREVIEW_ERR: &str = "Unauthenticated preview does not work for previewing Workers Sites; you need to \
-                    authenticate to upload your site contents.";
+const SITES_UNAUTH_PREVIEW_ERR: &str =
+    "Unauthenticated preview does not work for previewing Workers Sites; you need to \
+     authenticate to upload your site contents.";
 
 // Builds and uploads the script and its bindings. Returns the ID of the uploaded script.
 pub fn build_and_upload(

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -33,6 +33,9 @@ struct V4ApiResponse {
     pub result: ApiPreview,
 }
 
+const SITES_UNAUTH_PREVIEW_ERR: &str = "Unauthenticated preview does not work for previewing Workers Sites; you need to \
+                    authenticate to upload your site contents.";
+
 // Builds and uploads the script and its bindings. Returns the ID of the uploaded script.
 pub fn build_and_upload(
     target: &mut Target,
@@ -61,8 +64,7 @@ pub fn build_and_upload(
                 ));
                 message::warn("Falling back to unauthenticated preview.");
                 if sites_preview {
-                    failure::bail!("Unauthenticated preview does not work for previewing Workers Sites; you need to \
-                    authenticate to upload your site contents. Exiting...")
+                    failure::bail!(SITES_UNAUTH_PREVIEW_ERR)
                 }
 
                 let client = http::client();
@@ -78,8 +80,7 @@ pub fn build_and_upload(
             );
 
             if sites_preview {
-                failure::bail!("Unauthenticated preview does not work for previewing Workers Sites; you need to \
-                authenticate to upload your site contents. Exiting...")
+                failure::bail!(SITES_UNAUTH_PREVIEW_ERR)
             }
 
             let client = http::client();

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -61,9 +61,8 @@ pub fn build_and_upload(
                 ));
                 message::warn("Falling back to unauthenticated preview.");
                 if sites_preview {
-                    message::warn(
-                        "Note that unauthenticated preview will not preview Workers Sites.",
-                    );
+                    failure::bail!("Unauthenticated preview does not work for previewing Workers Sites; you need to \
+                    authenticate to upload your site contents. Exiting...")
                 }
 
                 let client = http::client();
@@ -79,7 +78,8 @@ pub fn build_and_upload(
             );
 
             if sites_preview {
-                message::warn("Note that unauthenticated preview will not preview Workers Sites.");
+                failure::bail!("Unauthenticated preview does not work for previewing Workers Sites; you need to \
+                authenticate to upload your site contents. Exiting...")
             }
 
             let client = http::client();


### PR DESCRIPTION
This PR fixes #706.

We replace `message::warn` with `failure::bail` to ensure that the sites preview case with unauthed preview throws an error and exits. The error message now lacks the warn emoji (we can't use `message::warn` because it formats AND prints out the text). I still think this PR has the correct approach.

Example output:
```console
$ wrangler preview
 Your wrangler.toml is missing the following fields: ["account_id"]
 Falling back to unauthenticated preview.
Error: Unauthenticated preview does not work for previewing Workers Sites; you need to authenticate to upload your site contents.
```