### PR TITLE
Refactor: Use cloudflare-rs for calls to routes endpoints

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -5,8 +5,6 @@ pub mod upload_form;
 
 pub use package::Package;
 
-use route::Route;
-
 use std::env;
 use std::path::Path;
 
@@ -109,8 +107,8 @@ fn publish_script(
     }
 
     let pattern = if target.route.is_some() {
-        let route = Route::new(&target)?;
-        Route::publish(&user, &target, &route)?;
+        let route = route::Route::new(&target)?;
+        route::publish(&user, &target, &route)?;
         log::info!("publishing to route");
         route.pattern
     } else {

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -4,6 +4,7 @@ mod route;
 pub mod upload_form;
 
 pub use package::Package;
+use route::{publish_route, Route};
 
 use std::env;
 use std::path::Path;
@@ -107,8 +108,8 @@ fn publish_script(
     }
 
     let pattern = if target.route.is_some() {
-        let route = route::Route::new(&target)?;
-        route::publish(&user, &target, &route)?;
+        let route = Route::new(&target)?;
+        publish_route(&user, &target, &route)?;
         log::info!("publishing to route");
         route.pattern
     } else {

--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -5,8 +5,6 @@ use crate::terminal::emoji;
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 
-use log::info;
-
 #[derive(Deserialize, Serialize)]
 pub struct Route {
     script: Option<String>,
@@ -28,7 +26,10 @@ impl Route {
         {
             failure::bail!("You must provide a zone_id in your wrangler.toml before publishing!");
         }
-        let msg_config_error = format!("{} Your project config has an error, check your `wrangler.toml`: `route` must be provided.", emoji::WARN);
+        let msg_config_error = format!(
+            "{} Your project config has an error, check your `wrangler.toml`: `route` must be provided.", 
+            emoji::WARN
+        );
         Ok(Route {
             script: Some(target.name.to_string()),
             pattern: target.route.clone().expect(&msg_config_error),
@@ -90,7 +91,7 @@ fn create(user: &GlobalUser, target: &Target, route: &Route) -> Result<(), failu
 
     let routes_addr = get_routes_addr(target)?;
 
-    info!("Creating your route {:#?}", &route.pattern,);
+    log::info!("Creating your route {:#?}", &route.pattern,);
     let mut res = client
         .post(&routes_addr)
         .header(CONTENT_TYPE, "application/json")

--- a/src/commands/publish/route.rs
+++ b/src/commands/publish/route.rs
@@ -45,14 +45,19 @@ impl Route {
     }
 }
 
-pub fn publish(user: &GlobalUser, target: &Target, route: &Route) -> Result<(), failure::Error> {
-    if exists(user, target, route)? {
-        return Ok(());
+pub fn publish_route(
+    user: &GlobalUser,
+    target: &Target,
+    route: &Route,
+) -> Result<(), failure::Error> {
+    if route_exists(user, target, route)? {
+        Ok(())
+    } else {
+        create(user, target, route)
     }
-    create(user, target, route)
 }
 
-fn exists(user: &GlobalUser, target: &Target, route: &Route) -> Result<bool, failure::Error> {
+fn route_exists(user: &GlobalUser, target: &Target, route: &Route) -> Result<bool, failure::Error> {
     let routes = get_routes(user, target)?;
 
     for remote_route in routes {
@@ -87,7 +92,7 @@ fn create(user: &GlobalUser, target: &Target, route: &Route) -> Result<(), failu
             script: route.script.clone(),
         },
     }) {
-        Ok(_success) => Ok(()),
+        Ok(_) => Ok(()),
         Err(e) => failure::bail!("{}", format_error(e, Some(&routes_error_help))),
     }
 }

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::fs;
-use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
 use cloudflare::framework::auth::Credentials;
@@ -147,6 +146,7 @@ pub fn get_global_config_path() -> Result<PathBuf, failure::Error> {
 mod tests {
     use super::*;
     use std::fs::File;
+    use std::io::prelude::*;
     use tempfile::tempdir;
 
     use crate::settings::environment::MockEnvironment;


### PR DESCRIPTION
**NOTE: this PR is blocked as it will not compile until https://github.com/cloudflare/cloudflare-rs/pull/69 is merged and published. To test locally, build cloudflare-rs from the branch alewis/fix#68 and point wrangler's cargo.toml at that `path`**

This PR includes a refactor to use cloudflare-rs as the client for routes calls.

Also some 💅 :
* use `log::info` directly
* pull methods out of Route struct impl into functions in anticipation of additional refactors.
* impl PartialEq for Route rather than defining `Route.match` function
* move std::prelude::* import in global_user to test mod (fmt warning)