### PR TITLE
Alewis/refactor uploads

### DIFF
--- a/src/commands/build/wranglerjs/bundle.rs
+++ b/src/commands/build/wranglerjs/bundle.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::commands::build::wranglerjs::output::WranglerjsOutput;
 
@@ -30,9 +30,8 @@ impl Bundle {
     }
 
     pub fn write(&self, wranglerjs_output: &WranglerjsOutput) -> Result<(), failure::Error> {
-        let bundle_path = Path::new(&self.out);
-        if !bundle_path.exists() {
-            fs::create_dir(bundle_path)?;
+        if !self.out.exists() {
+            fs::create_dir(&self.out)?;
         }
 
         let mut script_file = File::create(self.script_path())?;
@@ -48,16 +47,12 @@ impl Bundle {
         Ok(())
     }
 
-    pub fn wasm_path(&self) -> String {
-        Path::new(&self.out)
-            .join("module.wasm".to_string())
-            .to_str()
-            .unwrap()
-            .to_string()
+    pub fn wasm_path(&self) -> PathBuf {
+        PathBuf::from(&self.out).join("module.wasm")
     }
 
     pub fn has_wasm(&self) -> bool {
-        Path::new(&self.wasm_path()).exists()
+        self.wasm_path().exists()
     }
 
     pub fn has_webpack_config(&self, webpack_config_path: &PathBuf) -> bool {
@@ -68,18 +63,15 @@ impl Bundle {
         "wasmprogram".to_string()
     }
 
-    pub fn script_path(&self) -> String {
-        Path::new(&self.out)
-            .join("script.js".to_string())
-            .to_str()
-            .unwrap()
-            .to_string()
+    pub fn script_path(&self) -> PathBuf {
+        PathBuf::from(&self.out).join("script.js")
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     fn create_temp_dir(name: &str) -> PathBuf {
         let mut dir = env::temp_dir();

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -9,8 +9,6 @@ pub use package::Package;
 use crate::settings::target::KvNamespace;
 use route::Route;
 
-use upload_form::build_upload_form;
-
 use std::path::Path;
 
 use crate::commands;
@@ -93,7 +91,7 @@ fn publish_script(
         http::auth_client(None, user)
     };
 
-    let script_upload_form = build_upload_form(target, asset_manifest)?;
+    let script_upload_form = upload_form::build(target, asset_manifest)?;
 
     let mut res = client
         .put(&worker_addr)

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -9,10 +9,11 @@ pub use package::Package;
 use crate::settings::target::KvNamespace;
 use route::Route;
 
-use upload_form::build_script_and_upload_form;
+use upload_form::build_upload_form;
 
 use std::path::Path;
 
+use crate::commands;
 use crate::commands::kv;
 use crate::commands::kv::bucket::AssetManifest;
 use crate::commands::subdomain::Subdomain;
@@ -43,7 +44,11 @@ pub fn publish(
     }
 
     let asset_manifest = upload_buckets(target, user, verbose)?;
-    build_and_publish_script(&user, &target, asset_manifest)?;
+
+    // Build the script before uploading.
+    commands::build(&target)?;
+
+    publish_script(&user, &target, asset_manifest)?;
 
     Ok(())
 }
@@ -72,7 +77,7 @@ pub fn bind_static_site_contents(
     Ok(())
 }
 
-fn build_and_publish_script(
+fn publish_script(
     user: &GlobalUser,
     target: &Target,
     asset_manifest: Option<AssetManifest>,
@@ -88,7 +93,7 @@ fn build_and_publish_script(
         http::auth_client(None, user)
     };
 
-    let script_upload_form = build_script_and_upload_form(target, asset_manifest)?;
+    let script_upload_form = build_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .put(&worker_addr)

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -16,8 +16,8 @@ impl Package {
             )
         } else if !build_dir.join(&self.main).exists() {
             failure::bail!(
-                "The entrypoint of your Worker ({:?}) could not be found.",
-                self.main
+                "The entrypoint of your Worker ({}) could not be found.",
+                self.main.display()
             )
         } else {
             Ok(self.main.clone())
@@ -30,15 +30,15 @@ impl Package {
         let manifest_path = pkg_path.join("package.json");
         if !manifest_path.is_file() {
             failure::bail!(
-                "Your JavaScript project is missing a `package.json` file; is `{:?}` the \
+                "Your JavaScript project is missing a `package.json` file; is `{}` the \
                  wrong directory?",
-                pkg_path
+                pkg_path.display()
             )
         }
 
         let package_json: String = fs::read_to_string(manifest_path.clone())?.parse()?;
         let package: Package = serde_json::from_str(&package_json)
-            .unwrap_or_else(|_| panic!("could not parse {:?}", manifest_path));
+            .unwrap_or_else(|_| panic!("could not parse {}", manifest_path.display()));
 
         Ok(package)
     }

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -12,7 +12,7 @@ impl Package {
     pub fn main(&self, build_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
         if self.main == PathBuf::from("") {
             failure::bail!(
-                "The `main` key in your `package.json` file is required; please specified the entrypoint of your Worker.",
+                "The `main` key in your `package.json` file is required; please specify the entry point of your Worker.",
             )
         } else if !build_dir.join(&self.main).exists() {
             failure::bail!(

--- a/src/commands/publish/package.rs
+++ b/src/commands/publish/package.rs
@@ -6,17 +6,17 @@ use serde::{self, Deserialize};
 #[derive(Debug, Deserialize)]
 pub struct Package {
     #[serde(default)]
-    main: String,
+    main: PathBuf,
 }
 impl Package {
-    pub fn main(&self, build_dir: &PathBuf) -> Result<String, failure::Error> {
-        if self.main == "" {
+    pub fn main(&self, build_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
+        if self.main == PathBuf::from("") {
             failure::bail!(
                 "The `main` key in your `package.json` file is required; please specified the entrypoint of your Worker.",
             )
         } else if !build_dir.join(&self.main).exists() {
             failure::bail!(
-                "The entrypoint of your Worker ({}) could not be found.",
+                "The entrypoint of your Worker ({:?}) could not be found.",
                 self.main
             )
         } else {

--- a/src/commands/publish/preview/mod.rs
+++ b/src/commands/publish/preview/mod.rs
@@ -7,7 +7,7 @@ mod http_method;
 pub use http_method::HTTPMethod;
 
 mod upload;
-use upload::build_and_upload;
+use upload::upload;
 
 use crate::commands;
 
@@ -35,9 +35,11 @@ pub fn preview(
     livereload: bool,
     verbose: bool,
 ) -> Result<(), failure::Error> {
+    commands::build(&target)?;
+
     let sites_preview: bool = target.site.is_some();
 
-    let script_id = build_and_upload(&mut target, user.as_ref(), sites_preview, verbose)?;
+    let script_id = upload(&mut target, user.as_ref(), sites_preview, verbose)?;
 
     let session = Uuid::new_v4().to_simple();
     let preview_host = "example.com";
@@ -147,7 +149,9 @@ fn watch_for_changes(
     commands::watch_and_build(&target, Some(tx))?;
 
     while let Ok(_e) = rx.recv() {
-        if let Ok(new_id) = build_and_upload(&mut target, user, sites_preview, verbose) {
+        commands::build(&target)?;
+
+        if let Ok(new_id) = upload(&mut target, user, sites_preview, verbose) {
             let msg = FiddleMessage {
                 session_id: session_id.clone(),
                 data: FiddleMessageData::LiveReload { new_id },

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -38,7 +38,7 @@ const SITES_UNAUTH_PREVIEW_ERR: &str =
      authenticate to upload your site contents.";
 
 // Builds and uploads the script and its bindings. Returns the ID of the uploaded script.
-pub fn build_and_upload(
+pub fn upload(
     target: &mut Target,
     user: Option<&GlobalUser>,
     sites_preview: bool,
@@ -133,7 +133,7 @@ fn authenticated_upload(
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_script_and_upload_form(target, asset_manifest)?;
+    let script_upload_form = publish::build_upload_form(target, asset_manifest)?;
 
     let mut res = client
         .post(&create_address)
@@ -163,9 +163,9 @@ fn unauthenticated_upload(client: &Client, target: &Target) -> Result<Preview, f
         );
         let mut target = target.clone();
         target.kv_namespaces = None;
-        publish::build_script_and_upload_form(&target, None)?
+        publish::build_upload_form(&target, None)?
     } else {
-        publish::build_script_and_upload_form(&target, None)?
+        publish::build_upload_form(&target, None)?
     };
 
     let mut res = client

--- a/src/commands/publish/preview/upload.rs
+++ b/src/commands/publish/preview/upload.rs
@@ -133,7 +133,7 @@ fn authenticated_upload(
     );
     log::info!("address: {}", create_address);
 
-    let script_upload_form = publish::build_upload_form(target, asset_manifest)?;
+    let script_upload_form = publish::upload_form::build(target, asset_manifest)?;
 
     let mut res = client
         .post(&create_address)
@@ -163,9 +163,9 @@ fn unauthenticated_upload(client: &Client, target: &Target) -> Result<Preview, f
         );
         let mut target = target.clone();
         target.kv_namespaces = None;
-        publish::build_upload_form(&target, None)?
+        publish::upload_form::build(&target, None)?
     } else {
-        publish::build_upload_form(&target, None)?
+        publish::upload_form::build(&target, None)?
     };
 
     let mut res = client

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -7,7 +7,6 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::commands;
 use crate::commands::build::wranglerjs;
 use crate::commands::kv::bucket::AssetManifest;
 use crate::settings::binding;
@@ -20,13 +19,10 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_script_and_upload_form(
+pub fn build_upload_form(
     target: &Target,
     asset_manifest: Option<AssetManifest>,
 ) -> Result<Form, failure::Error> {
-    // Build the script before uploading.
-    commands::build(&target)?;
-
     let target_type = &target.target_type;
     let kv_namespaces = target.kv_namespaces();
     match target_type {

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -5,6 +5,7 @@ mod wasm_module;
 use reqwest::multipart::{Form, Part};
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::commands;
 use crate::commands::build::wranglerjs;
@@ -36,11 +37,11 @@ pub fn build_script_and_upload_form(
             build_generated_dir()?;
             concat_js(&name)?;
 
-            let path = format!("./pkg/{}_bg.wasm", name);
+            let path = PathBuf::from(format!("./pkg/{}_bg.wasm", name));
             let binding = "wasm".to_string();
             let wasm_module = WasmModule::new(path, binding)?;
 
-            let script_path = "./worker/generated/script.js".to_string();
+            let script_path = PathBuf::from("./worker/generated/script.js");
 
             let assets =
                 ProjectAssets::new(script_path, vec![wasm_module], kv_namespaces, Vec::new())?;
@@ -144,8 +145,7 @@ fn add_metadata(mut form: Form, assets: &ProjectAssets) -> Result<Form, failure:
     Ok(form)
 }
 
-fn filename_from_path(path: &str) -> Option<String> {
-    let path = Path::new(path);
+fn filename_from_path(path: &PathBuf) -> Option<String> {
     path.file_stem()?.to_str().map(|s| s.to_string())
 }
 

--- a/src/commands/publish/upload_form/mod.rs
+++ b/src/commands/publish/upload_form/mod.rs
@@ -19,7 +19,7 @@ use wasm_module::WasmModule;
 
 use super::{krate, Package};
 
-pub fn build_upload_form(
+pub fn build(
     target: &Target,
     asset_manifest: Option<AssetManifest>,
 ) -> Result<Form, failure::Error> {

--- a/src/commands/publish/upload_form/project_assets.rs
+++ b/src/commands/publish/upload_form/project_assets.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use failure::format_err;
 
 use super::binding::Binding;
@@ -10,7 +12,7 @@ use crate::settings::target::KvNamespace;
 #[derive(Debug)]
 pub struct ProjectAssets {
     script_name: String,
-    script_path: String,
+    script_path: PathBuf,
     pub wasm_modules: Vec<WasmModule>,
     pub kv_namespaces: Vec<KvNamespace>,
     pub text_blobs: Vec<TextBlob>,
@@ -18,13 +20,13 @@ pub struct ProjectAssets {
 
 impl ProjectAssets {
     pub fn new(
-        script_path: String,
+        script_path: PathBuf,
         wasm_modules: Vec<WasmModule>,
         kv_namespaces: Vec<KvNamespace>,
         text_blobs: Vec<TextBlob>,
     ) -> Result<Self, failure::Error> {
         let script_name = filename_from_path(&script_path)
-            .ok_or_else(|| format_err!("filename should not be empty: {}", script_path))?;
+            .ok_or_else(|| format_err!("filename should not be empty: {:?}", script_path))?;
 
         Ok(Self {
             script_name,
@@ -58,7 +60,7 @@ impl ProjectAssets {
         self.script_name.to_string()
     }
 
-    pub fn script_path(&self) -> String {
-        self.script_path.to_string()
+    pub fn script_path(&self) -> PathBuf {
+        self.script_path.clone()
     }
 }

--- a/src/commands/publish/upload_form/project_assets.rs
+++ b/src/commands/publish/upload_form/project_assets.rs
@@ -25,8 +25,9 @@ impl ProjectAssets {
         kv_namespaces: Vec<KvNamespace>,
         text_blobs: Vec<TextBlob>,
     ) -> Result<Self, failure::Error> {
-        let script_name = filename_from_path(&script_path)
-            .ok_or_else(|| format_err!("filename should not be empty: {:?}", script_path))?;
+        let script_name = filename_from_path(&script_path).ok_or_else(|| {
+            format_err!("filename should not be empty: {}", script_path.display())
+        })?;
 
         Ok(Self {
             script_name,

--- a/src/commands/publish/upload_form/wasm_module.rs
+++ b/src/commands/publish/upload_form/wasm_module.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use failure::format_err;
 
 use super::binding::Binding;
@@ -5,15 +7,15 @@ use super::filename_from_path;
 
 #[derive(Debug)]
 pub struct WasmModule {
-    path: String,
+    path: PathBuf,
     filename: String,
     binding: String,
 }
 
 impl WasmModule {
-    pub fn new(path: String, binding: String) -> Result<Self, failure::Error> {
+    pub fn new(path: PathBuf, binding: String) -> Result<Self, failure::Error> {
         let filename = filename_from_path(&path)
-            .ok_or_else(|| format_err!("filename should not be empty: {}", path))?;
+            .ok_or_else(|| format_err!("filename should not be empty: {:?}", path))?;
 
         Ok(Self {
             filename,
@@ -31,8 +33,8 @@ impl WasmModule {
         Binding::new_wasm_module(name, part)
     }
 
-    pub fn path(&self) -> String {
-        self.path.to_string()
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
     }
 
     pub fn filename(&self) -> String {

--- a/src/commands/publish/upload_form/wasm_module.rs
+++ b/src/commands/publish/upload_form/wasm_module.rs
@@ -15,7 +15,7 @@ pub struct WasmModule {
 impl WasmModule {
     pub fn new(path: PathBuf, binding: String) -> Result<Self, failure::Error> {
         let filename = filename_from_path(&path)
-            .ok_or_else(|| format_err!("filename should not be empty: {:?}", path))?;
+            .ok_or_else(|| format_err!("filename should not be empty: {}", path.display()))?;
 
         Ok(Self {
             filename,


### PR DESCRIPTION
Some refactors to make testing upload form building easier.

* Use PathBuf instead of String when generating upload forms
* remove call to build command from upload form building logic