### PR TITLE
Rename proxy to dev

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,7 +15,7 @@ pub use build::build;
 pub use build::watch_and_build;
 pub use generate::generate;
 pub use init::init;
-pub use preview::{preview, proxy, HTTPMethod};
+pub use preview::{dev_server, preview, HTTPMethod};
 pub use publish::publish;
 use regex::Regex;
 pub use subdomain::get_subdomain;

--- a/src/commands/preview/dev_server.rs
+++ b/src/commands/preview/dev_server.rs
@@ -15,22 +15,24 @@ use uuid::Uuid;
 
 use url::Url;
 
+use crate::commands;
+use crate::commands::preview::upload;
+
 use crate::settings::global_user::GlobalUser;
 use crate::settings::target::Target;
 
-use crate::commands;
-use crate::commands::preview::upload;
+use crate::terminal::emoji;
 
 const PREVIEW_HOST: &str = "rawhttp.cloudflareworkers.com";
 
 #[derive(Clone)]
-struct ProxyConfig {
+struct ServerConfig {
     host: String,
     listening_address: SocketAddr,
     is_https: bool,
 }
 
-impl ProxyConfig {
+impl ServerConfig {
     pub fn new(
         host: Option<&str>,
         ip: Option<&str>,
@@ -64,7 +66,7 @@ impl ProxyConfig {
 
         let host = parsed_url.host_str().ok_or(format_err!("Invalid host, accepted formats are example.com, http://example.com, or https://example.com"))?.to_string();
 
-        Ok(ProxyConfig {
+        Ok(ServerConfig {
             listening_address,
             host,
             is_https,
@@ -78,7 +80,7 @@ impl ProxyConfig {
     }
 }
 
-pub async fn proxy(
+pub async fn dev_server(
     target: Target,
     user: Option<GlobalUser>,
     host: Option<&str>,
@@ -86,32 +88,36 @@ pub async fn proxy(
     ip: Option<&str>,
 ) -> Result<(), failure::Error> {
     commands::build(&target)?;
-    let proxy_config = ProxyConfig::new(host, ip, port)?;
+    let server_config = ServerConfig::new(host, ip, port)?;
     let https = HttpsConnector::new().expect("TLS initialization failed");
     let client = Client::builder().build::<_, Body>(https);
 
-    let preview_id = get_preview_id(target, user, &proxy_config)?;
-    let listening_address = &proxy_config.listening_address.clone();
-    let listening_address_string = proxy_config.listening_address_as_string();
+    let preview_id = get_preview_id(target, user, &server_config)?;
+    let listening_address = &server_config.listening_address.clone();
+    let listening_address_string = server_config.listening_address_as_string();
 
     let make_service = make_service_fn(move |_| {
         let client = client.clone();
         let preview_id = preview_id.to_owned();
-        let proxy_config = proxy_config.clone();
+        let server_config = server_config.clone();
         async move {
             Ok::<_, failure::Error>(service_fn(move |req| {
                 preview_request(
                     req,
                     client.to_owned(),
                     preview_id.to_owned(),
-                    proxy_config.clone(),
+                    server_config.clone(),
                 )
             }))
         }
     });
 
     let server = Server::bind(listening_address).serve(make_service);
-    println!("Listening on http://{}", listening_address_string);
+    println!(
+        "{} Listening on http://{}",
+        emoji::EAR,
+        listening_address_string
+    );
     if let Err(e) = server.await {
         eprintln!("server error: {}", e);
     }
@@ -133,7 +139,7 @@ fn preview_request(
     req: Request<Body>,
     client: Client<HttpsConnector<HttpConnector>>,
     preview_id: String,
-    proxy_config: ProxyConfig,
+    server_config: ServerConfig,
 ) -> ResponseFuture {
     let (mut parts, body) = req.into_parts();
 
@@ -161,7 +167,7 @@ fn preview_request(
         "[{}] \"{} {}{} {:?}\"",
         now.format("%Y-%m-%d %H:%M:%S"),
         method,
-        proxy_config.host,
+        server_config.host,
         path,
         req.version()
     );
@@ -171,7 +177,7 @@ fn preview_request(
 fn get_preview_id(
     mut target: Target,
     user: Option<GlobalUser>,
-    proxy_config: &ProxyConfig,
+    server_config: &ServerConfig,
 ) -> Result<String, failure::Error> {
     let session = Uuid::new_v4().to_simple();
     let verbose = true;
@@ -179,6 +185,6 @@ fn get_preview_id(
     let script_id: String = upload(&mut target, user.as_ref(), sites_preview, verbose)?;
     Ok(format!(
         "{}{}{}{}",
-        &script_id, session, proxy_config.is_https as u8, proxy_config.host
+        &script_id, session, server_config.is_https as u8, server_config.host
     ))
 }

--- a/src/commands/preview/mod.rs
+++ b/src/commands/preview/mod.rs
@@ -6,8 +6,8 @@ use fiddle_messenger::*;
 mod http_method;
 pub use http_method::HTTPMethod;
 
-mod proxy;
-pub use proxy::proxy;
+mod dev_server;
+pub use dev_server::dev_server;
 
 mod upload;
 use upload::upload;

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,10 +349,10 @@ fn run() -> Result<(), failure::Error> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("proxy")
+            SubCommand::with_name("dev")
                 .about(&*format!(
-                    "{} Create a proxy to preview your worker",
-                    emoji::UP // TODO: get new emoji
+                    "{} Start a local server for developing your worker",
+                    emoji::EAR
                 ))
                 .arg(
                     Arg::with_name("port")
@@ -544,8 +544,8 @@ fn run() -> Result<(), failure::Error> {
         let headless = matches.is_present("headless");
 
         commands::preview(target, user, method, body, watch, verbose, headless)?;
-    } else if let Some(matches) = matches.subcommand_matches("proxy") {
-        log::info!("Starting proxy service");
+    } else if let Some(matches) = matches.subcommand_matches("dev") {
+        log::info!("Starting dev server");
         let port = matches.value_of("port");
         let host = matches.value_of("host");
         let ip = matches.value_of("ip");
@@ -554,7 +554,7 @@ fn run() -> Result<(), failure::Error> {
         let target = manifest.get_target(env)?;
         let user = settings::global_user::GlobalUser::new().ok();
         let rt = Runtime::new().unwrap();
-        rt.block_on(commands::proxy(target, user, host, port, ip))?;
+        rt.block_on(commands::dev_server(target, user, host, port, ip))?;
         rt.shutdown_now();
     } else if matches.subcommand_matches("whoami").is_some() {
         log::info!("Getting User settings");

--- a/src/terminal/emoji.rs
+++ b/src/terminal/emoji.rs
@@ -15,7 +15,9 @@ use console::Emoji;
 
 pub static BICEP: Emoji = Emoji("💪 ", "");
 pub static CRAB: Emoji = Emoji("🦀 ", "");
+pub static COMPUTER: Emoji = Emoji("💻 ", "");
 pub static DANCERS: Emoji = Emoji("👯 ", "");
+pub static EAR: Emoji = Emoji("👂 ", "");
 pub static EYES: Emoji = Emoji("👀 ", "");
 pub static FILES: Emoji = Emoji("🗂️ ", "");
 pub static INBOX: Emoji = Emoji("📥 ", "");


### PR DESCRIPTION
Rename `wrangler proxy` to `wrangler dev`

Reasoning:

"proxy" means too many things, this isn't really a proxy, it's a MITM layer. 

Users won't know what "proxy" means, and may be scared away because they think they are not smart enough to understand.

If it truly was a "proxy" it would still be an implementation detail. This is a local development environment that requires an internet connection.