### PR TITLE
Alewis/test routes toml

### DIFF
--- a/src/settings/toml/deploy_target.rs
+++ b/src/settings/toml/deploy_target.rs
@@ -1,0 +1,117 @@
+use crate::settings::toml::Route;
+
+#[derive(Debug)]
+pub struct RouteConfig {
+    pub workers_dev: Option<bool>,
+    pub route: Option<String>,
+    pub routes: Option<Vec<String>>,
+    pub zone_id: Option<String>,
+}
+
+impl RouteConfig {
+    fn has_conflicting_targets(&self) -> bool {
+        if self.workers_dev.unwrap_or_default() {
+            if let Some(pattern) = &self.route {
+                !pattern.is_empty() || self.routes.is_some() // this is all so messy because of deserializer
+            } else {
+                self.routes.is_some()
+            }
+        } else {
+            if let Some(pattern) = &self.route {
+                !pattern.is_empty() && self.routes.is_some()
+            } else {
+                false
+            }
+        }
+    }
+
+    pub fn is_zoneless(&self) -> bool {
+        self.workers_dev.unwrap_or_default() && !self.has_conflicting_targets()
+    }
+
+    pub fn is_complete_zoned(&self) -> bool {
+        (self.route.is_some() || self.routes.is_some()) && self.zone_id.is_some()
+    }
+
+    // zone id is another weird one where `Some("")` is treated the same as `None`
+    pub fn missing_zone_id(&self) -> bool {
+        let result = !self.workers_dev.unwrap_or_default()
+            && (self.route.is_some() || self.routes.is_some());
+        if let Some(zone_id) = &self.zone_id {
+            result && zone_id.is_empty()
+        } else {
+            result
+        }
+    }
+}
+
+impl DeployTarget {
+    pub fn build(
+        script: &String,
+        route_config: &RouteConfig,
+    ) -> Result<DeployTarget, failure::Error> {
+        if route_config.is_zoneless() {
+            Ok(DeployTarget::Zoneless)
+        } else {
+            // zone_id is required
+            let zone_id = route_config.zone_id.as_ref().unwrap();
+            if zone_id.is_empty() {
+                failure::bail!("field `zone_id` is required to deploy to routes");
+            }
+
+            if route_config.has_conflicting_targets() {
+                failure::bail!("specify either `route` or `routes`");
+            }
+
+            let mut zoned = Zoned {
+                zone_id: zone_id.to_owned(),
+                routes: Vec::new(),
+            };
+
+            // TODO: these should be an if/else if block; write deserializer
+            // for `route` key that turns `Some("")` into `None`
+            if let Some(pattern) = &route_config.route {
+                zoned.add_route(&pattern, script);
+            }
+
+            if let Some(patterns) = &route_config.routes {
+                for pattern in patterns {
+                    zoned.add_route(&pattern, script);
+                }
+            }
+
+            if zoned.routes.is_empty() {
+                failure::bail!("No deploy target specified");
+            }
+
+            Ok(DeployTarget::Zoned(zoned))
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DeployTarget {
+    Zoneless,
+    Zoned(Zoned),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Zoned {
+    pub zone_id: String,
+    pub routes: Vec<Route>,
+}
+
+impl Zoned {
+    pub fn add_route(&mut self, pattern: &String, script: &String) -> &Self {
+        // TODO: Write custom deserializer for route, which will make this fn unnecessary
+        if !pattern.is_empty() {
+            self.routes.push(Route {
+                id: None,
+                script: Some(script.to_string()),
+                pattern: pattern.to_string(),
+            })
+        }
+
+        self
+    }
+}

--- a/src/settings/toml/deploy_target.rs
+++ b/src/settings/toml/deploy_target.rs
@@ -46,10 +46,7 @@ impl RouteConfig {
 }
 
 impl DeployTarget {
-    pub fn build(
-        script: &String,
-        route_config: &RouteConfig,
-    ) -> Result<DeployTarget, failure::Error> {
+    pub fn build(script: &str, route_config: &RouteConfig) -> Result<DeployTarget, failure::Error> {
         if route_config.is_zoneless() {
             Ok(DeployTarget::Zoneless)
         } else {
@@ -76,7 +73,7 @@ impl DeployTarget {
 
             if let Some(patterns) = &route_config.routes {
                 for pattern in patterns {
-                    zoned.add_route(&pattern, script);
+                    zoned.add_route(pattern, script);
                 }
             }
 
@@ -102,7 +99,7 @@ pub struct Zoned {
 }
 
 impl Zoned {
-    pub fn add_route(&mut self, pattern: &String, script: &String) -> &Self {
+    pub fn add_route(&mut self, pattern: &str, script: &str) -> &Self {
         // TODO: Write custom deserializer for route, which will make this fn unnecessary
         if !pattern.is_empty() {
             self.routes.push(Route {

--- a/src/settings/toml/deploy_target.rs
+++ b/src/settings/toml/deploy_target.rs
@@ -34,7 +34,7 @@ impl RouteConfig {
     }
 
     // zone id is another weird one where `Some("")` is treated the same as `None`
-    pub fn missing_zone_id(&self) -> bool {
+    pub fn is_missing_zone_id(&self) -> bool {
         let result = !self.workers_dev.unwrap_or_default()
             && (self.route.is_some() || self.routes.is_some());
         if let Some(zone_id) = &self.zone_id {

--- a/src/settings/toml/environment.rs
+++ b/src/settings/toml/environment.rs
@@ -3,7 +3,7 @@ use super::site::Site;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Environment {
     pub name: Option<String>,
     pub account_id: Option<String>,

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use config::{Config, File};
 use serde::{Deserialize, Serialize};
 
+use crate::settings::toml::deploy_target::{DeployTarget, RouteConfig};
 use crate::settings::toml::environment::Environment;
 use crate::settings::toml::kv_namespace::KvNamespace;
 use crate::settings::toml::site::Site;
@@ -129,6 +130,21 @@ impl Manifest {
         }
 
         self.name.clone()
+    }
+
+    fn route_config(&self) -> RouteConfig {
+        RouteConfig {
+            workers_dev: self.workers_dev,
+            route: self.route.clone(),
+            routes: self.routes.clone(),
+            zone_id: self.zone_id.clone(),
+        }
+    }
+
+    pub fn deploy_target(&self, env: Option<&str>) -> Result<DeployTarget, failure::Error> {
+        let script = self.worker_name(env);
+        let route_config = self.route_config();
+        DeployTarget::build(&script, &route_config)
     }
 
     pub fn get_target(&self, environment_name: Option<&str>) -> Result<Target, failure::Error> {

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -20,7 +20,7 @@ fn some_string() -> Option<String> {
     Some("".to_string())
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Manifest {
     #[serde(default)]
     pub name: String,
@@ -51,6 +51,10 @@ impl Manifest {
         check_for_duplicate_names(&manifest)?;
 
         Ok(manifest)
+    }
+
+    pub fn new_from_string(serialized_toml: String) -> Result<Self, toml::de::Error> {
+        toml::from_str(&serialized_toml)
     }
 
     pub fn generate(

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use config::{Config, File};
 use serde::{Deserialize, Serialize};
 
+use crate::commands::validate_worker_name;
 use crate::settings::toml::deploy_target::{DeployTarget, RouteConfig};
 use crate::settings::toml::environment::Environment;
 use crate::settings::toml::kv_namespace::KvNamespace;
@@ -143,6 +144,7 @@ impl Manifest {
 
     pub fn deploy_target(&self, env: Option<&str>) -> Result<DeployTarget, failure::Error> {
         let script = self.worker_name(env);
+        validate_worker_name(&script)?;
         let route_config = self.route_config();
         DeployTarget::build(&script, &route_config)
     }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -1,9 +1,3 @@
-use super::environment::Environment;
-use super::kv_namespace::KvNamespace;
-use super::site::Site;
-use super::target_type::TargetType;
-use crate::settings::toml::Target;
-
 use std::collections::{HashMap, HashSet};
 use std::env;
 
@@ -13,6 +7,11 @@ use std::path::{Path, PathBuf};
 use config::{Config, File};
 use serde::{Deserialize, Serialize};
 
+use crate::settings::toml::environment::Environment;
+use crate::settings::toml::kv_namespace::KvNamespace;
+use crate::settings::toml::site::Site;
+use crate::settings::toml::target_type::TargetType;
+use crate::settings::toml::Target;
 use crate::terminal::emoji;
 use crate::terminal::message;
 
@@ -119,6 +118,19 @@ impl Manifest {
         Ok(template_config)
     }
 
+    pub fn worker_name(&self, env_arg: Option<&str>) -> String {
+        if let Some(environment) = self.get_environment(env_arg).unwrap_or_default() {
+            if let Some(name) = &environment.name {
+                return name.clone();
+            }
+            if let Some(env) = env_arg {
+                return format!("{}-{}", self.name, env);
+            }
+        }
+
+        self.name.clone()
+    }
+
     pub fn get_target(&self, environment_name: Option<&str>) -> Result<Target, failure::Error> {
         // Site projects are always webpack for now; don't let toml override this.
         let target_type = match self.site {
@@ -144,14 +156,7 @@ impl Manifest {
 
         target.route = self.negotiate_zoneless(environment)?;
         if let Some(environment) = environment {
-            target.name = if let Some(name) = &environment.name {
-                name.clone()
-            } else {
-                match environment_name {
-                    Some(environment_name) => format!("{}-{}", self.name, environment_name),
-                    None => failure::bail!("You must specify `name` in your wrangler.toml"),
-                }
-            };
+            target.name = self.worker_name(environment_name);
             if let Some(account_id) = &environment.account_id {
                 target.account_id = account_id.clone();
             }

--- a/src/settings/toml/mod.rs
+++ b/src/settings/toml/mod.rs
@@ -1,3 +1,4 @@
+mod deploy_target;
 mod environment;
 mod kv_namespace;
 mod manifest;
@@ -6,6 +7,7 @@ mod site;
 mod target;
 mod target_type;
 
+pub use deploy_target::DeployTarget;
 pub use environment::Environment;
 pub use kv_namespace::KvNamespace;
 pub use manifest::Manifest;

--- a/src/settings/toml/route.rs
+++ b/src/settings/toml/route.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use cloudflare::endpoints::workers::WorkersRoute;
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Route {
     pub id: Option<String>,
     pub script: Option<String>,

--- a/src/settings/toml/site.rs
+++ b/src/settings/toml/site.rs
@@ -8,7 +8,7 @@ use crate::commands::generate::run_generate;
 
 const SITE_ENTRY_POINT: &str = "workers-site";
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Site {
     pub bucket: PathBuf,
     #[serde(rename = "entry-point")]

--- a/src/settings/toml/tests/deploy_target.rs
+++ b/src/settings/toml/tests/deploy_target.rs
@@ -1,0 +1,301 @@
+use super::wrangler_toml::WranglerToml;
+
+use crate::settings::toml::deploy_target::Zoned;
+use crate::settings::toml::route::Route;
+use crate::settings::toml::DeployTarget;
+use crate::settings::toml::Manifest;
+
+// TOP LEVEL TESTS
+#[test]
+fn it_can_get_a_top_level_zoneless_deploy_target() {
+    let test_toml = WranglerToml::webpack_no_config("zoneless");
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+    let actual_deploy_target = manifest.deploy_target(environment).unwrap();
+    let expected_deploy_target = DeployTarget::Zoneless;
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn it_errors_on_zoneless_deploy_target_missing_workers_dev() {
+    let test_toml = WranglerToml::webpack("zoneless_missing");
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_zoneless_deploy_target_workers_dev_false() {
+    let mut test_toml = WranglerToml::webpack("zoneless_false");
+    test_toml.workers_dev = Some(false);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_can_get_a_single_route_zoned_deploy_target() {
+    let script = "single_route_zoned";
+    let pattern = "hostname.tld/*";
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.route = Some(pattern);
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+    let actual_deploy_target = manifest.deploy_target(environment).unwrap();
+    let expected_routes = vec![Route {
+        script: Some(script.to_string()),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn it_can_get_a_single_route_zoned_deploy_target_workers_dev_false() {
+    let script = "single_route_zoned_workers_dev_false";
+    let pattern = "hostname.tld/*";
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.workers_dev = Some(false);
+    test_toml.route = Some(pattern);
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+    let actual_deploy_target = manifest.deploy_target(environment).unwrap();
+    let expected_routes = vec![Route {
+        script: Some(script.to_string()),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn it_errors_on_single_route_deploy_target_missing_zone_id() {
+    let script = "single_route_missing_zone_id";
+    let pattern = "hostname.tld/*";
+    let zone_id = "";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.route = Some(pattern);
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_single_route_deploy_target_empty_route() {
+    let script = "single_route_empty_route";
+    let pattern = "";
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.route = Some(pattern);
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_can_get_a_multi_route_zoned_deploy_target() {
+    let script = "multi_route_zoned";
+    let patterns = ["hostname.tld/*", "blog.hostname.tld/*"];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let expected_routes = patterns
+        .iter()
+        .map(|p| Route {
+            script: Some(script.to_string()),
+            pattern: p.to_string(),
+            id: None,
+        })
+        .collect();
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    let environment = None;
+    let actual_deploy_target = manifest.deploy_target(environment).unwrap();
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn it_can_get_a_multi_route_zoned_deploy_target_workers_dev_false() {
+    let script = "multi_route_zoned_workers_dev_false";
+    let patterns = ["hostname.tld/*", "blog.hostname.tld/*"];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.workers_dev = Some(false);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let expected_routes = patterns
+        .iter()
+        .map(|p| Route {
+            script: Some(script.to_string()),
+            pattern: p.to_string(),
+            id: None,
+        })
+        .collect();
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    let environment = None;
+    let actual_deploy_target = manifest.deploy_target(environment).unwrap();
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn it_errors_on_multi_route_deploy_target_missing_zone_id() {
+    let script = "multi_route_missing_zone_id";
+    let patterns = ["hostname.tld/*", "blog.hostname.tld/*"];
+    let zone_id = "";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_multi_route_deploy_target_empty_routes_list() {
+    let script = "multi_route_empty_routes_list";
+    let patterns = [];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_multi_route_deploy_target_empty_route() {
+    let script = "multi_route_empty_route";
+    let patterns = [""];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_deploy_target_route_and_routes() {
+    let script = "route_and_routes";
+    let pattern = "hostname.tld/*";
+    let patterns = ["blog.hostname.tld/*"];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.route = Some(pattern);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_deploy_target_route_and_workers_dev_true() {
+    let script = "route_and_workers_dev";
+    let pattern = "hostname.tld/*";
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.workers_dev = Some(true);
+    test_toml.route = Some(pattern);
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
+fn it_errors_on_deploy_target_routes_and_workers_dev_true() {
+    let script = "routes_and_workers_dev";
+    let patterns = ["blog.hostname.tld/*"];
+    let zone_id = "samplezoneid";
+
+    let mut test_toml = WranglerToml::webpack(script);
+    test_toml.workers_dev = Some(true);
+    test_toml.routes = Some(patterns.to_vec());
+    test_toml.zone_id = Some(zone_id);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}

--- a/src/settings/toml/tests/deploy_target.rs
+++ b/src/settings/toml/tests/deploy_target.rs
@@ -8,7 +8,7 @@ use crate::settings::toml::Manifest;
 // TOP LEVEL TESTS
 #[test]
 fn it_can_get_a_top_level_zoneless_deploy_target() {
-    let test_toml = WranglerToml::webpack_no_config("zoneless");
+    let test_toml = WranglerToml::webpack_zoneless("zoneless", true);
     let toml_string = toml::to_string(&test_toml).unwrap();
     let manifest = Manifest::new_from_string(toml_string).unwrap();
 

--- a/src/settings/toml/tests/deploy_target.rs
+++ b/src/settings/toml/tests/deploy_target.rs
@@ -31,6 +31,17 @@ fn it_errors_on_zoneless_deploy_target_missing_workers_dev() {
 }
 
 #[test]
+fn it_errors_on_deploy_target_missing_name() {
+    let test_toml = WranglerToml::webpack_zoneless("", true);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let environment = None;
+
+    assert!(manifest.deploy_target(environment).is_err());
+}
+
+#[test]
 fn it_errors_on_zoneless_deploy_target_workers_dev_false() {
     let mut test_toml = WranglerToml::webpack("zoneless_false");
     test_toml.workers_dev = Some(false);

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -98,27 +98,19 @@ fn parses_same_from_config_path_as_string() {
 }
 
 #[test]
-fn worker_name_function_generates_the_correct_name() {
+fn it_returns_top_level_name_when_no_env() {
     let top_level_name = "worker";
-    let env = "prod";
-    let custom_env_name = "george";
-
-    let no_name_no_env = WranglerToml::webpack(""); // should error
-    let manifest = Manifest::new_from_string(toml::to_string(&no_name_no_env).unwrap()).unwrap();
-
-    // this function is not opinionated about valid names; that is evaluated in commands
-    assert_eq!(manifest.worker_name(None), String::new());
 
     let with_name_no_env = WranglerToml::webpack(top_level_name);
     let manifest = Manifest::new_from_string(toml::to_string(&with_name_no_env).unwrap()).unwrap();
 
     assert_eq!(manifest.worker_name(None), top_level_name);
+}
 
-    let no_name_with_env = WranglerToml::webpack_with_env("", env, EnvConfig::default());
-    let manifest = Manifest::new_from_string(toml::to_string(&no_name_with_env).unwrap()).unwrap();
-
-    // this function is not opinionated about valid names; that is evaluated in commands
-    assert_eq!(manifest.worker_name(Some(env)), format!("-{}", env));
+#[test]
+fn it_concatenates_top_level_with_env_when_env_omits_name() {
+    let top_level_name = "worker";
+    let env = "prod";
 
     let with_name_with_env =
         WranglerToml::webpack_with_env(top_level_name, env, EnvConfig::default());
@@ -129,13 +121,13 @@ fn worker_name_function_generates_the_correct_name() {
         manifest.worker_name(Some(env)),
         format!("{}-{}", top_level_name, env)
     );
+}
 
-    let env_config = EnvConfig::custom_script_name(custom_env_name);
-    let no_name_env_override = WranglerToml::webpack_with_env("", env, env_config);
-    let manifest =
-        Manifest::new_from_string(toml::to_string(&no_name_env_override).unwrap()).unwrap();
-
-    assert_eq!(manifest.worker_name(Some(env)), custom_env_name);
+#[test]
+fn it_uses_env_name_when_provided() {
+    let top_level_name = "worker";
+    let env = "prod";
+    let custom_env_name = "george";
 
     let env_config = EnvConfig::custom_script_name(custom_env_name);
     let with_name_env_override = WranglerToml::webpack_with_env(top_level_name, env, env_config);

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -2,6 +2,8 @@
 #[cfg(test)]
 mod wrangler_toml;
 
+mod deploy_target;
+
 use super::*;
 
 use std::env;

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -1,8 +1,14 @@
+#[path = "../../../../tests/fixture/wrangler_toml.rs"]
+#[cfg(test)]
+mod wrangler_toml;
+
 use super::*;
 
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use wrangler_toml::{EnvConfig, WranglerToml};
 
 #[test]
 fn it_builds_from_config() {
@@ -87,6 +93,54 @@ fn parses_same_from_config_path_as_string() {
     let manifest_from_config = Manifest::new(&config_path).unwrap();
 
     assert_eq!(manifest_from_config, manifest_from_string);
+}
+
+#[test]
+fn worker_name_function_generates_the_correct_name() {
+    let top_level_name = "worker";
+    let env = "prod";
+    let custom_env_name = "george";
+
+    let no_name_no_env = WranglerToml::webpack(""); // should error
+    let manifest = Manifest::new_from_string(toml::to_string(&no_name_no_env).unwrap()).unwrap();
+
+    // this function is not opinionated about valid names; that is evaluated in commands
+    assert_eq!(manifest.worker_name(None), String::new());
+
+    let with_name_no_env = WranglerToml::webpack(top_level_name);
+    let manifest = Manifest::new_from_string(toml::to_string(&with_name_no_env).unwrap()).unwrap();
+
+    assert_eq!(manifest.worker_name(None), top_level_name);
+
+    let no_name_with_env = WranglerToml::webpack_with_env("", env, EnvConfig::default());
+    let manifest = Manifest::new_from_string(toml::to_string(&no_name_with_env).unwrap()).unwrap();
+
+    // this function is not opinionated about valid names; that is evaluated in commands
+    assert_eq!(manifest.worker_name(Some(env)), format!("-{}", env));
+
+    let with_name_with_env =
+        WranglerToml::webpack_with_env(top_level_name, env, EnvConfig::default());
+    let manifest =
+        Manifest::new_from_string(toml::to_string(&with_name_with_env).unwrap()).unwrap();
+
+    assert_eq!(
+        manifest.worker_name(Some(env)),
+        format!("{}-{}", top_level_name, env)
+    );
+
+    let env_config = EnvConfig::custom_script_name(custom_env_name);
+    let no_name_env_override = WranglerToml::webpack_with_env("", env, env_config);
+    let manifest =
+        Manifest::new_from_string(toml::to_string(&no_name_env_override).unwrap()).unwrap();
+
+    assert_eq!(manifest.worker_name(Some(env)), custom_env_name);
+
+    let env_config = EnvConfig::custom_script_name(custom_env_name);
+    let with_name_env_override = WranglerToml::webpack_with_env(top_level_name, env, env_config);
+    let manifest =
+        Manifest::new_from_string(toml::to_string(&with_name_env_override).unwrap()).unwrap();
+
+    assert_eq!(manifest.worker_name(Some(env)), custom_env_name);
 }
 
 fn base_fixture_path() -> PathBuf {

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 #[test]
@@ -74,6 +75,18 @@ fn it_builds_from_environments_config_with_kv() {
         }
         None => assert!(false),
     }
+}
+
+#[test]
+fn parses_same_from_config_path_as_string() {
+    let config_path = toml_fixture_path("environments.toml");
+    eprintln!("{:?}", &config_path);
+    let string_toml = fs::read_to_string(&config_path).unwrap();
+
+    let manifest_from_string = Manifest::new_from_string(string_toml).unwrap();
+    let manifest_from_config = Manifest::new(&config_path).unwrap();
+
+    assert_eq!(manifest_from_config, manifest_from_string);
 }
 
 fn base_fixture_path() -> PathBuf {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -14,7 +14,7 @@ fn it_builds_webpack() {
     let fixture = Fixture::new();
     fixture.scaffold_webpack();
 
-    let wrangler_toml = WranglerToml::webpack_no_config("test-build-webpack");
+    let wrangler_toml = WranglerToml::webpack_zoneless("test-build-webpack", true);
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -41,7 +41,7 @@ fn it_builds_with_webpack_single_js() {
     );
     fixture.create_default_package_json();
 
-    let wrangler_toml = WranglerToml::webpack_no_config("test-build-webpack-single-js");
+    let wrangler_toml = WranglerToml::webpack_zoneless("test-build-webpack-single-js", true);
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_creates_assets(&fixture, vec!["script.js"]);
@@ -137,7 +137,7 @@ fn it_builds_with_webpack_single_js_missing_package_main() {
     );
 
     let wrangler_toml =
-        WranglerToml::webpack_no_config("test-build-webpack-single-js-missing-package-main");
+        WranglerToml::webpack_zoneless("test-build-webpack-single-js-missing-package-main", true);
     fixture.create_wrangler_toml(wrangler_toml);
 
     build_fails_with(

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -84,6 +84,32 @@ impl WranglerToml<'_> {
         wrangler_toml
     }
 
+    pub fn webpack_zoned_single_route<'a>(
+        name: &'a str,
+        zone_id: &'a str,
+        route: &'a str,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack(name);
+        wrangler_toml.zone_id = Some(zone_id);
+        wrangler_toml.route = Some(route);
+
+        eprintln!("{:#?}", &wrangler_toml);
+        wrangler_toml
+    }
+
+    pub fn webpack_zoned_multi_route<'a>(
+        name: &'a str,
+        zone_id: &'a str,
+        routes: Vec<&'a str>,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack(name);
+        wrangler_toml.zone_id = Some(zone_id);
+        wrangler_toml.routes = Some(routes);
+
+        eprintln!("{:#?}", &wrangler_toml);
+        wrangler_toml
+    }
+
     pub fn webpack_with_env<'a>(
         name: &'a str,
         env_name: &'a str,

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -43,6 +43,7 @@ impl EnvConfig<'_> {
         let mut env_config = EnvConfig::default();
         env_config.name = Some(name);
 
+        eprintln!("{:#?}", &env_config);
         env_config
     }
 }
@@ -71,6 +72,7 @@ impl WranglerToml<'_> {
         wrangler_toml.name = Some(name);
         wrangler_toml.target_type = Some("webpack");
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -78,6 +80,7 @@ impl WranglerToml<'_> {
         let mut wrangler_toml = WranglerToml::webpack(name);
         wrangler_toml.workers_dev = Some(is_workers_dev);
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -91,6 +94,7 @@ impl WranglerToml<'_> {
         env.insert(env_name, env_config);
         wrangler_toml.env = Some(env);
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -98,6 +102,7 @@ impl WranglerToml<'_> {
         let mut wrangler_toml = WranglerToml::webpack_zoneless(name, true);
         wrangler_toml.webpack_config = Some("webpack.config.js");
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -105,6 +110,7 @@ impl WranglerToml<'_> {
         let mut wrangler_toml = WranglerToml::webpack_zoneless(name, true);
         wrangler_toml.webpack_config = Some(webpack_config);
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -114,6 +120,7 @@ impl WranglerToml<'_> {
         wrangler_toml.workers_dev = Some(true);
         wrangler_toml.target_type = Some("rust");
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 
@@ -123,6 +130,7 @@ impl WranglerToml<'_> {
         wrangler_toml.workers_dev = Some(true);
         wrangler_toml.target_type = Some("javascript");
 
+        eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
 }

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -74,6 +74,13 @@ impl WranglerToml<'_> {
         wrangler_toml
     }
 
+    pub fn webpack_zoneless(name: &str, is_workers_dev: bool) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::webpack(name);
+        wrangler_toml.workers_dev = Some(is_workers_dev);
+
+        wrangler_toml
+    }
+
     pub fn webpack_with_env<'a>(
         name: &'a str,
         env_name: &'a str,
@@ -87,24 +94,15 @@ impl WranglerToml<'_> {
         wrangler_toml
     }
 
-    pub fn webpack_no_config(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::default();
-        wrangler_toml.name = Some(name);
-        wrangler_toml.workers_dev = Some(true);
-        wrangler_toml.target_type = Some("webpack");
-
-        wrangler_toml
-    }
-
     pub fn webpack_std_config(name: &str) -> WranglerToml {
-        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        let mut wrangler_toml = WranglerToml::webpack_zoneless(name, true);
         wrangler_toml.webpack_config = Some("webpack.config.js");
 
         wrangler_toml
     }
 
     pub fn webpack_custom_config<'a>(name: &'a str, webpack_config: &'a str) -> WranglerToml<'a> {
-        let mut wrangler_toml = WranglerToml::webpack_no_config(name);
+        let mut wrangler_toml = WranglerToml::webpack_zoneless(name, true);
         wrangler_toml.webpack_config = Some(webpack_config);
 
         wrangler_toml

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -38,6 +38,15 @@ pub struct EnvConfig<'a> {
     pub kv_namespaces: Option<Vec<KvConfig<'a>>>,
 }
 
+impl EnvConfig<'_> {
+    pub fn custom_script_name(name: &str) -> EnvConfig {
+        let mut env_config = EnvConfig::default();
+        env_config.name = Some(name);
+
+        env_config
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct WranglerToml<'a> {
     pub name: Option<&'a str>,
@@ -57,6 +66,27 @@ pub struct WranglerToml<'a> {
 }
 
 impl WranglerToml<'_> {
+    pub fn webpack(name: &str) -> WranglerToml {
+        let mut wrangler_toml = WranglerToml::default();
+        wrangler_toml.name = Some(name);
+        wrangler_toml.target_type = Some("webpack");
+
+        wrangler_toml
+    }
+
+    pub fn webpack_with_env<'a>(
+        name: &'a str,
+        env_name: &'a str,
+        env_config: EnvConfig<'a>,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack(name);
+        let mut env = HashMap::new();
+        env.insert(env_name, env_config);
+        wrangler_toml.env = Some(env);
+
+        wrangler_toml
+    }
+
     pub fn webpack_no_config(name: &str) -> WranglerToml {
         let mut wrangler_toml = WranglerToml::default();
         wrangler_toml.name = Some(name);

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -43,7 +43,7 @@ fn it_can_preview_webpack_project() {
     let fixture = Fixture::new();
     fixture.scaffold_webpack();
 
-    let wrangler_toml = WranglerToml::webpack_no_config("test-preview-webpack");
+    let wrangler_toml = WranglerToml::webpack_zoneless("test-preview-webpack", true);
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);


### PR DESCRIPTION
Sorry this is a lot, but the high level overview is that this PR adds an enum, `DeployTarget`, and a function `deploy_target` to `Manifest` that extracts the relevant deploy information from the manifest in preparation for publishing. 

This PR covers adding unit tests for pulling deploy targets from the top level of a wrangler toml. There are helper methods added here, also, for things like getting the worker name from the manifest, and lots and lots of test suite helpers.