### PR TITLE
[WIP] serialize maps and arrays

### DIFF
--- a/src/commands/dev/socket/events/console/messages/mod.rs
+++ b/src/commands/dev/socket/events/console/messages/mod.rs
@@ -25,7 +25,7 @@ pub enum LogMessage {
     BigInt(BigIntData),
     Boolean(BooleanData),
     #[serde(rename = "string")]
-    StringVal(StringData),
+    StringJs(StringData),
     Symbol(SymbolData),
     Undefined,
     Function(FunctionData),
@@ -36,7 +36,7 @@ impl fmt::Display for LogMessage {
         match &self {
             LogMessage::Object(object) => write!(f, "{}", object),
             LogMessage::Boolean(boolean) => write!(f, "{}", boolean),
-            LogMessage::StringVal(string) => write!(f, "{}", string),
+            LogMessage::StringJs(string) => write!(f, "{}", string),
             LogMessage::Undefined => write!(f, "undefined"),
             LogMessage::Function(function) => write!(f, "{}", function),
             LogMessage::Number(number) => write!(f, "{}", number),

--- a/src/commands/dev/socket/events/console/messages/objects/mod.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/mod.rs
@@ -17,24 +17,8 @@ pub enum ObjectData {
 impl fmt::Display for ObjectData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            ObjectData::Object(object) => {
-                let last_index = object.preview.properties.len() - 1;
-                for (idx, property) in &mut object.preview.properties.iter().enumerate() {
-                    if idx == 0 {
-                        write!(f, "{{")?;
-                    }
-                    write!(f, "{}", property)?;
-                    if idx < last_index {
-                        write!(f, ", ")?;
-                    } else {
-                        write!(f, "}}")?;
-                    }
-                }
-            }
-            ObjectData::Subtype(subtype) => {
-                write!(f, "{}", subtype)?;
-            }
-        };
-        Ok(())
+            ObjectData::Subtype(subtype) => write!(f, "{}", subtype),
+            ObjectData::Object(object) => write!(f, "{}", object),
+        }
     }
 }

--- a/src/commands/dev/socket/events/console/messages/objects/object/mod.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/object/mod.rs
@@ -1,6 +1,7 @@
 mod properties;
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use properties::ObjectProperties;
 
@@ -9,12 +10,45 @@ pub struct Object {
     pub preview: ObjectPreview,
 }
 
+impl fmt::Display for Object {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.preview)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectPreview {
     #[serde(rename = "type")]
     pub object_type: String,
+    pub subtype: Option<String>,
     pub description: String,
     pub overflow: bool,
     pub properties: Vec<ObjectProperties>,
+}
+
+impl fmt::Display for ObjectPreview {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(subtype) = &self.subtype {
+            println!("unhandled subtype {}", subtype);
+        }
+        let len = self.properties.len();
+        if len > 0 {
+            let last_index = len - 1;
+            for (idx, property) in &mut self.properties.iter().enumerate() {
+                if idx == 0 {
+                    write!(f, "{{")?;
+                }
+                write!(f, "{}", property)?;
+                if idx < last_index {
+                    write!(f, ", ")?;
+                } else {
+                    write!(f, "}}")?;
+                }
+            }
+        } else {
+            write!(f, "{{}}")?;
+        }
+        Ok(())
+    }
 }

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/array.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/array.rs
@@ -6,27 +6,32 @@ use crate::commands::dev::socket::events::console::LogMessage;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ArrayData {
     pub preview: ArrayPreview,
+    pub description: String,
 }
 
 impl fmt::Display for ArrayData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let last_index = self.preview.properties.len() - 1;
