### PR TITLE
Handle failed exit codes elegantly

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -3,7 +3,6 @@ use std::process::Command;
 
 use crate::commands::validate_worker_name;
 use crate::settings::target::{Manifest, Site, TargetType};
-use crate::terminal::{emoji, message};
 use crate::{commands, install};
 
 pub fn generate(
@@ -40,13 +39,7 @@ pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
 }
 
 fn command(name: &str, binary_path: PathBuf, args: &[&str]) -> Command {
-    let msg = format!(
-        "{} Generating a new worker project with name '{}'...",
-        emoji::SHEEP,
-        name
-    );
-
-    message::working(&msg);
+    log::info!("Generating a new worker project with name '{}'", name);
 
     let mut c = if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -36,8 +36,7 @@ pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
     let command = command(name, binary_path, &args);
     let command_name = format!("{:?}", command);
 
-    commands::run(command, &command_name)?;
-    Ok(())
+    commands::run(command, &command_name)
 }
 
 fn command(name: &str, binary_path: PathBuf, args: &[&str]) -> Command {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,34 +22,18 @@ pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;
 
-use std::str;
-
-const UNKNOWN_ERR: &str =
-    "An unexpected error occurred, try running the command again with RUSTLOG=info";
-
 /// Run the given command and return its stdout.
 pub fn run(mut command: Command, command_name: &str) -> Result<(), failure::Error> {
     log::info!("Running {:?}", command);
 
-    let output = command.output()?;
-    dbg!(output.clone());
+    let status = command.status()?;
 
-    println!(
-        "{}",
-        String::from_utf8(output.stdout).expect(UNKNOWN_ERR).trim()
-    );
-
-    if !output.status.success() {
-        log::info!(
-            "failed to execute `{}`: exited with {}",
-            command_name,
-            output.status
-        );
-        let mut serr = String::from_utf8(output.stderr).expect(UNKNOWN_ERR);
-        if serr.starts_with("Error: ") {
-            serr = serr.get(7..).unwrap_or(UNKNOWN_ERR).to_string();
-        }
-        failure::bail!("{}", serr.trim())
+    if !status.success() {
+        failure::bail!(
+            "failed to execute `{}`\nexited with {}",
+            command_name.replace("\"", ""),
+            status
+        )
     }
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,9 +30,9 @@ pub fn run(mut command: Command, command_name: &str) -> Result<(), failure::Erro
 
     if !status.success() {
         failure::bail!(
-            "failed to execute `{}`\nexited with {}",
-            command_name.replace("\"", ""),
-            status
+            "command exited with {}\n`{}`",
+            status,
+            command_name.replace("\"", "")
         )
     }
     Ok(())


### PR DESCRIPTION
Instead of printing out this error:

```console
$ wrangler generate my-rust https://github.com/EverlastingBugstopper/rustwasm-worker-template/🌀  🐑  Generating a new rust worker project with name 'my-rust'...
🔧   Creating project called `my-rust`...
Error: ⛔   Target directory already exists, aborting!
Error: failed to execute `"/Users/averyharnish/.cargo/bin/cargo-generate" "generate" "--git" "https://github.com/EverlastingBugstopper/rustwasm-worker-template/" "--name" "my-rust" "--force"`: exited with exit code: 1
```

print out this error that lets people copy and paste the command we tried to run easier (before it had a bunch of quotes in it):

```console
$ wrangler generate my-rust https://github.com/EverlastingBugstopper/rustwasm-worker-template/
🌀  🐑  Generating a new worker project with name 'my-rust'...
🔧   Creating project called `my-rust`...
Error: ⛔   Target directory already exists, aborting!
Error: command exited with exit code: 1
`/Users/averyharnish/.cargo/bin/cargo-generate generate --git https://github.com/EverlastingBugstopper/rustwasm-worker-template/ --name my-rust --force`
```
