### PR TITLE
fix #735: initialize new iterator for second if clause

### DIFF
--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -39,10 +39,9 @@ pub fn site(
         }
         Err(e) => match e {
             ApiFailure::Error(_status, api_errors) => {
-                let mut error_iter = api_errors.errors.iter();
-                if error_iter.any(|e| e.code == 10026) {
+                if api_errors.errors.iter().any(|e| e.code == 10026) {
                     failure::bail!("You will need to enable Workers Unlimited for your account before you can use this feature.")
-                } else if error_iter.any(|e| e.code == 10014) {
+                } else if api_errors.errors.iter().any(|e| e.code == 10014) {
                     log::info!("Namespace {} already exists.", title);
                     let response = client.request(&ListNamespaces {
                         account_identifier: &target.account_id,


### PR DESCRIPTION
previously we tried to call `any` on an iterator twice, but i think the second time it was spent, and so did not catch the second clause. this pr should catch that.