### PR TITLE
reformat config api-key output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -423,7 +423,7 @@ fn run() -> Result<(), failure::Error> {
             api_token.truncate(api_token.trim_end().len());
             GlobalUser::TokenAuth { api_token }
         } else {
-            message::warn("We don't recommend using your Global API Key! Please consider using an API Token instead. https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys");
+            message::big_info("We don't recommend using your Global API Key! Please consider using an\n\tAPI Token instead.\n\thttps://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys\n");
             println!("Enter email: ");
             let mut email: String = read!("{}\n");
             email.truncate(email.trim_end().len());


### PR DESCRIPTION
Resolves #889 

```
$ wrangler config --api-key 
         We don't recommend using your Global API Key! Please consider using an
        API Token instead.
        https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys

Enter email: 
...
```

which matches formatting of:

```
$ wrangler config 
         To find your API token, go to https://dash.cloudflare.com/profile/api-tokens
        and create it using the "Edit Cloudflare Workers" template

         If you are trying to use your Global API Key instead of an API Token
        (Not Recommended), run "wrangler config --api-key".

Enter API token: 
...
```