### PR TITLE
Disallow templates with generate site

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -390,12 +390,12 @@ fn run() -> Result<(), failure::Error> {
     } else if let Some(matches) = matches.subcommand_matches("generate") {
         let name = matches.value_of("name").unwrap_or("worker");
         let site = matches.is_present("site");
-        let template_value = matches.value_of("template");
+        let template = matches.value_of("template");
         let mut target_type = None;
 
         let template = if site {
-            if template_value.is_some() {
-                failure::bail!("You cannot specify a template when generating a Workers Site. If you want to generate site boilerplate, run wrangler generate --site")
+            if template.is_some() {
+                failure::bail!("You cannot specify a template when generating a Workers Site. If you'd like to use the default site boilerplate, run wrangler generate --site. If you'd like to use another site boilerplate, omit the --site when running wrangler generate.")
             }
             "https://github.com/cloudflare/worker-sites-template"
         } else {
@@ -404,7 +404,7 @@ fn run() -> Result<(), failure::Error> {
             }
 
             let default_template = "https://github.com/cloudflare/worker-template";
-            let template = template_value.unwrap_or(match target_type {
+            let template = template.unwrap_or(match target_type {
                 Some(ref pt) => match pt {
                     TargetType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
                     _ => default_template,

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,7 +408,7 @@ fn run() -> Result<(), failure::Error> {
 
         let template = if site {
             if template.is_some() {
-                failure::bail!("You cannot specify a template when generating a Workers Site. If you'd like to use the default site boilerplate, run wrangler generate --site. If you'd like to use another site boilerplate, omit the --site when running wrangler generate.")
+                failure::bail!("You cannot pass a template and the --site flag to wrangler generate. If you'd like to use the default site boilerplate, run wrangler generate --site. If you'd like to use another site boilerplate, omit --site when running wrangler generate.")
             }
             "https://github.com/cloudflare/worker-sites-template"
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,9 +390,13 @@ fn run() -> Result<(), failure::Error> {
     } else if let Some(matches) = matches.subcommand_matches("generate") {
         let name = matches.value_of("name").unwrap_or("worker");
         let site = matches.is_present("site");
+        let template_value = matches.value_of("template");
         let mut target_type = None;
 
         let template = if site {
+            if template_value.is_some() {
+                failure::bail!("You cannot specify a template when generating a Workers Site. If you want to generate site boilerplate, run wrangler generate --site")
+            }
             "https://github.com/cloudflare/worker-sites-template"
         } else {
             if let Some(type_value) = matches.value_of("type") {
@@ -400,7 +404,7 @@ fn run() -> Result<(), failure::Error> {
             }
 
             let default_template = "https://github.com/cloudflare/worker-template";
-            let template = matches.value_of("template").unwrap_or(match target_type {
+            let template = template_value.unwrap_or(match target_type {
                 Some(ref pt) => match pt {
                     TargetType::Rust => "https://github.com/cloudflare/rustwasm-worker-template",
                     _ => default_template,


### PR DESCRIPTION
This PR adds failure logic when a template is passed to `wrangler generate --site`

**Example**
```console
$ wrangler generate --site name https://github.com/cloudflare/wrangler
Error: You cannot specify a template when generating a Workers Site. If you want to generate site boilerplate, run wrangler generate --site
```

Fixes #776 