### PR TITLE
Update wrangler config messaging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -403,8 +403,9 @@ fn run() -> Result<(), failure::Error> {
         let default = !matches.is_present("api-key");
 
         let user: GlobalUser = if default {
-            // Default: use API token.
-            message::info("Looking to use a Global API Key and email instead? Run \"wrangler config --api-key\". (Not Recommended)");
+            // API Tokens are the default
+            message::info("To find your API token, go to https://dash.cloudflare.com/profile/api-tokens and create it using the \"Edit Cloudflare Workers\" template");
+            message::info("If you are trying to use your Global API Key instead of an API Token (Not Recommended), run \"wrangler config --api-key\".");
             println!("Enter API token: ");
             let mut api_token: String = read!("{}\n");
             api_token.truncate(api_token.trim_end().len());


### PR DESCRIPTION
This PR doesn't need to make it into the changelog, it's nits on the new `wrangler config` messaging.

The first is an additional message explaining where users can go to create their API token.

The second is kind of based on this comment and just changes the wording of the message explaining the difference between global api key/email and api token: https://github.com/cloudflare/wrangler/pull/471#discussion_r341770699

**Before:**

```console
$ wrangler config
💁  Looking to use a Global API Key and email instead? Run "wrangler config --api-key". (Not Recommended)
Enter API token:
asdjhkfjasdljfhaasdjhkfjasdljfhaasdjhkfjasd
✨  Successfully configured. You can find your configuration file at: /Users/averyharnish/.wrangler/config/default.toml
```

**After:**

```console
$ wrangler config
💁  To find your API token, go to https://dash.cloudflare.com/profile/api-tokens and create it using the "Edit Cloudflare Workers" template
💁  If you are trying to use your Global API Key instead of an API Token (Not Recommended), run "wrangler config --api-key".
Enter API token: 
asdjhkfjasdljfhaasdjhkfjasdljfhaasdjhkfjasd
✨  Successfully configured. You can find your configuration file at: /Users/averyharnish/.wrangler/config/default.toml
```