### PR TITLE
Alewis/improve test fixtures

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -20,6 +20,7 @@ fn it_builds_webpack() {
     fixture.scaffold_webpack();
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
     "#,
     );
@@ -49,6 +50,7 @@ fn it_builds_with_webpack_single_js() {
     fixture.create_default_package_json();
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
     "#,
     );
@@ -71,6 +73,7 @@ fn it_builds_with_webpack_function_config_js() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -94,6 +97,7 @@ fn it_builds_with_webpack_promise_config_js() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -117,6 +121,7 @@ fn it_builds_with_webpack_function_promise_config_js() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -140,6 +145,7 @@ fn it_builds_with_webpack_specify_config() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.worker.js"
     "#,
@@ -165,6 +171,7 @@ fn it_builds_with_webpack_single_js_missing_package_main() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
     "#,
     );
@@ -193,6 +200,7 @@ fn it_fails_with_multiple_webpack_configs() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -247,6 +255,7 @@ fn it_builds_with_webpack_wast() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -273,6 +282,7 @@ fn it_fails_with_webpack_target_node() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -302,6 +312,7 @@ fn it_fails_with_webpack_target_web() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,
@@ -331,6 +342,7 @@ fn it_builds_with_webpack_target_webworker() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
         webpack_config = "webpack.config.js"
     "#,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -19,9 +19,7 @@ fn it_builds_webpack() {
     let fixture = Fixture::new("webpack");
     fixture.scaffold_webpack();
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
+    let wrangler_toml = WranglerToml::webpack_no_config("test-build-webpack");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -49,9 +47,7 @@ fn it_builds_with_webpack_single_js() {
     );
     fixture.create_default_package_json();
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
+    let wrangler_toml = WranglerToml::webpack_no_config("test-build-webpack-single-js");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -70,10 +66,7 @@ fn it_builds_with_webpack_function_config_js() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-webpack-function");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -92,10 +85,7 @@ fn it_builds_with_webpack_promise_config_js() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-webpack-promise");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -114,10 +104,7 @@ fn it_builds_with_webpack_function_promise_config_js() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-webpack-function-promise");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -136,10 +123,10 @@ fn it_builds_with_webpack_specify_config() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.worker.js");
+    let wrangler_toml = WranglerToml::webpack_custom_config(
+        "test-build-webpack-specify-config",
+        "webpack.worker.js",
+    );
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -160,9 +147,8 @@ fn it_builds_with_webpack_single_js_missing_package_main() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
+    let wrangler_toml =
+        WranglerToml::webpack_no_config("test-build-webpack-single-js-missing-package-main");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
@@ -187,10 +173,7 @@ fn it_fails_with_multiple_webpack_configs() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-multiple-webpack-configs");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(&fixture, "Multiple webpack configurations are not supported. You can specify a different path for your webpack configuration file in wrangler.toml with the `webpack_config` field");
@@ -240,10 +223,7 @@ fn it_builds_with_webpack_wast() {
 
     fixture.create_file("module.wast", "(module)");
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-webpack-wast");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js", "module.wasm"]);
@@ -265,10 +245,7 @@ fn it_fails_with_webpack_target_node() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-fails-webpack-target-node");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
@@ -293,10 +270,7 @@ fn it_fails_with_webpack_target_web() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-fails-webpack-target-web");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
@@ -321,10 +295,7 @@ fn it_builds_with_webpack_target_webworker() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
-    wrangler_toml.webpack_config = Some("webpack.config.js");
+    let wrangler_toml = WranglerToml::webpack_std_config("test-build-webpack-target-webworker");
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -8,7 +8,7 @@ use std::str;
 use std::sync::Mutex;
 
 use assert_cmd::prelude::*;
-use fixture::Fixture;
+use fixture::{Fixture, WranglerToml};
 
 lazy_static! {
     static ref BUILD_LOCK: Mutex<u8> = Mutex::new(0);
@@ -18,12 +18,12 @@ lazy_static! {
 fn it_builds_webpack() {
     let fixture = Fixture::new("webpack");
     fixture.scaffold_webpack();
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-    "#,
-    );
+
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    fixture.create_wrangler_toml(wrangler_toml);
+
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup();
 }
@@ -48,12 +48,11 @@ fn it_builds_with_webpack_single_js() {
     "#,
     );
     fixture.create_default_package_json();
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-    "#,
-    );
+
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup();
@@ -71,13 +70,11 @@ fn it_builds_with_webpack_function_config_js() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup();
@@ -95,13 +92,11 @@ fn it_builds_with_webpack_promise_config_js() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup();
@@ -119,13 +114,11 @@ fn it_builds_with_webpack_function_promise_config_js() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup()
@@ -143,13 +136,11 @@ fn it_builds_with_webpack_specify_config() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.worker.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.worker.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup();
@@ -169,12 +160,10 @@ fn it_builds_with_webpack_single_js_missing_package_main() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
         &fixture,
