### PR TITLE
[dev] Return proper response code

### DIFF
--- a/src/commands/dev/headers.rs
+++ b/src/commands/dev/headers.rs
@@ -1,10 +1,35 @@
 const HEADER_PREFIX: &str = "cf-ew-raw-";
 
+use std::str::FromStr;
+
 use hyper::header::{HeaderMap, HeaderName};
 use hyper::http::request::Parts as RequestParts;
 use hyper::http::response::Parts as ResponseParts;
+use hyper::http::status::StatusCode;
 
-pub fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+pub fn structure_request(parts: &mut RequestParts) {
+    prepend_request_headers_prefix(parts)
+}
+
+pub fn destructure_response(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+    set_response_status(parts)?;
+    strip_response_headers_prefix(parts)
+}
+
+fn prepend_request_headers_prefix(parts: &mut RequestParts) {
+    let mut headers: HeaderMap = HeaderMap::new();
+
+    for header in &parts.headers {
+        let (name, value) = header;
+        let forward_header = format!("{}{}", HEADER_PREFIX, name);
+        let header_name = HeaderName::from_bytes(forward_header.as_bytes())
+            .unwrap_or_else(|_| panic!("Could not create header name for {}", name));
+        headers.insert(header_name, value.clone());
+    }
+    parts.headers = headers;
+}
+
+fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<(), failure::Error> {
     let mut headers = HeaderMap::new();
 
     for header in &parts.headers {
@@ -20,15 +45,14 @@ pub fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<(), fa
     Ok(())
 }
 
-pub fn prepend_request_headers_prefix(parts: &mut RequestParts) {
-    let mut headers: HeaderMap = HeaderMap::new();
-
-    for header in &parts.headers {
-        let (name, value) = header;
-        let forward_header = format!("{}{}", HEADER_PREFIX, name);
-        let header_name = HeaderName::from_bytes(forward_header.as_bytes())
-            .unwrap_or_else(|_| panic!("Could not create header name for {}", name));
-        headers.insert(header_name, value.clone());
-    }
-    parts.headers = headers;
+fn set_response_status(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+    let status = parts
+        .headers
+        .get("cf-ew-status")
+        .expect("Could not determine status code of response");
+    // status will be "404 not found" or "200 ok"
+    // we need to split that string to create hyper's status code
+    let status_vec: Vec<&str> = status.to_str()?.split(" ").collect();
+    parts.status = StatusCode::from_str(status_vec[0])?;
+    Ok(())
 }

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -1,7 +1,7 @@
 mod server_config;
 use server_config::ServerConfig;
 mod headers;
-use headers::{prepend_request_headers_prefix, strip_response_headers_prefix};
+use headers::{destructure_response, structure_request};
 
 use chrono::prelude::*;
 
@@ -55,11 +55,10 @@ pub async fn dev(
                 let server_config = server_config.to_owned();
                 async move {
                     let resp = preview_request(req, client, preview_id, server_config).await?;
-
                     let (mut parts, body) = resp.into_parts();
 
-                    strip_response_headers_prefix(&mut parts)?;
-
+                    destructure_response(&mut parts)?;
+                    println!(" {}", parts.status.as_str());
                     let resp = Response::from_parts(parts, body);
                     Ok::<_, failure::Error>(resp)
                 }
@@ -99,7 +98,7 @@ fn preview_request(
     let now: DateTime<Local> = Local::now();
     let preview_id = &preview_id;
 
-    prepend_request_headers_prefix(&mut parts);
+    structure_request(&mut parts);
 
     parts.headers.insert(
         HeaderName::from_static("host"),
@@ -115,7 +114,7 @@ fn preview_request(
 
     let req = Request::from_parts(parts, body);
 
-    println!(
+    print!(
         "[{}] \"{} {}{} {:?}\"",
         now.format("%Y-%m-%d %H:%M:%S"),
         method,


### PR DESCRIPTION
Fixes #965

The cloudflareworkers endpoint always returns 200 when it's a good request, and includes the status of the worker in the `cf-ew-status` header. This PR pulls out that status and returns it from the local server.