### PR TITLE
Adds error message for site with non-trailing asterisk

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -38,7 +38,7 @@ pub fn publish(
     if let Some(site_config) = target.site.clone() {
         if let Some(route) = &target.route {
             if !route.ends_with("*") {
-                failure::bail!("The route in your wrangler.toml should have a trailing * to apply the Worker on every path, otherwise your site will not behave as expected.\nroute = {}*", route)
+                message::warn(&format!("The route in your wrangler.toml should have a trailing * to apply the Worker on every path, otherwise your site will not behave as expected.\nroute = {}*", route));
             }
         }
         bind_static_site_contents(user, target, &site_config, false)?;

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -36,6 +36,11 @@ pub fn publish(
     validate_worker_name(&target.name)?;
 
     if let Some(site_config) = target.site.clone() {
+        if let Some(route) = &target.route {
+            if !route.ends_with("*") {
+                failure::bail!("The route in your wrangler.toml should have a trailing * to apply the Worker on every path, otherwise your site will not behave as expected.\nroute = {}*", route)
+            }
+        }
         bind_static_site_contents(user, target, &site_config, false)?;
     }
 


### PR DESCRIPTION
Fixes #814 

This PR adds an error message for users deploying a site to a route without a trailing asterisk.

```console
$ wrangler publish
Error: The route in your wrangler.toml should have a trailing * to apply the Worker on every path.
route = test.averyharnish.com*
```

Open to suggestions on the error message itself, and if we think this should be a `message::warn` instead of a `failure::bail`. The reason I have it bailing here is because I see absolutely no scenario where you would deploy a site without a trailing asterisk. Even for single page applications I believe you still need the worker to run on every route.