-        for (idx, property) in &mut self.preview.properties.iter().enumerate() {
-            if idx == 0 {
-                write!(f, "[")?;
-            }
-            write!(f, "{}", property)?;
-            if idx < last_index {
-                write!(f, ", ")?;
-            } else {
-                write!(f, "]")?;
-            }
-        }
-        Ok(())
+        write!(f, "{} {}", &self.description, &self.preview)
     }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ArrayPreview {
-    properties: Vec<LogMessage>,
+    pub properties: Vec<LogMessage>,
+}
+
+impl fmt::Display for ArrayPreview {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[")?;
+        let last_index = self.properties.len() - 1;
+        for (index, property) in &mut self.properties.iter().enumerate() {
+            if index == 0 {}
+            write!(f, "{}", property)?;
+            if index < last_index {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
 }

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/description.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/description.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Description {
+    pub description: String,
+}
+
+impl fmt::Display for Description {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.description)
+    }
+}

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/map.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/map.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::commands::dev::socket::events::console::LogMessage;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MapData {
+    pub preview: MapPreview,
+    pub description: String,
+}
+
+impl fmt::Display for MapData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", &self.description, &self.preview)
+        // write!(f, "{}", &self.description)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MapPreview {
+    pub entries: Vec<MapEntry>,
+}
+
+impl fmt::Display for MapPreview {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let len = self.entries.len();
+        if len > 0 {
+            let last_index = len - 1;
+            for (index, entry) in &mut self.entries.iter().enumerate() {
+                if index == 0 {
+                    write!(f, "{{")?;
+                }
+                write!(f, "{}", entry)?;
+                if index < last_index {
+                    write!(f, ", ")?;
+                } else {
+                    write!(f, "}}")?;
+                }
+            }
+        } else {
+            write!(f, "{{}}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MapEntry {
+    pub key: LogMessage,
+    pub value: LogMessage,
+}
+
+impl fmt::Display for MapEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} => {}", &self.key, &self.value)
+    }
+}

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/map.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/map.rs
@@ -23,23 +23,15 @@ pub struct MapPreview {
 
 impl fmt::Display for MapPreview {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let len = self.entries.len();
-        if len > 0 {
-            let last_index = len - 1;
-            for (index, entry) in &mut self.entries.iter().enumerate() {
-                if index == 0 {
-                    write!(f, "{{")?;
-                }
-                write!(f, "{}", entry)?;
-                if index < last_index {
-                    write!(f, ", ")?;
-                } else {
-                    write!(f, "}}")?;
-                }
+        write!(f, "{{")?;
+        let last_index = self.entries.len() - 1;
+        for (index, entry) in &mut self.entries.iter().enumerate() {
+            write!(f, "{}", entry)?;
+            if index < last_index {
+                write!(f, ", ")?;
             }
-        } else {
-            write!(f, "{{}}")?;
         }
+        write!(f, "}}")?;
         Ok(())
     }
 }

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/mod.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/mod.rs
@@ -1,31 +1,34 @@
 mod array;
+mod description;
+mod map;
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use array::ArrayData;
+use description::Description;
+use map::MapData;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "subtype", rename_all = "lowercase")]
 pub enum Subtype {
     Array(ArrayData),
     Null,
-    Node,
-    RegExp,
-    Date,
-    Map,
-    Set,
-    WeakMap,
-    WeakSet,
+    RegExp(Description),
+    Date(Description),
+    Map(MapData),
+    Set(Description),
+    WeakMap(Description),
+    WeakSet(Description),
     #[serde(rename = "iterator")]
-    JsIterator,
-    Generator,
-    Error,
-    Proxy,
-    Promise,
-    TypedArray,
-    ArrayBuffer,
-    DataView,
+    JsIterator(Description),
+    Generator(Description),
+    Error(Description),
+    Proxy(Description),
+    Promise(Description),
+    TypedArray(Description),
+    ArrayBuffer(Description),
+    DataView(Description),
 }
 
 impl fmt::Display for Subtype {
@@ -33,7 +36,10 @@ impl fmt::Display for Subtype {
         match &self {
             Subtype::Array(array) => write!(f, "{}", array),
             Subtype::Null => write!(f, "null"),
-            _ => write!(f, "{:?}", &self),
+            Subtype::RegExp(reg_exp) => write!(f, "{}", reg_exp),
+            Subtype::Date(date) => write!(f, "{}", date),
+            Subtype::Map(map) => write!(f, "{}", map),
+            _ => write!(f, "unhandled type"),
         }
     }
 }


### PR DESCRIPTION
Currently blocked on serializing maps - arrays seems to work beautifully but maps don't want to serialize. they're getting parsed as an `Object` not a `Subtype`. if i remove the `preview` field from the `MapData` struct and only print out the description, it will serialize as a `Subtype`, so there's something wonky there. I'm really not sure what it is though because I've modeled MapData just like ArrayData and it works fine. 

Running with `RUST_LOG=info wrangler dev` will print out the message that its trying to serialize. Run the command from within a dir that points to a project that logs out an array and an object like so.

```
addEventListener('fetch', event => {
  event.respondWith(handleRequest(event.request))
})

async function handleRequest(request) {	
  console.log(["hello", "world"])
  let map = new Map()
  map.set("hello", "world")
  console.log(map)
  return new Response(`you requested url ${request.url} with method ${request.method}`);
}
```