### PR TITLE
Clarify wrangler config prompts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -392,10 +392,10 @@ fn run() -> Result<(), failure::Error> {
     let config_path = Path::new("./wrangler.toml");
 
     if let Some(_matches) = matches.subcommand_matches("config") {
-        println!("Enter email: ");
+        println!("Enter your cloudflare account's email: ");
         let mut email: String = read!("{}\n");
         email.truncate(email.trim_end().len());
-        println!("Enter api key: ");
+        println!("Enter your cloudflare account's global api key: ");
         let mut api_key: String = read!("{}\n");
         api_key.truncate(api_key.trim_end().len());
 


### PR DESCRIPTION
Spent almost an hour trying to figure out why `wrangler preview` kept returning `Client Error: 400 Bad Request`. An explicit mention of the global API key while #471 is not implemented would help others not make the same mistake: #581  #371 