### PR TITLE
Fix #958: Do not factor in .gitignore into workers sites upload directory traversal

### DIFF
--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -477,6 +477,11 @@ mod tests {
 
         assert!(files.contains(&test_path));
 
+        // Why drop()? Well, fs::remove_dir_all on Windows depends on the DeleteFileW syscall.
+        // This syscalldoesn't actually delete a file, but only marks it for deletion. It still
+        // can be alive when we try to delete the parent directory test_dir, causing a "directory
+        // is not empty" error. As a result, we MUST call drop() to close the gitignore file so
+        // that it is not alive when fs::remove_dir_all(test_dir) is called.
         drop(gitignore);
         fs::remove_dir_all(test_dir).unwrap();
     }

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -477,6 +477,7 @@ mod tests {
 
         assert!(files.contains(&test_path));
 
+        drop(gitignore);
         fs::remove_dir_all(test_dir).unwrap();
     }
 

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -478,7 +478,7 @@ mod tests {
         assert!(files.contains(&test_path));
 
         // Why drop()? Well, fs::remove_dir_all on Windows depends on the DeleteFileW syscall.
-        // This syscalldoesn't actually delete a file, but only marks it for deletion. It still
+        // This syscall doesn't actually delete a file, but only marks it for deletion. It still
         // can be alive when we try to delete the parent directory test_dir, causing a "directory
         // is not empty" error. As a result, we MUST call drop() to close the gitignore file so
         // that it is not alive when fs::remove_dir_all(test_dir) is called.

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -477,6 +477,7 @@ mod tests {
 
         assert!(files.contains(&test_path));
 
+        fs::remove_dir_all(upload_dir).unwrap();
         fs::remove_dir_all(test_dir).unwrap();
     }
 

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -447,7 +447,7 @@ mod tests {
     fn it_can_include_gitignore_entries() {
         // We don't want our wrangler include/exclude functionality to read .gitignore files.
         let mut site = Site::default();
-        site.bucket = PathBuf::from("fake");
+        site.bucket = PathBuf::from("public");
         let target = make_target(site);
 
         let test_dir = "test7";
@@ -461,7 +461,7 @@ mod tests {
         let gitignore_pathname = format!("{}/.gitignore", test_dir);
         let gitignore_path = PathBuf::from(&gitignore_pathname);
         let mut gitignore = fs::File::create(&gitignore_path).unwrap();
-        gitignore.write_all(b"public/\n").unwrap();
+        writeln!(gitignore, "public/").unwrap();
 
         // Create 'public/' directory, which should be included.
         let upload_dir = format!("{}/public", test_dir);
@@ -477,7 +477,6 @@ mod tests {
 
         assert!(files.contains(&test_path));
 
-        fs::remove_dir_all(upload_dir).unwrap();
         fs::remove_dir_all(test_dir).unwrap();
     }
 


### PR DESCRIPTION
Fixes #958. This change ensures that the wrangler include/exclude logic for workers sites bucket directory traversal does NOT take into account .gitignore. A test has been added to ensure this functionality exists.