@@ -198,13 +187,11 @@ fn it_fails_with_multiple_webpack_configs() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(&fixture, "Multiple webpack configurations are not supported. You can specify a different path for your webpack configuration file in wrangler.toml with the `webpack_config` field");
     fixture.cleanup();
@@ -253,13 +240,11 @@ fn it_builds_with_webpack_wast() {
 
     fixture.create_file("module.wast", "(module)");
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js", "module.wasm"]);
     fixture.cleanup();
@@ -280,13 +265,11 @@ fn it_fails_with_webpack_target_node() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
         &fixture,
@@ -310,13 +293,11 @@ fn it_fails_with_webpack_target_web() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(
         &fixture,
@@ -340,13 +321,11 @@ fn it_builds_with_webpack_target_webworker() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-        webpack_config = "webpack.config.js"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    wrangler_toml.webpack_config = Some("webpack.config.js");
+    fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
     fixture.cleanup()

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -151,3 +151,46 @@ pub struct WranglerToml<'a> {
     pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
     pub site: Option<SiteConfig<'a>>,
 }
+
+impl WranglerToml<'_> {
+    pub fn webpack_no_config(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("webpack");
+
+        wrangler_toml
+    }
+
+    pub fn webpack_std_config(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        wrangler_toml.webpack_config = Some("webpack.config.js");
+
+        wrangler_toml
+    }
+
+    pub fn webpack_custom_config<'a>(name: &'a str, webpack_config: &'a str) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        wrangler_toml.webpack_config = Some(webpack_config);
+
+        wrangler_toml
+    }
+
+    pub fn rust(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("rust");
+
+        wrangler_toml
+    }
+
+    pub fn javascript(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("javascript");
+
+        wrangler_toml
+    }
+}

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -78,7 +78,6 @@ impl Fixture {
         let content = &format!(
             r#"
             name = "test"
-            workers_dev = true
             {}
         "#,
             content

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+mod wrangler_toml;
+pub use wrangler_toml::{EnvConfig, KvConfig, SiteConfig, WranglerToml};
+
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -7,7 +9,6 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Mutex;
 
-use serde::Serialize;
 use toml;
 
 lazy_static! {
@@ -95,102 +96,5 @@ impl Fixture {
         } else {
             fs::remove_dir_all(&path).unwrap();
         }
-    }
-}
-
-// small suite of flexible toml structs
-// the  idea here is to focus on "when this config key is set"
-// rather than needing to write tomls all the time.
-// these structs set every value as an `Option`. To use,
-// initialize a new WranglerToml::default() and begin setting
-// values on it.
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct KvConfig<'a> {
-    pub binding: Option<&'a str>,
-    pub id: Option<&'a str>,
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct SiteConfig<'a> {
-    pub bucket: Option<&'a str>,
-    #[serde(rename = "entry-point")]
-    pub entry_point: Option<&'a str>,
-    pub include: Option<Vec<&'a str>>,
-    pub exclude: Option<Vec<&'a str>>,
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct EnvConfig<'a> {
-    pub name: Option<&'a str>,
-    pub account_id: Option<&'a str>,
-    pub workers_dev: Option<bool>,
-    pub route: Option<&'a str>,
-    pub routes: Option<Vec<&'a str>>,
-    pub zone_id: Option<&'a str>,
-    pub webpack_config: Option<&'a str>,
-    pub private: Option<bool>,
-    pub site: Option<SiteConfig<'a>>,
-    #[serde(rename = "kv-namespaces")]
-    pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct WranglerToml<'a> {
-    pub name: Option<&'a str>,
-    #[serde(rename = "type")]
-    pub target_type: Option<&'a str>,
-    pub account_id: Option<&'a str>,
-    pub workers_dev: Option<bool>,
-    pub route: Option<&'a str>,
-    pub routes: Option<Vec<&'a str>>,
-    pub zone_id: Option<&'a str>,
-    pub webpack_config: Option<&'a str>,
-    pub private: Option<bool>,
-    pub env: Option<HashMap<&'a str, EnvConfig<'a>>>,
-    #[serde(rename = "kv-namespaces")]
-    pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
-    pub site: Option<SiteConfig<'a>>,
-}
-
-impl WranglerToml<'_> {
-    pub fn webpack_no_config(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::default();
-        wrangler_toml.name = Some(name);
-        wrangler_toml.workers_dev = Some(true);
-        wrangler_toml.target_type = Some("webpack");
-
-        wrangler_toml
-    }
-
-    pub fn webpack_std_config(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
-        wrangler_toml.webpack_config = Some("webpack.config.js");
-
-        wrangler_toml
-    }
-
-    pub fn webpack_custom_config<'a>(name: &'a str, webpack_config: &'a str) -> WranglerToml<'a> {
-        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
-        wrangler_toml.webpack_config = Some(webpack_config);
-
-        wrangler_toml
-    }
-
-    pub fn rust(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::default();
-        wrangler_toml.name = Some(name);
-        wrangler_toml.workers_dev = Some(true);
-        wrangler_toml.target_type = Some("rust");
-
-        wrangler_toml
-    }
-
-    pub fn javascript(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::default();
-        wrangler_toml.name = Some(name);
-        wrangler_toml.workers_dev = Some(true);
-        wrangler_toml.target_type = Some("javascript");
-
-        wrangler_toml
     }
 }

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+// small suite of flexible toml structs
+// the  idea here is to focus on "when this config key is set"
+// rather than needing to write tomls all the time.
+// these structs set every value as an `Option`. To use,
+// initialize a new WranglerToml::default() and begin setting
+// values on it.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct KvConfig<'a> {
+    pub binding: Option<&'a str>,
+    pub id: Option<&'a str>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct SiteConfig<'a> {
+    pub bucket: Option<&'a str>,
+    #[serde(rename = "entry-point")]
+    pub entry_point: Option<&'a str>,
+    pub include: Option<Vec<&'a str>>,
+    pub exclude: Option<Vec<&'a str>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EnvConfig<'a> {
+    pub name: Option<&'a str>,
+    pub account_id: Option<&'a str>,
+    pub workers_dev: Option<bool>,
+    pub route: Option<&'a str>,
+    pub routes: Option<Vec<&'a str>>,
+    pub zone_id: Option<&'a str>,
+    pub webpack_config: Option<&'a str>,
+    pub private: Option<bool>,
+    pub site: Option<SiteConfig<'a>>,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct WranglerToml<'a> {
+    pub name: Option<&'a str>,
+    #[serde(rename = "type")]
+    pub target_type: Option<&'a str>,
+    pub account_id: Option<&'a str>,
+    pub workers_dev: Option<bool>,
+    pub route: Option<&'a str>,
+    pub routes: Option<Vec<&'a str>>,
+    pub zone_id: Option<&'a str>,
+    pub webpack_config: Option<&'a str>,
+    pub private: Option<bool>,
+    pub env: Option<HashMap<&'a str, EnvConfig<'a>>>,
+    #[serde(rename = "kv-namespaces")]
+    pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
+    pub site: Option<SiteConfig<'a>>,
+}
+
+impl WranglerToml<'_> {
+    pub fn webpack_no_config(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("webpack");
+
+        wrangler_toml
+    }
+
+    pub fn webpack_std_config(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        wrangler_toml.webpack_config = Some("webpack.config.js");
+
+        wrangler_toml
+    }
+
+    pub fn webpack_custom_config<'a>(name: &'a str, webpack_config: &'a str) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        wrangler_toml.webpack_config = Some(webpack_config);
+
+        wrangler_toml
+    }
+
+    pub fn rust(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("rust");
+
+        wrangler_toml
+    }
+
+    pub fn javascript(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.workers_dev = Some(true);
+        wrangler_toml.target_type = Some("javascript");
+
+        wrangler_toml
+    }
+}

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -7,18 +7,13 @@ use fixture::WranglerToml;
 
 use std::env;
 use std::process::Command;
