### PR TITLE
[WIP] [dev] Attempt to send cf-ew-raw-host

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -99,7 +99,7 @@ fn preview_request(
     let now: DateTime<Local> = Local::now();
     let preview_id = &preview_id;
 
-    prepend_request_headers_prefix(&mut parts);
+    prepend_request_headers_prefix(&mut parts, &server_config);
 
     parts.headers.insert(
         HeaderName::from_static("host"),
@@ -129,7 +129,7 @@ fn preview_request(
 fn get_preview_id(
     mut target: Target,
     user: Option<GlobalUser>,
-    server_config: &ServerConfig,
+    server_config: &ServerConfig
 ) -> Result<String, failure::Error> {
     let session = Uuid::new_v4().to_simple();
     let verbose = true;

--- a/src/commands/dev/server_config/host.rs
+++ b/src/commands/dev/server_config/host.rs
@@ -35,17 +35,17 @@ impl Host {
     pub fn is_https(&self) -> bool {
         self.url.scheme() == "https"
     }
+
+    pub fn to_string(&self) -> String {
+        self.url
+            .host_str()
+            .expect("could not parse host")
+            .to_string()
+    }
 }
 
 impl fmt::Display for Host {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.url
-                .host_str()
-                .expect("could not parse host")
-                .to_string()
-        )
+        write!(f, "{}", self.to_string())
     }
 }

--- a/src/commands/dev/server_config/listening_address.rs
+++ b/src/commands/dev/server_config/listening_address.rs
@@ -18,13 +18,13 @@ impl ListeningAddress {
         Ok(ListeningAddress { address })
     }
 
-    fn as_str(&self) -> String {
+    pub fn to_string(&self) -> String {
         self.address.to_string().replace("[::1]", "localhost")
     }
 }
 
 impl fmt::Display for ListeningAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        write!(f, "{}", self.to_string())
     }
 }


### PR DESCRIPTION
Attempt to fix #926  

The preview service doesn't seem to care if I send a `cf-ew-raw-host` header and instead uses the host that we've passed to the preview service when we create a new session.