### PR TITLE
Fix map serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_with 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ openssl = "0.10.26"
 reqwest = "0.9.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
+serde_with = "1.3.1"
 toml = "0.5.0"
 uuid = "0.7"
 which = "2.0.1"

--- a/src/commands/dev/socket/events/console/messages/objects/subtype/mod.rs
+++ b/src/commands/dev/socket/events/console/messages/objects/subtype/mod.rs
@@ -13,10 +13,9 @@ use map::MapData;
 #[serde(tag = "subtype", rename_all = "lowercase")]
 pub enum Subtype {
     Array(ArrayData),
-    Null,
+    Map(MapData),
     RegExp(Description),
     Date(Description),
-    Map(MapData),
     Set(Description),
     WeakMap(Description),
     WeakSet(Description),
@@ -29,6 +28,7 @@ pub enum Subtype {
     TypedArray(Description),
     ArrayBuffer(Description),
     DataView(Description),
+    Null,
 }
 
 impl fmt::Display for Subtype {

--- a/src/commands/dev/socket/events/console/messages/string.rs
+++ b/src/commands/dev/socket/events/console/messages/string.rs
@@ -1,13 +1,19 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StringData {
+    #[serde(default)]
     value: String,
+    description: Option<String>,
 }
 
 impl fmt::Display for StringData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "\"{}\"", &self.value)
+        match &self.description {
+            Some(d) => write!(f, "\"{}\"", d),
+            None => write!(f, "\"{}\"", &self.value),
+        }
     }
 }


### PR DESCRIPTION
As it turns out, the devtools protocol does something funny when string types for map keys. 
Take a look:
```
{
  "method": "Runtime.consoleAPICalled",
  "params": {
    "type": "log",
    "args": [
      {
        "type": "object",
        "subtype": "map",
        "className": "Map",
        "description": "Map(1)",
        "objectId": "{\"injectedScriptId\":2,\"id\":2}",
        "preview": {
          "type": "object",
          "subtype": "map",
          "description": "Map(1)",
          "overflow": false,
          "properties": [],
          "entries": [
            {
              "key": {
                "type": "string",
                "description": "hello",
                "overflow": false,
                "properties": []
              },
              "value": {
                "type": "string",
                "description": "world",
                "overflow": false,
                "properties": []
              }
            }
          ]
        }
      }
    ],
....
}
```
The string type here is not the usual expected 
```
{ "name": "0", "type": "string", "value": "hello" }
```
meaning that deserialization with the current logic in this feature branch will not work. If we allow the StringData struct to accept a `description` field to replace a `value` field, we can allow wrangler to deserialize these map keys/values and fix this deserialization problem.