### PR TITLE
Make azure use latest rustc

### DIFF
--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -4,6 +4,7 @@ parameters:
 steps:
   - bash: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
+      rustup update $TOOLCHAIN
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     displayName: Install rust - Unix
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
@@ -12,6 +13,7 @@ steps:
   - script: |
       curl -sSf -o rustup-init.exe https://win.rustup.rs
       rustup-init.exe -y --default-toolchain %TOOLCHAIN%
+      rustup update %TOOLCHAIN%
       echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     displayName: Install rust - Windows
     condition: eq( variables['Agent.OS'], 'Windows_NT' )


### PR DESCRIPTION
Builds are failing for dev server - run `rustup update stable` after curl installer

Fixes #887 