### PR TITLE
Use indicatif to provide a more intuitive representation of upload progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +869,17 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2390,6 +2416,7 @@ dependencies = [
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2500,6 +2527,7 @@ dependencies = [
 "checksum cloudflare 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59ad92e7809c9c30862f371bdb613d7aaac8a5372332e323ab3e1b978693665c"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
 "checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
+"checksum console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
@@ -2560,6 +2588,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+"checksum indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
 "checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ sha2 = "0.8.0"
 data-encoding = "2.1.2"
 ignore = "0.4.10"
 tempfile = "3.1.0"
+indicatif = "0.13.0"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -74,10 +74,8 @@ pub fn upload_files(
                 || key_pair_bytes + pair.key.len() + pair.value.len() > UPLOAD_MAX_SIZE
                 {
                     upload_batch(&client, target, namespace_id, &mut key_value_batch)?;
-                    match &pb {
-                        // Need to unwrap via match to elegantly handle borrowing of pb.
-                        Some(p) => p.inc(key_value_batch.len() as u64),
-                        None => (),
+                    if let Some(p) = &pb {
+                        p.inc(key_value_batch.len() as u64);
                     }
 
                     // If upload successful, reset counters
@@ -91,9 +89,8 @@ pub fn upload_files(
                 key_value_batch.push(pair);
             }
         }
-        if pb.is_some() {
-            // OK to call unwrap here because we have alrady checked that pb is Some.
-            pb.unwrap().finish_with_message("Done Uploading");
+        if let Some(p) = pb {
+            p.finish_with_message("Done Uploading");
         }
     }
 

--- a/src/commands/kv/bucket/upload.rs
+++ b/src/commands/kv/bucket/upload.rs
@@ -50,7 +50,7 @@ pub fn upload_files(
     if pairs.len() > 0 {
         let client = kv::api_client(user)?;
         // Iterate over all key-value pairs and create batches of uploads, each of which are
-        // maximum 10K key-value pairs in size OR maximum ~50MB in size. Upload each batch
+        // maximum 5K key-value pairs in size OR maximum ~50MB in size. Upload each batch
         // as it is created.
         let mut key_count = 0;
         let mut key_pair_bytes = 0;


### PR DESCRIPTION
This PR closes #906. It uses the indicatif crate to represent progress in KV uploads for workers sites. This provides more context to upload progress than `Uploading...` messages.

Now uploads look like
```console
$ wrangler publish
 Using namespace for Workers Site "__blog-workers_sites_assets"
 Uploading site files
████████████████████████████████████████████████████████████████████████ 48/48
 Success
⬇️ Installing wasm-pack...
 Built successfully, built project size is 11 KiB.
 Successfully published your script to https://blog.ziggy.workers.dev

```