### PR TITLE
run-wrangler.js: send error to stderr and exit 1 if child process has an error

### DIFF
--- a/npm/run-wrangler.js
+++ b/npm/run-wrangler.js
@@ -12,4 +12,12 @@ const opts = {
   cwd: process.cwd(),
   stdio: "inherit"
 };
-process.exit(spawnSync(bin, args, opts).status);
+
+const result = spawnSync(bin, args, opts);
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+process.exit(result.status);


### PR DESCRIPTION
fixes #848 

ideally i'd add some tests but there doesn't seem to be a test suite for the npm shim. let me know if you have any preference there or if it's fine to just leave untested.

before:

```fish
> ./npm/run-wrangler.js --version
👷 ✨  wrangler 1.5.0
> mv ~/.wrangler/out/wrangler ~/.wrangler/out/wrangler.bak
> ./npm/run-wrangler.js --version
> echo $status
0
```

after:

```fish
> ./npm/run-wrangler.js --version
👷 ✨  wrangler 1.5.0
> mv ~/.wrangler/out/wrangler ~/.wrangler/out/wrangler.bak
jared@Jareds-MBP-2 ~/p/wrangler> ./npm/run-wrangler.js --version
{ Error: spawnSync /Users/jared/.wrangler/out/wrangler ENOENT
    at _errnoException (util.js:992:11)
    at spawnSync (child_process.js:579:20)
    at Object.<anonymous> (/Users/jared/projects/wrangler/npm/run-wrangler.js:16:16)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawnSync /Users/jared/.wrangler/out/wrangler',
  path: '/Users/jared/.wrangler/out/wrangler',
  spawnargs: [ '--version' ] }
> echo $status
1
```