### PR TITLE
[wip] [dev] Disallow localhost as backend

### DIFF
--- a/src/commands/dev/server_config/host.rs
+++ b/src/commands/dev/server_config/host.rs
@@ -27,6 +27,11 @@ impl Host {
         // validate host
         let host = url.host_str().ok_or_else(|| format_err!("Invalid host, accepted formats are example.com, http://example.com, or https://example.com"))?;
 
+        // TODO: make this less naive, the preview service will rick roll on other IP addresses as well, these are just the most common
+        if host == "localhost" || host == "127.0.0.1" {
+            failure::bail!("You cannot currently use wrangler dev with a local server as the host. You could use TryCloudflare to generate a public URL that you could then pass as the host to wrangler dev.\nSee https://developers.cloudflare.com/argo-tunnel/trycloudflare/ for more info")
+        }
+
         // recreate url without any trailing path
         let url = Url::parse(&format!("{}://{}", scheme, host))?;
         Ok(Host { url })


### PR DESCRIPTION
Fixes #902

```console
$ wrangler dev -h http://localhost:8000
💁  JavaScript project found. Skipping unnecessary build!
Error: You cannot currently use wrangler dev with a local server as the host. You could use TryCloudflare to generate a public URL that you could then pass as the host to wrangler dev.
See https://developers.cloudflare.com/argo-tunnel/trycloudflare/ for more info
```

This approach is a bit naive at the moment, there are other endpoints that the preview service will return a rick roll embed on.