### PR TITLE
Add and test environment override logic

### DIFF
--- a/src/settings/toml/deploy_target.rs
+++ b/src/settings/toml/deploy_target.rs
@@ -23,10 +23,10 @@ impl RouteConfig {
 
     pub fn routes_defined(&self) -> bool {
         if let Some(pattern) = &self.route {
-                !pattern.is_empty() || self.routes.is_some() // this is all so messy because of deserializer
-            } else {
-                self.routes.is_some()
-            }
+            !pattern.is_empty() || self.routes.is_some() // this is all so messy because of deserializer
+        } else {
+            self.routes.is_some()
+        }
     }
 
     pub fn is_zoneless(&self) -> bool {

--- a/src/settings/toml/environment.rs
+++ b/src/settings/toml/environment.rs
@@ -1,7 +1,8 @@
-use super::kv_namespace::KvNamespace;
-use super::site::Site;
-
 use serde::{Deserialize, Serialize};
+
+use crate::settings::toml::deploy_target::RouteConfig;
+use crate::settings::toml::kv_namespace::KvNamespace;
+use crate::settings::toml::site::Site;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Environment {
@@ -16,4 +17,15 @@ pub struct Environment {
     pub site: Option<Site>,
     #[serde(rename = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<KvNamespace>>,
+}
+
+impl Environment {
+    pub fn route_config(&self) -> Result<RouteConfig, failure::Error> {
+        Ok(RouteConfig {
+            workers_dev: self.workers_dev,
+            route: self.route.clone(),
+            routes: self.routes.clone(),
+            zone_id: self.zone_id.clone(),
+        })
+    }
 }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -145,7 +145,29 @@ impl Manifest {
     pub fn deploy_target(&self, env: Option<&str>) -> Result<DeployTarget, failure::Error> {
         let script = self.worker_name(env);
         validate_worker_name(&script)?;
+        if let Some(environment) = self.get_environment(env)? {
+            // if there is a complete environment level deploy target, return that
+            let mut env_route_config = environment.route_config()?;
+            if env_route_config.workers_dev_false_by_itself() {
+                failure::bail!("you must set workers_dev = true or a zoned deploy config.")
+            }
+            if env_route_config.is_zoneless() || env_route_config.is_zoned() {
+                if env_route_config.missing_zone_id() && env_route_config.routes_defined() {
+                    // if there is an incomplete environment level deploy target,
+                    // it is not zoneless, and routes do not inherit,
+                    // so fill in the zone id and build from that
+                    env_route_config.zone_id = self.zone_id.clone();
+                }
+                return DeployTarget::build(&script, &env_route_config);
+            }
+        }
+        // if there is no environment level deploy target, return the top level deploy target
         let route_config = self.route_config();
+
+        if route_config.workers_dev_false_by_itself() {
+            failure::bail!("you must set workers_dev = true or a zoned deploy config.")
+        }
+
         DeployTarget::build(&script, &route_config)
     }
 

--- a/src/settings/toml/tests/deploy_target.rs
+++ b/src/settings/toml/tests/deploy_target.rs
@@ -1,4 +1,4 @@
-use super::wrangler_toml::WranglerToml;
+use super::wrangler_toml::{EnvConfig, WranglerToml};
 
 use crate::settings::toml::deploy_target::Zoned;
 use crate::settings::toml::route::Route;
@@ -334,4 +334,541 @@ fn it_errors_on_deploy_target_routes_and_workers_dev_true() {
     let environment = None;
 
     assert!(manifest.deploy_target(environment).is_err());
+}
+
+// ENVIRONMENT TESTS
+// Top level empty
+#[test]
+fn when_top_level_empty_env_empty() {
+    let script = "top_level_empty_env_empty";
+    let env_name = "test";
+    let env_config = EnvConfig::default();
+
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // if env only includes zone id, error
+    let mut env_config = EnvConfig::default();
+    env_config.zone_id = Some("samplezoneid");
+
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+}
+
+#[test]
+fn when_top_level_empty_zoneless_env() {
+    let env_name = "test";
+
+    // TODO: THIS TEST SHOULD PASS
+    // when env.workers_dev = false
+    let env_config = EnvConfig::zoneless(false);
+
+    let script = "top_level_empty_env_empty";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when env.workers_dev = true
+    let env_config = EnvConfig::zoneless(true);
+
+    let script = "top_level_empty_env_zoneless_true";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    assert_eq!(actual_deploy_target, DeployTarget::Zoneless);
+}
+
+#[test]
+fn when_top_level_empty_zoned_single_route_env() {
+    let env_name = "test";
+    let zone_id = "samplezoneid";
+
+    // when route is empty, error
+    let pattern = "";
+    let env_config = EnvConfig::zoned_single_route(zone_id, pattern);
+
+    let script = "top_level_empty_env_zoned_single_route_empty";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is missing, error
+    let pattern = "hostname.tld/*";
+    let env_config = EnvConfig::zoned_single_route("", pattern);
+
+    let script = "top_level_empty_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when only zone id is present (no routes)
+    let mut env_config = EnvConfig::default();
+    env_config.zone_id = Some("samplezoneid");
+
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is present, all good
+    let pattern = "hostname.tld/*";
+    let env_config = EnvConfig::zoned_single_route(zone_id, pattern);
+
+    let script = "top_level_empty_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = vec![Route {
+        script: Some(expected_name),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn when_top_level_empty_zoned_multi_route_env() {
+    let env_name = "test";
+    let zone_id = "samplezoneid";
+
+    // when routes list is empty, error
+    let patterns = [];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_empty_env_zoned_multi_route_empty_list";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when route is empty, error
+    let patterns = [""];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_empty_env_zoned_multi_route_empty";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is missing, error
+    let patterns = ["hostname.tld/*"];
+    let env_config = EnvConfig::zoned_multi_route("", patterns.to_vec());
+
+    let script = "top_level_empty_env_zoned_multi_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is present, all good
+    let patterns = ["hostname.tld/*"];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_empty_env_zoned_multi_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_with_env(script, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = patterns
+        .iter()
+        .map(|p| Route {
+            script: Some(expected_name.to_string()),
+            pattern: p.to_string(),
+            id: None,
+        })
+        .collect();
+
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn when_top_level_zoneless_env_empty() {
+    let script = "top_level_zoneless_env_empty";
+    let env_name = "test";
+    let env_config = EnvConfig::default();
+
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    assert_eq!(actual_deploy_target, DeployTarget::Zoneless);
+}
+
+#[test]
+fn when_top_level_zoneless_env_zoneless() {
+    let env_name = "test";
+
+    // TODO: SHOULD THIS TEST PASS?
+    // when env.workers_dev = false
+    let env_config = EnvConfig::zoneless(false);
+
+    let script = "top_level_zoneless_env_zoneless_false";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when env.workers_dev = true
+    let env_config = EnvConfig::zoneless(true);
+
+    let script = "top_level_zoneless_env_zoneless_true";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    assert_eq!(actual_deploy_target, DeployTarget::Zoneless);
+}
+
+#[test]
+fn when_top_level_zoneless_env_zoned_single_route() {
+    let env_name = "test";
+    let zone_id = "samplezoneid";
+
+    // when route is empty, error
+    let pattern = "";
+    let env_config = EnvConfig::zoned_single_route(zone_id, pattern);
+
+    let script = "top_level_zoneless_env_zoned_single_route_empty";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is missing, error
+    let pattern = "hostname.tld/*";
+    let env_config = EnvConfig::zoned_single_route("", pattern);
+
+    let script = "top_level_zoneless_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is present, all good
+    let pattern = "hostname.tld/*";
+    let env_config = EnvConfig::zoned_single_route(zone_id, pattern);
+
+    let script = "top_level_zoneless_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = vec![Route {
+        script: Some(expected_name),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn when_top_level_zoneless_env_zoned_multi_route() {
+    let env_name = "test";
+    let zone_id = "samplezoneid";
+
+    // when routes list is empty, error
+    let patterns = [];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_zoneless_env_zoned_multi_route_empty_list";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when route is empty, error
+    let patterns = [""];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_zoneless_env_zoned_multi_route_empty";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when route key also present, error
+    let patterns = ["hostname.tld/*"];
+    let mut env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+    env_config.route = Some("blog.hostname.tld/*");
+
+    let script = "top_level_zoneless_env_zoned_multi_route_empty";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is missing, error
+    let patterns = ["hostname.tld/*"];
+    let env_config = EnvConfig::zoned_multi_route("", patterns.to_vec());
+
+    let script = "top_level_zoneless_env_zoned_multi_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is present, all good
+    let patterns = ["hostname.tld/*"];
+    let env_config = EnvConfig::zoned_multi_route(zone_id, patterns.to_vec());
+
+    let script = "top_level_zoneless_env_zoned_multi_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoneless_with_env(script, true, env_name, env_config);
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = patterns
+        .iter()
+        .map(|p| Route {
+            script: Some(expected_name.to_string()),
+            pattern: p.to_string(),
+            id: None,
+        })
+        .collect();
+
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn when_top_level_zoned_env_empty() {
+    let zone_id = "samplezoneid";
+    let pattern = "hostname.tld/*";
+    let env_name = "test";
+
+    let env_config = EnvConfig::default();
+
+    let script = "top_level_zoned_env_empty";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = vec![Route {
+        script: Some(expected_name),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+}
+
+#[test]
+fn when_top_level_zoned_env_zoneless() {
+    let zone_id = "samplezoneid";
+    let pattern = "hostname.tld/*";
+    let env_name = "test";
+
+    // TODO: SHOULD THIS TEST PASS?
+    // when env.workers_dev = false
+    let env_config = EnvConfig::zoneless(false);
+
+    let script = "top_level_zoned_env_zoneless_false";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when env.workers_dev = true
+    let env_config = EnvConfig::zoneless(true);
+
+    let script = "top_level_zoned_env_zoneless_true";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    assert_eq!(actual_deploy_target, DeployTarget::Zoneless);
+}
+
+#[test]
+fn when_top_level_zoned_env_zoned_single_route() {
+    let zone_id = "samplezoneid";
+    let pattern = "hostname.tld/*";
+    let env_name = "test";
+
+    // when route is empty, error
+    let env_pattern = "";
+    let env_config = EnvConfig::zoned_single_route(zone_id, env_pattern);
+
+    let script = "top_level_zoned_env_zoned_single_route_empty";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name));
+
+    assert!(actual_deploy_target.is_err());
+
+    // when zone id is missing, use top level zone
+    let env_pattern = "env.hostname.tld/*";
+    let env_config = EnvConfig::zoned_single_route("", env_pattern);
+
+    let script = "top_level_zoned_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = vec![Route {
+        script: Some(expected_name),
+        pattern: env_pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
+
+    // when zone id is present in env, use that
+    let env_pattern = "hostname.tld/*";
+    let env_zone_id = "sampleenvzoneid";
+    let env_config = EnvConfig::zoned_single_route(env_zone_id, env_pattern);
+
+    let script = "top_level_zoned_env_zoned_single_route_no_zone_id";
+    let test_toml = WranglerToml::webpack_zoned_single_route_with_env(
+        script, zone_id, pattern, env_name, env_config,
+    );
+    let toml_string = toml::to_string(&test_toml).unwrap();
+    let manifest = Manifest::new_from_string(toml_string).unwrap();
+
+    let actual_deploy_target = manifest.deploy_target(Some(env_name)).unwrap();
+
+    let expected_name = manifest.worker_name(Some(env_name));
+
+    let expected_routes = vec![Route {
+        script: Some(expected_name),
+        pattern: pattern.to_string(),
+        id: None,
+    }];
+    let expected_deploy_target = DeployTarget::Zoned(Zoned {
+        zone_id: env_zone_id.to_string(),
+        routes: expected_routes,
+    });
+
+    assert_eq!(actual_deploy_target, expected_deploy_target);
 }

--- a/tests/fixture/wrangler_toml.rs
+++ b/tests/fixture/wrangler_toml.rs
@@ -46,6 +46,29 @@ impl EnvConfig<'_> {
         eprintln!("{:#?}", &env_config);
         env_config
     }
+
+    pub fn zoneless(is_workers_dev: bool) -> EnvConfig<'static> {
+        let mut env_config = EnvConfig::default();
+        env_config.workers_dev = Some(is_workers_dev);
+
+        env_config
+    }
+
+    pub fn zoned_single_route<'a>(zone_id: &'a str, route: &'a str) -> EnvConfig<'a> {
+        let mut env_config = EnvConfig::default();
+        env_config.zone_id = Some(zone_id);
+        env_config.route = Some(route);
+
+        env_config
+    }
+
+    pub fn zoned_multi_route<'a>(zone_id: &'a str, routes: Vec<&'a str>) -> EnvConfig<'a> {
+        let mut env_config = EnvConfig::default();
+        env_config.zone_id = Some(zone_id);
+        env_config.routes = Some(routes);
+
+        env_config
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -116,9 +139,48 @@ impl WranglerToml<'_> {
         env_config: EnvConfig<'a>,
     ) -> WranglerToml<'a> {
         let mut wrangler_toml = WranglerToml::webpack(name);
-        let mut env = HashMap::new();
-        env.insert(env_name, env_config);
-        wrangler_toml.env = Some(env);
+        wrangler_toml.env = Some(test_env(env_name, env_config));
+
+        eprintln!("{:#?}", &wrangler_toml);
+        wrangler_toml
+    }
+
+    pub fn webpack_zoneless_with_env<'a>(
+        name: &'a str,
+        is_workers_dev: bool,
+        env_name: &'a str,
+        env_config: EnvConfig<'a>,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack_zoneless(name, is_workers_dev);
+        wrangler_toml.env = Some(test_env(env_name, env_config));
+
+        eprintln!("{:#?}", &wrangler_toml);
+        wrangler_toml
+    }
+
+    pub fn webpack_zoned_single_route_with_env<'a>(
+        name: &'a str,
+        zone_id: &'a str,
+        route: &'a str,
+        env_name: &'a str,
+        env_config: EnvConfig<'a>,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack_zoned_single_route(name, zone_id, route);
+        wrangler_toml.env = Some(test_env(env_name, env_config));
+
+        eprintln!("{:#?}", &wrangler_toml);
+        wrangler_toml
+    }
+
+    pub fn webpack_zoned_multi_route_with_env<'a>(
+        name: &'a str,
+        zone_id: &'a str,
+        routes: Vec<&'a str>,
+        env_name: &'a str,
+        env_config: EnvConfig<'a>,
+    ) -> WranglerToml<'a> {
+        let mut wrangler_toml = WranglerToml::webpack_zoned_multi_route(name, zone_id, routes);
+        wrangler_toml.env = Some(test_env(env_name, env_config));
 
         eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
@@ -159,4 +221,11 @@ impl WranglerToml<'_> {
         eprintln!("{:#?}", &wrangler_toml);
         wrangler_toml
     }
+}
+
+fn test_env<'a>(env_name: &'a str, env_config: EnvConfig<'a>) -> HashMap<&'a str, EnvConfig<'a>> {
+    let mut env = HashMap::new();
+    env.insert(env_name, env_config);
+
+    env
 }


### PR DESCRIPTION
depends on #944

for realsies mostly unit tests because this logic is like whack a mole. and i have STILL probably missed a few use cases.