### PR TITLE
[WIP] Consistency in passing &GlobalUser and refactoring kv::namespace calls

### DIFF
--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -16,7 +16,7 @@ use crate::terminal::message;
 
 pub fn sync(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     path: &Path,
     verbose: bool,
@@ -29,7 +29,7 @@ pub fn sync(
     // Turn it into a HashSet. This will be used by upload() to figure out which
     // files to exclude from upload (because their current version already exists in
     // the Workers KV remote).
-    let remote_keys_iter = KeyList::new(target, user.clone(), namespace_id, None)?;
+    let remote_keys_iter = KeyList::new(target, &user, namespace_id, None)?;
     let mut remote_keys: HashSet<String> = HashSet::new();
     for remote_key in remote_keys_iter {
         match remote_key {
@@ -45,7 +45,7 @@ pub fn sync(
     }
     let asset_manifest = upload_files(
         target,
-        user.clone(),
+        &user,
         namespace_id,
         path,
         Some(&remote_keys),

--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -16,7 +16,7 @@ use crate::terminal::message;
 
 pub fn delete(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     filename: &Path,
 ) -> Result<(), failure::Error> {
@@ -59,7 +59,7 @@ pub fn delete(
 
 pub fn delete_bulk(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     keys: Vec<String>,
 ) -> Result<(), failure::Error> {

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -16,7 +16,7 @@ use crate::terminal::message;
 
 pub fn put(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     filename: &Path,
 ) -> Result<(), failure::Error> {
@@ -45,7 +45,7 @@ pub fn put(
 
 pub fn put_bulk(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     pairs: Vec<KeyValuePair>,
 ) -> Result<(), failure::Error> {

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -8,7 +8,7 @@ use crate::terminal::message;
 
 pub fn delete(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     id: &str,
     key: &str,
 ) -> Result<(), failure::Error> {

--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -10,7 +10,7 @@ use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 
-pub fn get(target: &Target, user: GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
+pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",

--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -25,7 +25,7 @@ pub struct KeyList {
 impl KeyList {
     pub fn new(
         target: &Target,
-        user: GlobalUser,
+        user: &GlobalUser,
         namespace_id: &str,
         prefix: Option<&str>,
     ) -> Result<KeyList, failure::Error> {

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -10,7 +10,7 @@ use crate::settings::target::Target;
 // representation won't make sense)
 pub fn list(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     namespace_id: &str,
     prefix: Option<&str>,
 ) -> Result<(), failure::Error> {

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -16,7 +16,7 @@ use crate::terminal::message;
 
 pub fn put(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
     id: &str,
     key: &str,
     value: &str,

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -63,8 +63,8 @@ pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failur
     )
 }
 
-fn api_client(user: GlobalUser) -> Result<HttpApiClient, failure::Error> {
-    Ok(HttpApiClient::new(Credentials::from(user)))
+fn api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
+    Ok(HttpApiClient::new(Credentials::from(user.to_owned())))
 }
 
 fn format_error(e: ApiFailure) -> String {

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 pub fn create(
     target: &Target,
     env: Option<&str>,
-    user: GlobalUser,
+    user: &GlobalUser,
     binding: &str,
 ) -> Result<(), failure::Error> {
     kv::validate_target(target)?;

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -6,7 +6,7 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 use crate::terminal::message;
 
-pub fn delete(target: &Target, user: GlobalUser, id: &str) -> Result<(), failure::Error> {
+pub fn delete(target: &Target, user: &GlobalUser, id: &str) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 

--- a/src/commands/kv/namespace/list.rs
+++ b/src/commands/kv/namespace/list.rs
@@ -12,7 +12,7 @@ use crate::settings::target::Target;
 const MAX_NAMESPACES_PER_PAGE: u32 = 100;
 const PAGE_NUMBER: u32 = 1;
 
-pub fn list(target: &Target, user: GlobalUser) -> Result<(), failure::Error> {
+pub fn list(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
     let result = call_api(target, user);
     match result {
         Ok(success) => {
@@ -25,7 +25,7 @@ pub fn list(target: &Target, user: GlobalUser) -> Result<(), failure::Error> {
 
 pub fn call_api(
     target: &Target,
-    user: GlobalUser,
+    user: &GlobalUser,
 ) -> Result<Vec<WorkersKvNamespace>, failure::Error> {
     kv::validate_target(target)?;
     let client = kv::api_client(user)?;

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -18,7 +18,7 @@ pub fn site(
     preview: bool,
 ) -> Result<WorkersKvNamespace, failure::Error> {
     kv::validate_target(target)?;
-    let client = kv::api_client(user.to_owned())?;
+    let client = kv::api_client(user)?;
 
     let title = if preview {
         format!("__{}-{}", target.name, "workers_sites_assets_preview")

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -14,7 +14,6 @@ pub fn site(
     preview: bool,
 ) -> Result<WorkersKvNamespace, failure::Error> {
     kv::validate_target(target)?;
-    let client = kv::api_client(user)?;
 
     let title = if preview {
         format!("__{}-{}", target.name, "workers_sites_assets_preview")
@@ -22,6 +21,10 @@ pub fn site(
         format!("__{}-{}", target.name, "workers_sites_assets")
     };
 
+    // We call CreateNamespace here directly because we want raw access to the
+    // response codes; the implementations in commands::kv::namespace cannot surface
+    // the raw response
+    let client = kv::api_client(user)?;
     let response = client.request(&CreateNamespace {
         account_identifier: &target.account_id,
         params: CreateNamespaceParams {

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -141,7 +141,7 @@ pub fn upload_buckets(
                 )
             }
             let manifest_result =
-                kv::bucket::sync(target, user.to_owned(), &namespace.id, path, false)?;
+                kv::bucket::sync(target, user, &namespace.id, path, false)?;
             if target.site.is_some() {
                 if asset_manifest.is_none() {
                     asset_manifest = Some(manifest_result)

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -140,8 +140,7 @@ pub fn upload_buckets(
                     path.display()
                 )
             }
-            let manifest_result =
-                kv::bucket::sync(target, user, &namespace.id, path, false)?;
+            let manifest_result = kv::bucket::sync(target, user, &namespace.id, path, false)?;
             if target.site.is_some() {
                 if asset_manifest.is_none() {
                     asset_manifest = Some(manifest_result)

--- a/src/main.rs
+++ b/src/main.rs
@@ -512,7 +512,7 @@ fn run() -> Result<(), failure::Error> {
                 let env = create_matches.value_of("env");
                 let target = manifest.get_target(env, false)?;
                 let binding = create_matches.value_of("binding").unwrap();
-                commands::kv::namespace::create(&target, env, user, binding)?;
+                commands::kv::namespace::create(&target, env, &user, binding)?;
             }
             ("delete", Some(delete_matches)) => {
                 let target = manifest.get_target(delete_matches.value_of("env"), false)?;
@@ -525,11 +525,11 @@ fn run() -> Result<(), failure::Error> {
                         .unwrap() // clap configs ensure that if "binding" isn't present,"namespace-id" must be.
                         .to_string(),
                 };
-                commands::kv::namespace::delete(&target, user, &namespace_id)?;
+                commands::kv::namespace::delete(&target, &user, &namespace_id)?;
             }
             ("list", Some(list_matches)) => {
                 let target = manifest.get_target(list_matches.value_of("env"), false)?;
-                commands::kv::namespace::list(&target, user)?;
+                commands::kv::namespace::list(&target, &user)?;
             }
             ("", None) => message::warn("kv:namespace expects a subcommand"),
             _ => unreachable!(),
@@ -560,7 +560,7 @@ fn run() -> Result<(), failure::Error> {
         match (subcommand, subcommand_matches) {
             ("get", Some(get_key_matches)) => {
                 let key = get_key_matches.value_of("key").unwrap();
-                commands::kv::key::get(&target, user, &namespace_id, key)?
+                commands::kv::key::get(&target, &user, &namespace_id, key)?
             }
             ("put", Some(put_key_matches)) => {
                 let key = put_key_matches.value_of("key").unwrap();
@@ -572,7 +572,7 @@ fn run() -> Result<(), failure::Error> {
                 let ttl = put_key_matches.value_of("expiration-ttl");
                 commands::kv::key::put(
                     &target,
-                    user,
+                    &user,
                     &namespace_id,
                     key,
                     &value,
@@ -583,11 +583,11 @@ fn run() -> Result<(), failure::Error> {
             }
             ("delete", Some(delete_key_matches)) => {
                 let key = delete_key_matches.value_of("key").unwrap();
-                commands::kv::key::delete(&target, user, &namespace_id, key)?
+                commands::kv::key::delete(&target, &user, &namespace_id, key)?
             }
             ("list", Some(list_key_matches)) => {
                 let prefix = list_key_matches.value_of("prefix");
-                commands::kv::key::list(&target, user, &namespace_id, prefix)?
+                commands::kv::key::list(&target, &user, &namespace_id, prefix)?
             }
             ("", None) => message::warn("kv:key expects a subcommand"),
             _ => unreachable!(),
@@ -618,11 +618,11 @@ fn run() -> Result<(), failure::Error> {
         match (subcommand, subcommand_matches) {
             ("put", Some(put_bulk_matches)) => {
                 let path = put_bulk_matches.value_of("path").unwrap();
-                commands::kv::bulk::put(&target, user, &namespace_id, Path::new(path))?
+                commands::kv::bulk::put(&target, &user, &namespace_id, Path::new(path))?
             }
             ("delete", Some(delete_bulk_matches)) => {
                 let path = delete_bulk_matches.value_of("path").unwrap();
-                commands::kv::bulk::delete(&target, user, &namespace_id, Path::new(path))?
+                commands::kv::bulk::delete(&target, &user, &namespace_id, Path::new(path))?
             }
             ("", None) => message::warn("kv:bulk expects a subcommand"),
             _ => unreachable!(),


### PR DESCRIPTION
Closes #623.

This PR does two things:
1. Refactors the passing of GlobalUser as a reference to be consistent with other wrangler command invocations
1. Reduces a duplicate implementation of calling ListNamespaces, instead using `kv::commands::namespace::list::call_api`.

I wanted to remove the duplicate implementation of CreateNamespace, but the problem is that `kv::commands::namespace::create::call_api`, if it existed, must return a `failure::Error` because it must creates an API client and THEN calls the API endpoint. But `site()` expects an `ApiError` in response, because it wants access to the API error code to understand when a namespace already exists or whether the user doesn't have Workers KV entitled to their account. I'm trying to think of workarounds here, but they would honestly convolute the `kv::commands::namespace::create` crate; calling `CreateNamespace` directly from `site()` is not the end of the world given how custom its handling logic is.
