### PR TITLE
Allow POST-ing of files in `wrangler preview`

### DIFF
--- a/src/commands/preview/mod.rs
+++ b/src/commands/preview/mod.rs
@@ -137,8 +137,6 @@ fn post(
             .send(),
         None => client.post(PREVIEW_ADDRESS).header("Cookie", cookie).send(),
     };
-    let msg = format!("POST {}", PREVIEW_ADDRESS);
-    message::preview(&msg);
     Ok(res?.text()?)
 }
 

--- a/src/commands/preview/mod.rs
+++ b/src/commands/preview/mod.rs
@@ -31,7 +31,7 @@ pub fn preview(
     mut target: Target,
     user: Option<GlobalUser>,
     method: HTTPMethod,
-    body: Option<String>,
+    body: Option<Vec<u8>>,
     livereload: bool,
     verbose: bool,
     headless: bool,
@@ -127,7 +127,7 @@ fn get(cookie: String, client: &reqwest::Client) -> Result<String, failure::Erro
 fn post(
     cookie: String,
     client: &reqwest::Client,
-    body: Option<String>,
+    body: Option<Vec<u8>>,
 ) -> Result<String, failure::Error> {
     let res = match body {
         Some(s) => client

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,7 +509,8 @@ fn run() -> Result<(), failure::Error> {
                 // If body starts with @, this is assumed to correspond to a path.
                 // Try to read the path contents and use that as body instead.
                 if s.starts_with("@") {
-                    let filename = Path::new(s.trim_start_matches("@"));
+                    // If starts with "@" to signify file, remove first "@".
+                    let filename = Path::new(&s[1..]);
                     match fs::read(filename) {
                         Ok(file_contents) => Some(file_contents),
                         Err(e) => failure::bail!("POST value started with @ so wrangler tried to open file \"{}\". Encountered error \"{}\"", filename.display(), e)

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,18 +504,18 @@ fn run() -> Result<(), failure::Error> {
 
         let method = HTTPMethod::from_str(matches.value_of("method").unwrap_or("get"))?;
 
-        let body = match matches.value_of("body") {
+        let body: Option<Vec<u8>> = match matches.value_of("body") {
             Some(s) => {
                 // If body starts with @, this is assumed to correspond to a path.
                 // Try to read the path contents and use that as body instead.
                 if s.starts_with("@") {
                     let filename = Path::new(s.trim_start_matches("@"));
-                    match fs::read_to_string(filename) {
+                    match fs::read(filename) {
                         Ok(file_contents) => Some(file_contents),
                         Err(e) => failure::bail!("POST value started with @ so wrangler tried to open file \"{}\". Encountered error \"{}\"", filename.display(), e)
                     }
                 } else {
-                    Some(s.to_string())
+                    Some(s.to_string().into_bytes())
                 }
             }
             None => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 extern crate text_io;
 
 use std::env;
+use std::fs;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -504,7 +505,19 @@ fn run() -> Result<(), failure::Error> {
         let method = HTTPMethod::from_str(matches.value_of("method").unwrap_or("get"))?;
 
         let body = match matches.value_of("body") {
-            Some(s) => Some(s.to_string()),
+            Some(s) => {
+                // If body starts with @, this is assumed to correspond to a path.
+                // Try to read the path contents and use that as body instead.
+                if s.starts_with("@") {
+                    let filename = Path::new(s.trim_start_matches("@"));
+                    match fs::read_to_string(filename) {
+                        Ok(file_contents) => Some(file_contents),
+                        Err(e) => failure::bail!("POST value started with @ so wrangler tried to open file \"{}\". Encountered error \"{}\"", filename.display(), e)
+                    }
+                } else {
+                    Some(s.to_string())
+                }
+            }
             None => None,
         };
 


### PR DESCRIPTION
This PR closes #282.

Previously, you could only POST strings directly provided to `wrangler preview post`:
```console
$ wrangler preview post hey --headless
 JavaScript project found. Skipping unnecessary build!
 Your wrangler.toml is missing the following fields: ["account_id"]
 Falling back to unauthenticated preview.
 Your Worker responded with: hey
```

This PR allows you to post files:
```console
$ wrangler preview post @./index.js --headless 
 JavaScript project found. Skipping unnecessary build!
 Your wrangler.toml is missing the following fields: ["account_id"]
 Falling back to unauthenticated preview.
 Your Worker responded with: <contents of ./index.js>
```

If a body argument to `wrangler preview post` starts with `@` but the filename following `@` does not exist, you get the following error message:
```console
$ wrangler preview post @not_real.json --headless
Error: POST value started with @ so wrangler tried to open file "not_real.json". Encountered error "No such file or directory (os error 2)"
```