### PR TITLE
Always npm install

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -73,7 +73,7 @@ fn build_and_publish_script(
         target.account_id, target.name,
     );
 
-    let client = if let Some(_) = &target.site {
+    let client = if target.site.is_some() {
         http::auth_client(Some("site"), user)
     } else {
         http::auth_client(None, user)

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -161,7 +161,7 @@ pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::
         Ok(())
     } else {
         let msg =
-            format!("No subdomain registered. Use `wrangler subdomain <name>` to register one.");
+            "No subdomain registered. Use `wrangler subdomain <name>` to register one.".to_string();
         message::user_error(&msg);
         Ok(())
     }


### PR DESCRIPTION
Closes #428 by removing logic to skip npm install step if node_modules is already present. npm install is pretty good about not redundantly downloading packages. tested locally on a mac.