### PR TITLE
[WIP] Add logic to download cloudflared binary from equinox.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,6 +2404,7 @@ dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_with 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.6"
 openssl = { version = '0.10.11', optional = true }
 reqwest = "0.9.18"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.3.1"
 serde_json = "1.0.39"
 toml = "0.5.0"
 uuid = "0.7"

--- a/src/commands/cloudflared/mod.rs
+++ b/src/commands/cloudflared/mod.rs
@@ -1,4 +1,5 @@
 use crate::commands;
+use crate::install;
 use crate::terminal::message;
 
 use std::path::PathBuf;
@@ -13,11 +14,11 @@ use hyper::service::service_fn;
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
 pub fn run_cloudflared_start_server() -> Result<(), failure::Error> {
-    let tool_name = PathBuf::from("cloudflared");
-    // let binary_path = install::install(tool_name, "cloudflare")?.binary(tool_name)?;
+    let tool_name = "cloudflared";
+    let binary_path = install::install(tool_name, "cloudflare")?.binary(tool_name)?;
     let args = ["tunnel"];
 
-    let command = command(&args, &tool_name);
+    let command = command(&args, &binary_path);
     let command_name = format!("{:?}", command);
 
     start_echo_http_server();

--- a/src/install/equinox.rs
+++ b/src/install/equinox.rs
@@ -1,0 +1,113 @@
+use crate::install::target;
+
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
+use reqwest::Client;
+use serde::{self, Deserialize, Serialize};
+
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    // TOOL_TO_ID_MAP maps a toolname to its equnix app_id.
+    static ref TOOL_TO_ID_MAP: HashMap<&'static str, &'static str> = [
+        ("cloudflared", "app_idCzgxYerVD")
+    ].iter().copied().collect();
+}
+
+// DOWNLOADS: tuples of (app_id, owner) we know to download from equinox.io.
+pub const DOWNLOADS: &[(&str, &str)] = &[
+    ("cloudflared", "cloudflare"), // First arg is the tool_id for Equinox lookup (this is used in place of a tool name).
+];
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize)]
+struct EquinoxVersionRequestParams<'a> {
+    app_id: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    target_version: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EquinoxVersion {
+    download_url: String,
+    release: EquinoxRelease,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EquinoxRelease {
+    version: String,
+}
+
+pub fn prebuilt_url(tool_name: &str, version: &str) -> Option<String> {
+    let app_id = match TOOL_TO_ID_MAP.get(tool_name) {
+        Some(id) => id,
+        None => "",
+    };
+    match check(app_id, Some(version)) {
+        // If URL exists, we want to download it as a tarball using the .tgz extension.
+        Ok(result) => Some(format!("{}.tgz", result.download_url)),
+        Err(_) => None,
+    }
+}
+
+pub fn get_latest_version(tool_name: &str) -> Result<String, failure::Error> {
+    let app_id = match TOOL_TO_ID_MAP.get(tool_name) {
+        Some(id) => id,
+        None => "",
+    };
+    let latest = check(app_id, None)?.release.version;
+    Ok(latest)
+}
+
+// If successful, returns version number and download endpoint.
+fn check(app_id: &str, version: Option<&str>) -> Result<EquinoxVersion, failure::Error> {
+    let (os, arch): (&str, &str) = if target::LINUX && target::x86_64 {
+        ("linux", "amd64")
+    } else if target::MACOS && target::x86_64 {
+        ("darwin", "amd64")
+    } else if target::WINDOWS && target::x86_64 {
+        ("windows", "amd64")
+    } else {
+        failure::bail!("Your platform does not support cloudflared at the moment.")
+    };
+
+    let params = EquinoxVersionRequestParams {
+        app_id,
+        os,
+        arch,
+        target_version: version,
+    };
+
+    let client = equinox_client()?;
+
+    let mut res = client
+        .post("https://update.equinox.io/check")
+        .json(&params)
+        .send()?;
+
+    let res_status = res.status();
+    let res_text = res.text()?;
+
+    if !res_status.is_success() {
+        failure::bail!(format!("{}:{}", res_status, res_text));
+    }
+
+    let version: EquinoxVersion = serde_json::from_str(&res_text)?;
+    return Ok(version);
+}
+
+fn equinox_client() -> Result<Client, failure::Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("application/json; q=1; version=1; charset=utf-8"),
+    );
+
+    match Client::builder().default_headers(headers).build() {
+        Ok(c) => Ok(c),
+        Err(e) => failure::bail!(e),
+    }
+}

--- a/src/install/github.rs
+++ b/src/install/github.rs
@@ -1,0 +1,37 @@
+use crate::install::krate::Krate;
+use crate::install::target;
+
+// DOWNLOADS: tuples of (tool_name, owner) we know to download from GitHub.
+pub const DOWNLOADS: &[(&str, &str)] = &[
+    ("cargo-generate", "ashleygwilliams"),
+    ("wasm-pack", "rustwasm"),
+];
+
+pub fn prebuilt_url(tool_name: &str, tool_owner: &str, version: &str) -> Option<String> {
+    if tool_name == "wranglerjs" {
+        Some(format!(
+            "https://workers.cloudflare.com/get-wranglerjs-binary/{0}/v{1}.tar.gz",
+            tool_name, version
+        ))
+    } else {
+        let target = if target::LINUX && target::x86_64 {
+            "x86_64-unknown-linux-musl"
+        } else if target::MACOS && target::x86_64 {
+            "x86_64-apple-darwin"
+        } else if target::WINDOWS && target::x86_64 {
+            "x86_64-pc-windows-msvc"
+        } else {
+            return None;
+        };
+
+        let url = format!(
+            "https://workers.cloudflare.com/get-binary/{0}/{1}/v{2}/{3}.tar.gz",
+            tool_owner, tool_name, version, target
+        );
+        Some(url)
+    }
+}
+
+pub fn get_latest_version(tool_name: &str) -> Result<String, failure::Error> {
+    Ok(Krate::new(tool_name)?.max_version)
+}


### PR DESCRIPTION
Closes #924.

Right now, this PR does not work as expected; it looks the the binary-install crate does not play well with the .tgz downloads from equinox.io:
```
thread 'main' panicked at 'don't know how to extract https://bin.equinox.io/a/hLuezyJbR6D/cloudflared-2019.11.3-linux-amd64.tgz', /home/gabbi/.cargo/registry/src/github.com-1ecc6299db9ec823/binary-install-0.0.3-alpha/src/lib.rs:125:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```