### PR TITLE
Print subdomain if `name` arg not provided to `wrangler subdomain`

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,7 +20,8 @@ pub use publish::preview::preview;
 pub use publish::preview::HTTPMethod;
 pub use publish::publish;
 use regex::Regex;
-pub use subdomain::subdomain;
+pub use subdomain::get_subdomain;
+pub use subdomain::set_subdomain;
 pub use whoami::whoami;
 
 /// Run the given command and return its stdout.

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -144,7 +144,7 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
         ))
     }
     let subdomain = Subdomain::get_as_option(&target.account_id, user);
-    return match subdomain {
+    match subdomain {
         Ok(None) => register_subdomain(&name, &user, &target),
         Ok(Some(subdomain)) => {
             let msg = format!("This account already has a registered subdomain. You can only register one subdomain per account. Your subdomain is {}.workers.dev", subdomain);
@@ -152,12 +152,12 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
             Ok(())
         }
         Err(error) => Err(error),
-    };
+    }
 }
 
 pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
     let subdomain = Subdomain::get_as_option(&target.account_id, user);
-    return match subdomain {
+    match subdomain {
         Ok(None) => {
             let msg = format!(
                 "No subdomain registered. Use `wrangler subdomain <name>` to register one."
@@ -171,7 +171,7 @@ pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::
             Ok(())
         }
         Err(error) => Err(error),
-    };
+    }
 }
 
 fn already_has_subdomain(errors: Vec<Error>) -> bool {

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -143,34 +143,27 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
             emoji::WARN
         ))
     }
-    let subdomain = Subdomain::get_as_option(&target.account_id, user);
-    match subdomain {
-        Ok(None) => register_subdomain(&name, &user, &target),
-        Ok(Some(subdomain)) => {
-            let msg = format!("This account already has a registered subdomain. You can only register one subdomain per account. Your subdomain is {}.workers.dev", subdomain);
-            message::user_error(&msg);
-            Ok(())
-        }
-        Err(error) => Err(error),
+    let subdomain = Subdomain::get_as_option(&target.account_id, user)?;
+    if let Some(subdomain) = subdomain {
+        let msg = format!("This account already has a registered subdomain. You can only register one subdomain per account. Your subdomain is {}.workers.dev", subdomain);
+        message::user_error(&msg);
+        Ok(())
+    } else {
+        register_subdomain(&name, &user, &target)
     }
 }
 
 pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
-    let subdomain = Subdomain::get_as_option(&target.account_id, user);
-    match subdomain {
-        Ok(None) => {
-            let msg = format!(
-                "No subdomain registered. Use `wrangler subdomain <name>` to register one."
-            );
-            message::user_error(&msg);
-            Ok(())
-        }
-        Ok(Some(subdomain)) => {
-            let msg = format!("{}.workers.dev", subdomain);
-            message::info(&msg);
-            Ok(())
-        }
-        Err(error) => Err(error),
+    let subdomain = Subdomain::get_as_option(&target.account_id, user)?;
+    if let Some(subdomain) = subdomain {
+        let msg = format!("{}.workers.dev", subdomain);
+        message::info(&msg);
+        Ok(())
+    } else {
+        let msg =
+            format!("No subdomain registered. Use `wrangler subdomain <name>` to register one.");
+        message::user_error(&msg);
+        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,7 +499,11 @@ fn run() -> Result<(), failure::Error> {
 
         let name = matches.value_of("name");
 
-        commands::subdomain(name, &user, &target)?;
+        if let Some(name) = name {
+            commands::subdomain::set_subdomain(&name, &user, &target)?;
+        } else {
+            commands::subdomain::get_subdomain(&user, &target)?;
+        }
     } else if let Some(kv_matches) = matches.subcommand_matches("kv:namespace") {
         let manifest = settings::target::Manifest::new(config_path)?;
         let user = settings::global_user::GlobalUser::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,8 +373,7 @@ fn run() -> Result<(), failure::Error> {
                 .arg(
                     Arg::with_name("name")
                         .help("the subdomain on workers.dev you'd like to reserve")
-                        .index(1)
-                        .required(true),
+                        .index(1),
                 ),
         )
         .subcommand(SubCommand::with_name("whoami").about(&*format!(
@@ -498,9 +497,7 @@ fn run() -> Result<(), failure::Error> {
         info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;
 
-        let name = matches
-            .value_of("name")
-            .expect("The subdomain name you are requesting must be provided.");
+        let name = matches.value_of("name");
 
         commands::subdomain(name, &user, &target)?;
     } else if let Some(kv_matches) = matches.subcommand_matches("kv:namespace") {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/wrangler/issues/701

I added a new method, `Subdomain::get_as_option`, since it seems like the common case is to assert that the subdomain is available.