### PR TITLE
Use custom KV api client to support longer timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudflare"
+version = "0.3.1"
+source = "git+https://github.com/cloudflare/cloudflare-rs#e91520886c8b648b51e3ac61404b2d65d651ed39"
+dependencies = [
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_qs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_with 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sloggers 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "config"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,29 +489,6 @@ dependencies = [
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "dubs-cloudflare"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_qs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_with 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sloggers 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "either"
@@ -2395,11 +2396,11 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary-install 0.0.3-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudflare 0.3.1 (git+https://github.com/cloudflare/cloudflare-rs)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "dubs-cloudflare 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exitfailure 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2514,6 +2515,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cloudflare 0.3.1 (git+https://github.com/cloudflare/cloudflare-rs)" = "<none>"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
 "checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
@@ -2536,7 +2538,6 @@ dependencies = [
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum dubs-cloudflare 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4246bd5bdc5bd81b92fcb1f361ac515ad8af408e93f9ff362d50545ea83056a6"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "79906e1ad1f7f8bc48864fcc6ffd58336fb5992e627bf61928099cb25fdf4314"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,8 +258,8 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.3.1"
-source = "git+https://github.com/cloudflare/cloudflare-rs#e91520886c8b648b51e3ac61404b2d65d651ed39"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2396,7 +2396,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary-install 0.0.3-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudflare 0.3.1 (git+https://github.com/cloudflare/cloudflare-rs)",
+ "cloudflare 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2515,7 +2515,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum cloudflare 0.3.1 (git+https://github.com/cloudflare/cloudflare-rs)" = "<none>"
+"checksum cloudflare 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a60a61015ab6e3d7ad185b6050a29e4b0bf27353109f739731eda31a6bc40"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
 "checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2.32.0"
 config = "0.9.2"
 console = "0.7.5"
 dirs = "1.0.5"
-cloudflare = { git = "https://github.com/cloudflare/cloudflare-rs" }
+cloudflare = "0.3.2"
 env_logger = "0.6.1"
 failure = "0.1.5"
 log = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2.32.0"
 config = "0.9.2"
 console = "0.7.5"
 dirs = "1.0.5"
-dubs-cloudflare = "0.3.1"
+cloudflare = { git = "https://github.com/cloudflare/cloudflare-rs" }
 env_logger = "0.6.1"
 failure = "0.1.5"
 log = "0.4.6"

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -4,12 +4,13 @@ use std::collections::HashSet;
 use std::fs::metadata;
 use std::path::Path;
 
+use crate::commands::kv;
 use crate::commands::kv::bucket::directory_keys_values;
-use crate::commands::kv::bulk::put::put_bulk;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 use crate::terminal::message;
 use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
+use cloudflare::framework::apiclient::ApiClient;
 use failure::format_err;
 
 const KEY_MAX_SIZE: usize = 512;
@@ -50,6 +51,7 @@ pub fn upload_files(
 
     validate_file_uploads(pairs.clone())?;
 
+    let client = kv::api_client(user)?;
     // Iterate over all key-value pairs and create batches of uploads, each of which are
     // maximum 10K key-value pairs in size OR maximum ~50MB in size. Upload each batch
     // as it is created.
@@ -60,14 +62,14 @@ pub fn upload_files(
     while !(pairs.is_empty() && key_value_batch.is_empty()) {
         if pairs.is_empty() {
             // Last batch to upload
-            upload_batch(target, &user, namespace_id, &mut key_value_batch)?;
+            upload_batch(&client, target, namespace_id, &mut key_value_batch)?;
         } else {
             let pair = pairs.pop().unwrap();
             if key_count + 1 > PAIRS_MAX_COUNT
             // Keep upload size small to keep KV bulk API happy
             || key_pair_bytes + pair.key.len() + pair.value.len() > UPLOAD_MAX_SIZE
             {
-                upload_batch(target, &user, namespace_id, &mut key_value_batch)?;
+                upload_batch(&client, target, namespace_id, &mut key_value_batch)?;
 
                 // If upload successful, reset counters
                 key_count = 0;
@@ -85,18 +87,21 @@ pub fn upload_files(
 }
 
 fn upload_batch(
+    client: &impl ApiClient,
     target: &Target,
-    user: &GlobalUser,
     namespace_id: &str,
     key_value_batch: &mut Vec<KeyValuePair>,
 ) -> Result<(), failure::Error> {
     message::info("Uploading...");
     // If partial upload fails (e.g. server error), return that error message
-    put_bulk(target, &user, namespace_id, key_value_batch.clone())?;
-
-    // Can clear batch now that we've uploaded it
-    key_value_batch.clear();
-    Ok(())
+    match kv::bulk::put::call_api(client, target, namespace_id, &key_value_batch) {
+        Ok(_) => {
+            // Can clear batch now that we've uploaded it
+            key_value_batch.clear();
+            Ok(())
+        }
+        Err(e) => failure::bail!("Failed to upload file batch. {}", kv::format_error(e)),
+    }
 }
 
 fn filter_files(pairs: Vec<KeyValuePair>, already_uploaded: &HashSet<String>) -> Vec<KeyValuePair> {

--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -63,7 +63,7 @@ pub fn delete_bulk(
     namespace_id: &str,
     keys: Vec<String>,
 ) -> Result<(), failure::Error> {
-    let client = kv::api_client(user);
+    let client = kv::api_client(user)?;
 
     // Check number of pairs is under limit
     if keys.len() > MAX_PAIRS {

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 use cloudflare::endpoints::workerskv::write_bulk::WriteBulk;
 use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::{ApiFailure, ApiSuccess};
 
 use crate::commands::kv;
 use crate::commands::kv::bulk::MAX_PAIRS;
@@ -22,34 +23,23 @@ pub fn put(
 ) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
 
-    let pairs: Result<Vec<KeyValuePair>, failure::Error> = match &metadata(filename) {
+    let pairs: Vec<KeyValuePair> = match &metadata(filename) {
         Ok(file_type) if file_type.is_file() => {
             let data = fs::read_to_string(filename)?;
             let data_vec = serde_json::from_str(&data);
             if data_vec.is_err() {
-                failure::bail!("Failed to decode JSON. Please make sure to follow the format, [{\"key\": \"test_key\", \"value\": \"test_value\"}, ...]")
+                Err(failure::format_err!("Failed to decode JSON. Please make sure to follow the format, [{{\"key\": \"test_key\", \"value\": \"test_value\"}}, ...]"))
             } else {
-                Ok(data_vec.unwrap())
+                let data_vec: Vec<KeyValuePair> = data_vec.unwrap();
+                Ok(data_vec)
             }
         }
-        Ok(_) => failure::bail!("{} should be a JSON file, but is not", filename.display()),
-        Err(e) => failure::bail!("{}", e),
-    };
-
-    match put_bulk(target, user, namespace_id, pairs?) {
-        Ok(_) => message::success("Success"),
-        Err(e) => print!("{}", e),
-    }
-    Ok(())
-}
-
-pub fn put_bulk(
-    target: &Target,
-    user: &GlobalUser,
-    namespace_id: &str,
-    pairs: Vec<KeyValuePair>,
-) -> Result<(), failure::Error> {
-    let client = kv::api_client(user);
+        Ok(_) => Err(failure::format_err!(
+            "{} should be a JSON file, but is not",
+            filename.display()
+        )),
+        Err(e) => Err(failure::format_err!("{}", e)),
+    }?;
 
     // Validate that bulk upload is within size constraints
     if pairs.len() > MAX_PAIRS {
@@ -60,14 +50,23 @@ pub fn put_bulk(
         );
     }
 
-    let response = client.request(&WriteBulk {
-        account_identifier: &target.account_id,
-        namespace_identifier: namespace_id,
-        bulk_key_value_pairs: pairs,
-    });
-
-    match response {
-        Ok(_) => Ok(()),
+    let client = kv::api_client(user)?;
+    match call_api(&client, target, namespace_id, &pairs) {
+        Ok(_) => message::success("Success"),
         Err(e) => failure::bail!("{}", kv::format_error(e)),
     }
+    Ok(())
+}
+
+pub fn call_api(
+    client: &impl ApiClient,
+    target: &Target,
+    namespace_id: &str,
+    pairs: &Vec<KeyValuePair>,
+) -> Result<ApiSuccess<()>, ApiFailure> {
+    client.request(&WriteBulk {
+        account_identifier: &target.account_id,
+        namespace_identifier: namespace_id,
+        bulk_key_value_pairs: pairs.to_owned(),
+    })
 }

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -13,7 +13,7 @@ pub fn delete(
     key: &str,
 ) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
-    let client = kv::api_client(user);
+    let client = kv::api_client(user)?;
 
     match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
         Ok(true) => (),

--- a/src/commands/kv/key/key_list.rs
+++ b/src/commands/kv/key/key_list.rs
@@ -32,7 +32,7 @@ impl KeyList {
         let iter = KeyList {
             keys_result: None,
             prefix: prefix.map(str::to_string),
-            client: kv::api_client(user),
+            client: kv::api_client(user)?,
             account_id: target.account_id.to_owned(),
             namespace_id: namespace_id.to_string(),
             cursor: None,

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
+use std::time::Duration;
 
 use cloudflare::framework::auth::Credentials;
 use cloudflare::framework::response::ApiFailure;
-use cloudflare::framework::HttpApiClient;
+use cloudflare::framework::{HttpApiClient, HttpApiClientConfig};
 
 use http::status::StatusCode;
 use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
@@ -63,8 +64,14 @@ pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failur
     )
 }
 
-fn api_client(user: &GlobalUser) -> HttpApiClient {
-    HttpApiClient::new(Credentials::from(user.to_owned()))
+fn api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
+    HttpApiClient::new(
+        Credentials::from(user.to_owned()),
+        HttpApiClientConfig {
+            // Use 3 minute timeout instead of default 30-second one.
+            http_timeout: Duration::from_secs(3 * 60),
+        },
+    )
 }
 
 fn format_error(e: ApiFailure) -> String {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -122,10 +122,12 @@ fn url_encode_key(key: &str) -> String {
 // (no KV error code is given).
 fn print_status_code_context(status_code: StatusCode) {
     match status_code {
+        // Folks should never hit PAYLOAD_TOO_LARGE, given that Wrangler ensures that bulk file uploads
+        // are max ~50 MB in size. This case is handled anyways out of an abundance of caution.
         StatusCode::PAYLOAD_TOO_LARGE =>
-            message::warn("Returned status code 413, Payload Too Large. Make sure your upload is less than 100MB in size"),
+            message::warn("Returned status code 413, Payload Too Large. Please make sure your upload is less than 100MB in size"),
         StatusCode::GATEWAY_TIMEOUT =>
-            message::warn("Returned status code 504, Gateway Timeout. Try again in a few seconds"),
+            message::warn("Returned status code 504, Gateway Timeout. Please try again in a few seconds"),
         _ => (),
     }
 }

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -23,7 +23,8 @@ pub fn create(
     let msg = format!("Creating namespace with title \"{}\"", title);
     message::working(&msg);
 
-    let result = call_api(target, user, &title);
+    let client = kv::api_client(user)?;
+    let result = call_api(&client, target, &title);
 
     match result {
         Ok(success) => {
@@ -64,11 +65,10 @@ pub fn create(
 }
 
 pub fn call_api(
+    client: &impl ApiClient,
     target: &Target,
-    user: &GlobalUser,
     title: &str,
 ) -> Result<ApiSuccess<WorkersKvNamespace>, ApiFailure> {
-    let client = kv::api_client(user);
     client.request(&CreateNamespace {
         account_identifier: &target.account_id,
         params: CreateNamespaceParams {

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -8,7 +8,7 @@ use crate::terminal::message;
 
 pub fn delete(target: &Target, user: &GlobalUser, id: &str) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
-    let client = kv::api_client(user);
+    let client = kv::api_client(user)?;
 
     match kv::interactive_delete(&format!(
         "Are you sure you want to delete namespace {}?",

--- a/src/commands/kv/namespace/list.rs
+++ b/src/commands/kv/namespace/list.rs
@@ -15,7 +15,9 @@ const PAGE_NUMBER: u32 = 1;
 
 pub fn list(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
-    let result = call_api(target, user);
+
+    let client = kv::api_client(user)?;
+    let result = call_api(&client, target);
     match result {
         Ok(success) => {
             let namespaces = success.result;
@@ -27,11 +29,9 @@ pub fn list(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
 }
 
 pub fn call_api(
+    client: &impl ApiClient,
     target: &Target,
-    user: &GlobalUser,
 ) -> Result<ApiSuccess<Vec<WorkersKvNamespace>>, ApiFailure> {
-    let client = kv::api_client(user);
-
     let params = ListNamespacesParams {
         page: Some(PAGE_NUMBER),
         per_page: Some(MAX_NAMESPACES_PER_PAGE),

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -1,4 +1,5 @@
 use cloudflare::endpoints::workerskv::WorkersKvNamespace;
+use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 
 use crate::commands::kv;
@@ -19,7 +20,8 @@ pub fn site(
         format!("__{}-{}", target.name, "workers_sites_assets")
     };
 
-    let response = kv::namespace::create::call_api(target, user, &title);
+    let client = kv::api_client(user)?;
+    let response = kv::namespace::create::call_api(&client, target, &title);
 
     match response {
         Ok(success) => {
@@ -37,7 +39,7 @@ pub fn site(
                     let msg = format!("Using namespace for Workers Site \"{}\"", title);
                     message::working(&msg);
 
-                    get_id_from_namespace_list(target, user, &title)
+                    get_id_from_namespace_list(&client, target, &title)
                 } else {
                     failure::bail!("{:?}", api_errors.errors)
                 }
@@ -48,11 +50,11 @@ pub fn site(
 }
 
 fn get_id_from_namespace_list(
+    client: &impl ApiClient,
     target: &Target,
-    user: &GlobalUser,
     title: &str,
 ) -> Result<WorkersKvNamespace, failure::Error> {
-    let result = kv::namespace::list::call_api(target, user);
+    let result = kv::namespace::list::call_api(client, target);
 
     match result {
         Ok(success) => Ok(success


### PR DESCRIPTION
This PR closes #746. 

It uses a newer version of cloudflare-rs that allows us to specify custom configurations for our API client. This allows us to specify a longer timeout for the client and wait longer for a bulk API upload to complete. This PR is blocked on cloudflare-rs being re-released so we can point to a version number instead of the latest master commit on the cloudflare-rs repository.

Given that this cloudflare-rs change is breaking (it now returns clients wrapped in a `Result`) we had to change where and how clients were constructed in Wrangler. Namely, clients can no longer be constructed in `call_api` functions anymore, because these functions must return `Result<ApiSuccess<_>, ApiFailure>` (not `failure::Error)`. Instead, clients are now passed in to `call_api` calls.