### PR TITLE
Pull version from package.json

### DIFF
--- a/npm/install-wrangler.js
+++ b/npm/install-wrangler.js
@@ -10,7 +10,7 @@ const { homedir } = require('os');
 
 const cwd = join(homedir(), ".wrangler");
 
-const VERSION = "1.5.0"
+const VERSION = require("./package.json").version;
 
 function getPlatform() {
   const type = os.type();


### PR DESCRIPTION
Fixes #812

Instead of requiring a hard coded version in two places, only require it to be changed in the package.json