### PR TITLE
Removes fixture dir if exists

### DIFF
--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -52,6 +52,7 @@ impl Fixture {
 
     pub fn create_dir(&self, name: &str) {
         let dir_path = self.get_path().join(name);
+        fs::remove_dir_all(&dir_path).ok();
         fs::create_dir(dir_path).unwrap();
     }
 


### PR DESCRIPTION
When running tests and creating directories, it's possible the dir already exists. If this is the case, remove it before creating the file.