### PR TITLE
Ensure creating namespace message is only printed when a namespace is actually created

### DIFF
--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -24,9 +24,6 @@ pub fn site(
         format!("__{}-{}", target.name, "workers_sites_assets")
     };
 
-    let msg = format!("Creating namespace for Workers Site \"{}\"", title);
-    message::working(&msg);
-
     let response = client.request(&CreateNamespace {
         account_identifier: &target.account_id,
         params: CreateNamespaceParams {
@@ -35,7 +32,11 @@ pub fn site(
     });
 
     match response {
-        Ok(success) => Ok(success.result),
+        Ok(success) => {
+            let msg = format!("Created namespace for Workers Site \"{}\"", title);
+            message::working(&msg);
+            Ok(success.result)
+        }
         Err(e) => match e {
             ApiFailure::Error(_status, api_errors) => {
                 if api_errors.errors.iter().any(|e| e.code == 10014) {
@@ -45,12 +46,17 @@ pub fn site(
                     });
 
                     match response {
-                        Ok(success) => Ok(success
-                            .result
-                            .iter()
-                            .find(|ns| ns.title == title)
-                            .unwrap()
-                            .to_owned()),
+                        Ok(success) => {
+                            let msg = format!("Using namespace for Workers Site \"{}\"", title);
+                            message::working(&msg);
+
+                            Ok(success
+                                .result
+                                .iter()
+                                .find(|ns| ns.title == title)
+                                .unwrap()
+                                .to_owned())
+                        }
                         Err(e) => failure::bail!("{:?}", e),
                     }
                 } else {


### PR DESCRIPTION
Fixes #646.

When namespace is created for site:
```console
$ wrangler publish
 Created namespace for Workers Site "__worker-site-workers_sites_assets_preview"
```

When namespace already exists for site:
```console
$ wrangler publish
 Using namespace for Workers Site "__blog-daniel-workers_sites_assets"
```