### PR TITLE
removal of internal link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,7 @@ contributions.
 
 ## People
 
-Wrangler is maintained by @ashleygwilliams, and her team, [Workers Developer Experience].
-
-[Workers Developer Experience]: https://github.com/orgs/cloudflare/teams/workers-devexp
+Wrangler is maintained by @ashleygwilliams, and her team, Workers Developer Experience.
 
 ## Primary Issue Triage
 


### PR DESCRIPTION
The link is only accessible to Cloudflare staff, resulting in a 404 to most users.

<img width="971" alt="Screen Shot 2019-10-15 at 2 01 18 PM" src="https://user-images.githubusercontent.com/17833/66833965-b71e0500-ef54-11e9-9ac7-56b45e10e8cf.png">