-use std::sync::Mutex;
 
 use assert_cmd::prelude::*;
 use fixture::Fixture;
 
-lazy_static! {
-    static ref BUILD_LOCK: Mutex<u8> = Mutex::new(0);
-}
-
 #[test]
 fn it_can_preview_js_project() {
-    let fixture = Fixture::new("simple_js");
+    let fixture = Fixture::new();
     fixture.create_file(
         "index.js",
         r#"
@@ -41,24 +36,22 @@ fn it_can_preview_js_project() {
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
-    fixture.cleanup()
 }
 
 #[test]
 fn it_can_preview_webpack_project() {
-    let fixture = Fixture::new("webpack_simple_js");
+    let fixture = Fixture::new();
     fixture.scaffold_webpack();
 
     let wrangler_toml = WranglerToml::webpack_no_config("test-preview-webpack");
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
-    fixture.cleanup()
 }
 
 #[test]
 fn it_can_preview_rust_project() {
-    let fixture = Fixture::new("simple_rust");
+    let fixture = Fixture::new();
     fixture.create_dir("src");
     fixture.create_dir("worker");
 
@@ -178,12 +171,10 @@ fn it_can_preview_rust_project() {
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
-    fixture.cleanup()
 }
 
 fn preview_succeeds(fixture: &Fixture) {
-    // Lock to avoid having concurrent builds
-    let _g = BUILD_LOCK.lock().unwrap();
+    let _lock = fixture.lock();
     env::remove_var("CF_ACCOUNT_ID");
     let mut preview = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     preview.current_dir(fixture.get_path());

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -3,6 +3,8 @@ extern crate lazy_static;
 
 pub mod fixture;
 
+use fixture::WranglerToml;
+
 use std::env;
 use std::process::Command;
 use std::sync::Mutex;
@@ -34,12 +36,12 @@ fn it_can_preview_js_project() {
     "#,
     );
     fixture.create_default_package_json();
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "javascript"
-    "#,
-    );
+
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("javascript");
+    fixture.create_wrangler_toml(wrangler_toml);
+
     preview_succeeds(&fixture);
     fixture.cleanup()
 }
@@ -48,12 +50,12 @@ fn it_can_preview_js_project() {
 fn it_can_preview_webpack_project() {
     let fixture = Fixture::new("webpack_simple_js");
     fixture.scaffold_webpack();
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "webpack"
-    "#,
-    );
+
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("webpack");
+    fixture.create_wrangler_toml(wrangler_toml);
+
     preview_succeeds(&fixture);
     fixture.cleanup()
 }
@@ -176,12 +178,11 @@ fn it_can_preview_rust_project() {
     "#,
     );
 
-    fixture.create_wrangler_toml(
-        r#"
-        workers_dev = true
-        type = "rust"
-    "#,
-    );
+    let mut wrangler_toml = WranglerToml::default();
+    wrangler_toml.workers_dev = Some(true);
+    wrangler_toml.target_type = Some("rust");
+    fixture.create_wrangler_toml(wrangler_toml);
+
     preview_succeeds(&fixture);
     fixture.cleanup()
 }

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -36,6 +36,7 @@ fn it_can_preview_js_project() {
     fixture.create_default_package_json();
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "javascript"
     "#,
     );
@@ -49,6 +50,7 @@ fn it_can_preview_webpack_project() {
     fixture.scaffold_webpack();
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "webpack"
     "#,
     );
@@ -176,6 +178,7 @@ fn it_can_preview_rust_project() {
 
     fixture.create_wrangler_toml(
         r#"
+        workers_dev = true
         type = "rust"
     "#,
     );

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -37,9 +37,7 @@ fn it_can_preview_js_project() {
     );
     fixture.create_default_package_json();
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("javascript");
+    let wrangler_toml = WranglerToml::javascript("test-preview-javascript");
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
@@ -51,9 +49,7 @@ fn it_can_preview_webpack_project() {
     let fixture = Fixture::new("webpack_simple_js");
     fixture.scaffold_webpack();
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("webpack");
+    let wrangler_toml = WranglerToml::webpack_no_config("test-preview-webpack");
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
@@ -178,9 +174,7 @@ fn it_can_preview_rust_project() {
     "#,
     );
 
-    let mut wrangler_toml = WranglerToml::default();
-    wrangler_toml.workers_dev = Some(true);
-    wrangler_toml.target_type = Some("rust");
+    let wrangler_toml = WranglerToml::rust("test-preview-rust");
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);


### PR DESCRIPTION
**Note: this PR was created in the context of implementing multiroute support, and so is under that milestone, however nothing here is specific to multiroute support, and so if everyone thinks it makes sense i can cherry pick these changes onto a new branch and pull against master, instead.**

It looks like there's a lot here, but it's pretty repetitive, and all of it is in service of improving the experience of writing tests! 🎉 

This PR introduces a WranglerToml struct and some convenience methods that make instantiating syntax-valid (but not necessarily wrangler-valid) tomls much simpler. The existing tests that use fixtures have been converted to show the difference.

I also noticed while exercising the tests that we were running into some concurrency issues caused by our use of the shared BUILD_LOCK mutex. I copied over the logic from wasm-pack's fixture implementation to put this mutex on each individual fixture instead of, seemingly, the whole process. This appears to have removed the status quo where, if one test failed, many others failed, as well as a weird issue where a test might fail due to an npm install error that I couldn't quite track down but smelled related. To see the difference, check out master, comment out a step in a test that might make it fail (such as writing a wrangler.toml or package.json), and observe that it tends to intermittently crash other tests. The fixture.lock method appears to have fixed that issue, decoupling our tests.