### PR TITLE
[dev] Code watching/live reload

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -5,6 +5,7 @@ mod headers;
 use headers::{destructure_response, structure_request};
 
 use std::thread;
+use std::sync::{mpsc, Mutex, Arc};
 
 use chrono::prelude::*;
 
@@ -34,6 +35,7 @@ const PREVIEW_HOST: &str = "rawhttp.cloudflareworkers.com";
 pub fn dev(
     target: Target,
     user: Option<GlobalUser>,
+    watch: bool,
     host: Option<&str>,
     port: Option<&str>,
     ip: Option<&str>,
@@ -41,19 +43,26 @@ pub fn dev(
     commands::build(&target)?;
     let server_config = ServerConfig::new(host, ip, port)?;
     let session_id = get_session_id()?;
-    let preview_id = get_preview_id(target, user, &server_config, &session_id)?;
+    let preview_id = get_preview_id(target.clone(), user.clone(), &server_config, &session_id)?;
+    let preview_id = Arc::new(Mutex::new(preview_id));
 
     // create a new thread to listen for devtools messages
-    thread::spawn(move || socket::listen(session_id));
+    thread::spawn(move || socket::listen(&session_id));
+    
+    { // create an artificial scope to create new preview_id Arc
+        let preview_id = preview_id.clone();
+        let server_config = server_config.clone();
+        thread::spawn(move || watch_for_changes(target, user, &server_config, Arc::clone(&preview_id), true));
+    }
 
     // spawn tokio runtime on the main thread to handle incoming HTTP requests
     let mut runtime = TokioRuntime::new()?;
-    runtime.block_on(serve(server_config, preview_id))?;
+    runtime.block_on(serve(server_config, Arc::clone(&preview_id)))?;
 
     Ok(())
 }
 
-async fn serve(server_config: ServerConfig, preview_id: String) -> Result<(), failure::Error> {
+async fn serve(server_config: ServerConfig, preview_id: Arc<Mutex<String>>) -> Result<(), failure::Error> {
     // set up https client to connect to the preview service
     let https = HttpsConnector::new();
     let client = HyperClient::builder().build::<_, Body>(https);
@@ -67,10 +76,10 @@ async fn serve(server_config: ServerConfig, preview_id: String) -> Result<(), fa
         async move {
             Ok::<_, failure::Error>(service_fn(move |req| {
                 let client = client.to_owned();
-                let preview_id = preview_id.to_owned();
+                let preview_id = preview_id.lock().unwrap().to_owned();
                 let server_config = server_config.to_owned();
                 async move {
-                    let resp = preview_request(req, client, preview_id, server_config).await?;
+                    let resp = preview_request(req, client, preview_id.to_owned(), server_config).await?;
                     let (mut parts, body) = resp.into_parts();
 
                     destructure_response(&mut parts)?;
@@ -112,6 +121,7 @@ fn preview_request(
     let method = parts.method.to_string();
     let now: DateTime<Local> = Local::now();
     let preview_id = &preview_id;
+    println!("request id: {:?}", preview_id);
 
     structure_request(&mut parts);
 
@@ -129,6 +139,7 @@ fn preview_request(
 
     let req = Request::from_parts(parts, body);
 
+    
     println!(
         "[{}] \"{} {}{} {:?}\"",
         now.format("%Y-%m-%d %H:%M:%S"),
@@ -160,4 +171,31 @@ fn get_preview_id(
         server_config.host.is_https() as u8,
         server_config.host
     ))
+}
+
+fn watch_for_changes(
+    target: Target,
+    user: Option<GlobalUser>,
+    server_config: &ServerConfig,
+    preview_id: Arc<Mutex<String>>,
+    verbose: bool,
+) -> Result<(), failure::Error> {
+    let sites_preview: bool = target.site.is_some();
+
+    let (tx, rx) = mpsc::channel();
+    
+    commands::watch_and_build(&target, Some(tx))?;
+
+    while let Ok(_) = rx.recv() {
+        let user = user.clone();
+        let mut target = target.clone();
+        commands::build(&target)?;
+
+        if let Ok(new_id) = upload(&mut target, user.as_ref(), sites_preview, verbose) {
+            let mut p = preview_id.lock().unwrap();
+            *p = get_preview_id(target, user, server_config, &new_id)?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/commands/dev/socket/mod.rs
+++ b/src/commands/dev/socket/mod.rs
@@ -2,7 +2,7 @@ mod client;
 
 use client::WsClient;
 
-pub fn listen(session_id: String) -> Result<(), failure::Error> {
+pub fn listen(session_id: &str) -> Result<(), failure::Error> {
     let socket_url = format!("wss://rawhttp.cloudflareworkers.com/inspect/{}", session_id);
     ws::connect(socket_url, |out| WsClient { out }).unwrap();
     Ok(())

--- a/src/commands/dev/watch.rs
+++ b/src/commands/dev/watch.rs
@@ -1,0 +1,33 @@
+use std::mem;
+use std::sync::{mpsc, Arc, Mutex};
+
+use crate::commands;
+use crate::commands::dev::get_preview_id;
+use crate::commands::dev::server_config::ServerConfig;
+
+use crate::settings::global_user::GlobalUser;
+use crate::settings::toml::Target;
+
+pub fn watch_for_changes(
+    target: Target,
+    user: Option<GlobalUser>,
+    server_config: &ServerConfig,
+    preview_id: Arc<Mutex<String>>,
+    session_id: &str,
+    verbose: bool,
+) -> Result<(), failure::Error> {
+    let (tx, rx) = mpsc::channel();
+    commands::watch_and_build(&target, Some(tx))?;
+
+    while let Ok(_) = rx.recv() {
+        let user = user.clone();
+        let target = target.clone();
+        commands::build(&target)?;
+
+        let mut p = preview_id.lock().unwrap();
+        *p = get_preview_id(target, user, server_config, session_id, verbose)?;
+        mem::drop(p);
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,11 +374,10 @@ fn run() -> Result<(), failure::Error> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("watch")
-                        .help("watch your project for changes and update the preview automagically")
-                        .long("watch")
-                        .takes_value(true)
-                        .default_value("true"),
+                    Arg::with_name("verbose")
+                        .long("verbose")
+                        .takes_value(false)
+                        .help("toggle verbose output"),
                 ),
         )
         .subcommand(
@@ -556,10 +555,10 @@ fn run() -> Result<(), failure::Error> {
         let ip = matches.value_of("ip");
         let manifest = settings::toml::Manifest::new(config_path)?;
         let env = matches.value_of("env");
-        let watch = FromStr::from_str(matches.value_of("watch").unwrap())?;
         let target = manifest.get_target(env)?;
+        let verbose = matches.is_present("verbose");
         let user = settings::global_user::GlobalUser::new().ok();
-        commands::dev::dev(target, user, watch, host, port, ip)?;
+        commands::dev::dev(target, user, host, port, ip, verbose)?;
     } else if matches.subcommand_matches("whoami").is_some() {
         log::info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,6 +372,13 @@ fn run() -> Result<(), failure::Error> {
                         .short("i")
                         .long("ip")
                         .takes_value(true)
+                )
+                .arg(
+                    Arg::with_name("watch")
+                        .help("watch your project for changes and update the preview automagically")
+                        .long("watch")
+                        .takes_value(true)
+                        .default_value("true"),
                 ),
         )
         .subcommand(
@@ -549,9 +556,10 @@ fn run() -> Result<(), failure::Error> {
         let ip = matches.value_of("ip");
         let manifest = settings::toml::Manifest::new(config_path)?;
         let env = matches.value_of("env");
+        let watch = FromStr::from_str(matches.value_of("watch").unwrap())?;
         let target = manifest.get_target(env)?;
         let user = settings::global_user::GlobalUser::new().ok();
-        commands::dev::dev(target, user, host, port, ip)?;
+        commands::dev::dev(target, user, watch, host, port, ip)?;
     } else if matches.subcommand_matches("whoami").is_some() {
         log::info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;


### PR DESCRIPTION
So this works - 

```console
$ wrangler dev
💁  JavaScript project found. Skipping unnecessary build!
👂  Listening on http://localhost:8787
💁  watching "./"
[2020-01-08 11:34:33] "GET example.com/ HTTP/1.1"
"hello, world! i have not edited a file"
🌀  Detected changes...
💁  JavaScript project found. Skipping unnecessary build!
[2020-01-08 11:34:37] "GET example.com/ HTTP/1.1"
"hello, world! i have edited a file"
🌀  Detected changes...
💁  JavaScript project found. Skipping unnecessary build!
[2020-01-08 11:34:55] "GET example.com/ HTTP/1.1"
unknown console event: "Script modified; context reset."
"hello, world! i have edited a file again"
```

The problem is that the console event `"Script modified; context reset"` only occurs after I issue another curl command, which makes me think that my thread logic is blocking somewhere that it shouldn't be. I'm not quite sure how that would be happening as I made sure to drop the mutex guards after i use them.