### PR TITLE
🤫 Secrets commands

### DIFF
--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -13,6 +13,7 @@ use crate::commands::kv::bulk::MAX_PAIRS;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
+use crate::terminal::utils;
 
 pub fn delete(
     target: &Target,
@@ -22,7 +23,7 @@ pub fn delete(
 ) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
 
-    match kv::interactive_delete(&format!(
+    match utils::interactive_delete(&format!(
         "Are you sure you want to delete all keys in {}?",
         filename.display()
     )) {

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -5,6 +5,7 @@ use crate::commands::kv;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
+use crate::terminal::utils;
 
 pub fn delete(
     target: &Target,
@@ -15,7 +16,7 @@ pub fn delete(
     kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 
-    match kv::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
+    match utils::interactive_delete(&format!("Are you sure you want to delete key \"{}\"?", key)) {
         Ok(true) => (),
         Ok(false) => {
             message::info(&format!("Not deleting key \"{}\"", key));

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -16,11 +16,6 @@ pub mod bulk;
 pub mod key;
 pub mod namespace;
 
-// Truncate all "yes", "no" responses for interactive delete prompt to just "y" or "n".
-const INTERACTIVE_RESPONSE_LEN: usize = 1;
-const YES: &str = "y";
-const NO: &str = "n";
-
 // Create a special API client that has a longer timeout than usual, given that KV operations
 // can be lengthy if payloads are large.
 fn api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
@@ -118,22 +113,6 @@ pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failur
         binding,
         target.name
     )
-}
-
-// For interactively handling deletes (and discouraging accidental deletes).
-// Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
-// and lowercasing logic below.
-pub fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
-    println!("{} [y/n]", prompt_string);
-    let mut response: String = read!("{}\n");
-    response = response.split_whitespace().collect(); // remove whitespace
-    response.make_ascii_lowercase(); // ensure response is all lowercase
-    response.truncate(INTERACTIVE_RESPONSE_LEN); // at this point, all valid input will be "y" or "n"
-    match response.as_ref() {
-        YES => Ok(true),
-        NO => Ok(false),
-        _ => failure::bail!("Response must either be \"y\" for yes or \"n\" for no"),
-    }
 }
 
 fn url_encode_key(key: &str) -> String {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -123,7 +123,7 @@ pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failur
 // For interactively handling deletes (and discouraging accidental deletes).
 // Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
 // and lowercasing logic below.
-fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
+pub fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
     println!("{} [y/n]", prompt_string);
     let mut response: String = read!("{}\n");
     response = response.split_whitespace().collect(); // remove whitespace

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -5,12 +5,13 @@ use crate::commands::kv;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
+use crate::terminal::utils;
 
 pub fn delete(target: &Target, user: &GlobalUser, id: &str) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
     let client = kv::api_client(user)?;
 
-    match kv::interactive_delete(&format!(
+    match utils::interactive_delete(&format!(
         "Are you sure you want to delete namespace {}?",
         id
     )) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,8 +7,8 @@ pub mod init;
 pub mod kv;
 pub mod preview;
 pub mod publish;
-pub mod subdomain;
 pub mod secret;
+pub mod subdomain;
 pub mod whoami;
 
 pub use self::config::global_config;
@@ -19,7 +19,9 @@ pub use init::init;
 pub use preview::{preview, HTTPMethod};
 pub use publish::publish;
 use regex::Regex;
-pub use secret::set_secret;
+pub use secret::create_secret;
+pub use secret::delete_secret;
+// TODO add more secret commands
 pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,7 +21,7 @@ pub use publish::publish;
 use regex::Regex;
 pub use secret::create_secret;
 pub use secret::delete_secret;
-// TODO add more secret commands
+pub use secret::list_secrets;
 pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod kv;
 pub mod preview;
 pub mod publish;
 pub mod subdomain;
+pub mod secret;
 pub mod whoami;
 
 pub use self::config::global_config;
@@ -18,6 +19,7 @@ pub use init::init;
 pub use preview::{preview, HTTPMethod};
 pub use publish::publish;
 use regex::Regex;
+pub use secret::set_secret;
 pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -1,0 +1,130 @@
+use crate::http;
+use crate::settings::global_user::GlobalUser;
+use crate::settings::toml::Target;
+use crate::terminal::{emoji, message};
+use crate::commands::kv;
+use std::path::Path;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct Secret {
+    secret: String,
+}
+
+impl Secret {
+    pub fn get(account_id: &str, user: &GlobalUser) -> Result<Option<String>, failure::Error> {
+        let addr = subdomain_addr(account_id);
+
+        let client = http::auth_client(None, user);
+
+        let mut response = client.get(&addr).send()?;
+
+        if !response.status().is_success() {
+            failure::bail!(
+                "{} There was an error fetching your secret.\n Status Code: {}\n Msg: {}",
+                emoji::WARN,
+                response.status(),
+                response.text()?,
+            )
+        }
+        let response: Response = serde_json::from_str(&response.text()?)?;
+        Ok(response.result.map(|r| r.secret))
+    }
+
+    pub fn put(name: &str, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+        let addr = subdomain_addr(account_id);
+        let secret = Secret {
+            secret: name.to_string(),
+        };
+        let subdomain_request = serde_json::to_string(&secret)?;
+
+        let client = http::auth_client(None, user);
+
+        let mut response = client.put(&addr).body(subdomain_request).send()?;
+
+        if !response.status().is_success() {
+            let response_text = response.text()?;
+            log::debug!("Status Code: {}", response.status());
+            log::debug!("Status Message: {}", response_text);
+            let msg = if response.status() == 409 {
+                format!(
+                    "{} Your requested secret is not available. Please pick another one.",
+                    emoji::WARN
+                )
+            } else {
+                format!(
+                "{} There was an error creating your requested secret.\n Status Code: {}\n Msg: {}",
+                emoji::WARN,
+                response.status(),
+                response_text
+            )
+            };
+            failure::bail!(msg)
+        }
+        message::success(&format!("Success! You've registered {}.", name));
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct Response {
+    result: Option<SubdomainResult>,
+}
+
+#[derive(Deserialize)]
+struct SubdomainResult {
+    secret: String,
+}
+
+fn subdomain_addr(account_id: &str) -> String {
+    format!(
+        "https://api.cloudflare.com/client/v4/accounts/{}/workers/subdomain",
+        account_id
+    )
+}
+
+fn register_subdomain(
+    name: &str,
+    user: &GlobalUser,
+    target: &Target,
+) -> Result<(), failure::Error> {
+    let msg = format!(
+        "Registering your secret, {}.workers.dev, this could take up to a minute.",
+        name
+    );
+    message::working(&msg);
+    Secret::put(name, &target.account_id, user)
+}
+
+pub fn set_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+  match kv::interactive_delete(&format!(
+    "Are you sure you want to delete all keys in {}?",
+    "name"
+    )) {
+        Ok(true) => (),
+        Ok(false) => {
+            message::info(&format!("Not deleting keys in "));
+            return Ok(());
+        }
+        Err(e) => failure::bail!(e),
+    }
+
+    if target.account_id.is_empty() {
+        failure::bail!(format!(
+            "{} You must provide an account_id in your wrangler.toml before creating a secret!",
+            emoji::WARN
+        ))
+    }
+    let secret = Secret::get(&target.account_id, user)?;
+    if let Some(secret) = secret {
+        let msg = if secret == name {
+            format!("You have previously registered {}.workers.dev", secret)
+        } else {
+            format!("This account already has a registered secret. You can only register one secret per account. Your secret is {}.workers.dev", secret)
+        };
+        failure::bail!(msg)
+    } else {
+        register_subdomain(&name, &user, &target)
+    }
+}
+

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -13,8 +13,6 @@ use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::HttpApiClientConfig;
 
 fn format_error(e: ApiFailure) -> String {
-    print!("TODO next ~5 lines of API Failure details {}", e); //TODO: remove
-                                                               // e.code
     http::format_error(e, Some(&secret_errors))
 }
 
@@ -69,7 +67,6 @@ fn api_put_secret(
     secret_value: String,
 ) -> Result<(), failure::Error> {
     let msg = format!("Creating the secret for script name {}", target.name);
-    // let response = call_api(target, name, secret_value);
     let client = http::cf_v4_api_client(user, HttpApiClientConfig::default())?;
 
     let response = client.request(&CreateSecret {
@@ -102,7 +99,10 @@ fn api_delete_secret(user: &GlobalUser, target: &Target, name: &str) -> Result<(
 
     match response {
         Ok(_) => message::success(&format!("You've deleted the secret {}.", name)),
-        Err(e) => failure::bail!(format!("Formatted error{}", format_error(e))),
+        Err(e) => failure::bail!(format!(
+            "TODO: delete this print of the error {}",
+            format_error(e)
+        )),
     }
     message::working(&msg);
     Ok(())

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -1,12 +1,10 @@
-use crate::http;
+// use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::{emoji, message};
-use crate::commands::kv;
-use std::path::Path;
-use serde::{Deserialize, Serialize};
+use serde::{ Serialize};
 // For interactively handling  reading in a string
-pub fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
+pub fn interactive_get_string(prompt_string: &str) -> Result<bool, failure::Error> {
     println!("{}",prompt_string);
     let mut response: String = read!("{}\n");
     println!("{}",response);
@@ -27,13 +25,13 @@ pub struct Script {
 
 impl Secret {
 
-    pub fn put(name: &str, target: &Target, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+    pub fn put(name: &str, user: &GlobalUser) -> Result<(), failure::Error> {
         message::success(&format!("Success! You've uploaded secret {}.", name));
         Ok(())
     }
 }
 impl Script {
-    pub fn put(name: &str, target: &Target, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+    pub fn put(name: &str, target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
         message::success(&format!("Success! You've bound the secret {} to {}.", name, target.name));
         Ok(())
     }
@@ -51,7 +49,7 @@ fn bind_secret(
         target.name
     );
     message::working(&msg);
-    Script::put(name, &target, &target.account_id, user)
+    Script::put(name, &target,  user)
 }
 fn put_secret(
     
@@ -65,11 +63,11 @@ fn put_secret(
     );
     
     message::working(&msg);
-    Secret::put(name, &target, &target.account_id, user)
+    Secret::put(name,  user)
 }
 
 pub fn set_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
-  match interactive_delete(&format!(
+  match interactive_get_string(&format!(
     "Enter the secret text you'd like assigned to {}?",
     name
     )) {

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -5,105 +5,77 @@ use crate::terminal::{emoji, message};
 use crate::commands::kv;
 use std::path::Path;
 use serde::{Deserialize, Serialize};
+// For interactively handling  reading in a string
+pub fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
+    println!("{}",prompt_string);
+    let mut response: String = read!("{}\n");
+    println!("{}",response);
+    match response.as_str() {
+        "" => Ok(false),
+        _ =>  Ok(true),
+    }
+}
 
 #[derive(Serialize)]
 pub struct Secret {
     secret: String,
 }
+#[derive(Serialize)]
+pub struct Script {
+    secret: String,
+}
 
 impl Secret {
-    pub fn get(account_id: &str, user: &GlobalUser) -> Result<Option<String>, failure::Error> {
-        let addr = subdomain_addr(account_id);
 
-        let client = http::auth_client(None, user);
-
-        let mut response = client.get(&addr).send()?;
-
-        if !response.status().is_success() {
-            failure::bail!(
-                "{} There was an error fetching your secret.\n Status Code: {}\n Msg: {}",
-                emoji::WARN,
-                response.status(),
-                response.text()?,
-            )
-        }
-        let response: Response = serde_json::from_str(&response.text()?)?;
-        Ok(response.result.map(|r| r.secret))
+    pub fn put(name: &str, target: &Target, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+        message::success(&format!("Success! You've uploaded secret {}.", name));
+        Ok(())
     }
-
-    pub fn put(name: &str, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
-        let addr = subdomain_addr(account_id);
-        let secret = Secret {
-            secret: name.to_string(),
-        };
-        let subdomain_request = serde_json::to_string(&secret)?;
-
-        let client = http::auth_client(None, user);
-
-        let mut response = client.put(&addr).body(subdomain_request).send()?;
-
-        if !response.status().is_success() {
-            let response_text = response.text()?;
-            log::debug!("Status Code: {}", response.status());
-            log::debug!("Status Message: {}", response_text);
-            let msg = if response.status() == 409 {
-                format!(
-                    "{} Your requested secret is not available. Please pick another one.",
-                    emoji::WARN
-                )
-            } else {
-                format!(
-                "{} There was an error creating your requested secret.\n Status Code: {}\n Msg: {}",
-                emoji::WARN,
-                response.status(),
-                response_text
-            )
-            };
-            failure::bail!(msg)
-        }
-        message::success(&format!("Success! You've registered {}.", name));
+}
+impl Script {
+    pub fn put(name: &str, target: &Target, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+        message::success(&format!("Success! You've bound the secret {} to {}.", name, target.name));
         Ok(())
     }
 }
 
-#[derive(Deserialize)]
-struct Response {
-    result: Option<SubdomainResult>,
-}
 
-#[derive(Deserialize)]
-struct SubdomainResult {
-    secret: String,
-}
 
-fn subdomain_addr(account_id: &str) -> String {
-    format!(
-        "https://api.cloudflare.com/client/v4/accounts/{}/workers/subdomain",
-        account_id
-    )
-}
-
-fn register_subdomain(
+fn bind_secret(
     name: &str,
     user: &GlobalUser,
     target: &Target,
 ) -> Result<(), failure::Error> {
     let msg = format!(
-        "Registering your secret, {}.workers.dev, this could take up to a minute.",
-        name
+        "Binding secret to script {}",
+        target.name
     );
     message::working(&msg);
-    Secret::put(name, &target.account_id, user)
+    Script::put(name, &target, &target.account_id, user)
+}
+fn put_secret(
+    
+    name: &str,
+    user: &GlobalUser,
+    target: &Target,
+) -> Result<(), failure::Error> {
+    let msg = format!(
+        "Creating the secret for account {}",
+        target.account_id
+    );
+    
+    message::working(&msg);
+    Secret::put(name, &target, &target.account_id, user)
 }
 
 pub fn set_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
-  match kv::interactive_delete(&format!(
-    "Are you sure you want to delete all keys in {}?",
-    "name"
+  match interactive_delete(&format!(
+    "Enter the secret text you'd like assigned to {}?",
+    name
     )) {
         Ok(true) => (),
         Ok(false) => {
-            message::info(&format!("Not deleting keys in "));
+            message::info(&format!("Enter a valid string "));
             return Ok(());
         }
         Err(e) => failure::bail!(e),
@@ -115,16 +87,8 @@ pub fn set_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), 
             emoji::WARN
         ))
     }
-    let secret = Secret::get(&target.account_id, user)?;
-    if let Some(secret) = secret {
-        let msg = if secret == name {
-            format!("You have previously registered {}.workers.dev", secret)
-        } else {
-            format!("This account already has a registered secret. You can only register one secret per account. Your secret is {}.workers.dev", secret)
-        };
-        failure::bail!(msg)
-    } else {
-        register_subdomain(&name, &user, &target)
-    }
+    put_secret(&name, &user, &target);
+    bind_secret(&name, &user, &target)
+    
 }
 

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -1,92 +1,138 @@
 // use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
-use crate::terminal::{emoji, message};
-use serde::{ Serialize};
+use crate::terminal::emoji;
+use crate::terminal::message;
+// use cloudflare::endpoints::workers::create_secret::CreateSecret;
+use crate::commands::kv;
+use crate::http;
+use cloudflare::endpoints::workers::create_secret::CreateSecret;
+use cloudflare::endpoints::workers::create_secret::CreateSecretParams;
+use cloudflare::endpoints::workers::delete_secret::DeleteSecret;
+use cloudflare::endpoints::workers::WorkersSecret;
+use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::{ApiFailure, ApiSuccess};
+use cloudflare::framework::{HttpApiClient, HttpApiClientConfig};
+
 // For interactively handling  reading in a string
-pub fn interactive_get_string(prompt_string: &str) -> Result<bool, failure::Error> {
-    println!("{}",prompt_string);
-    let mut response: String = read!("{}\n");
-    println!("{}",response);
-    match response.as_str() {
-        "" => Ok(false),
-        _ =>  Ok(true),
-    }
+pub fn interactive_get_string(prompt_string: &str) -> String {
+    println!("{}", prompt_string);
+    let foo: String = read!("{}\n");
+    // println!("{}", answer);
+    // read!("{}\n").as_str()
+    foo
 }
 
-#[derive(Serialize)]
-pub struct Secret {
-    secret: String,
+fn format_error(e: ApiFailure) -> String {
+    print!("Will remove, API Failure details {}", e);
+    // e.code
+    http::format_error(e, Some(&secret_errors))
 }
-#[derive(Serialize)]
-pub struct Script {
-    secret: String,
-}
-
-impl Secret {
-
-    pub fn put(name: &str, user: &GlobalUser) -> Result<(), failure::Error> {
-        message::success(&format!("Success! You've uploaded secret {}.", name));
-        Ok(())
-    }
-}
-impl Script {
-    pub fn put(name: &str, target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
-        message::success(&format!("Success! You've bound the secret {} to {}.", name, target.name));
-        Ok(())
-    }
-}
-
-
-
-fn bind_secret(
-    name: &str,
-    user: &GlobalUser,
-    target: &Target,
-) -> Result<(), failure::Error> {
-    let msg = format!(
-        "Binding secret to script {}",
-        target.name
-    );
-    message::working(&msg);
-    Script::put(name, &target,  user)
-}
-fn put_secret(
-    
-    name: &str,
-    user: &GlobalUser,
-    target: &Target,
-) -> Result<(), failure::Error> {
-    let msg = format!(
-        "Creating the secret for account {}",
-        target.account_id
-    );
-    
-    message::working(&msg);
-    Secret::put(name,  user)
-}
-
-pub fn set_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
-  match interactive_get_string(&format!(
-    "Enter the secret text you'd like assigned to {}?",
-    name
-    )) {
-        Ok(true) => (),
-        Ok(false) => {
-            message::info(&format!("Enter a valid string "));
-            return Ok(());
+// secret_errors() provides more detailed explanations of Workers KV API error codes.
+// See https://api.cloudflare.com/#workers-secrets ? for details.
+fn secret_errors(error_code: u16) -> &'static str {
+    // TODO replace these with real error messages
+    match error_code {
+        7003 | 7000 => {
+            "Your wrangler.toml is likely missing the field \"account_id\", which is required to write to Workers KV."
         }
-        Err(e) => failure::bail!(e),
+        // namespace errors
+        10010 | 10011 | 10012 | 10013 | 10014 | 10018 => {
+            "Run `wrangler kv:namespace list` to see your existing namespaces with IDs"
+        }
+        10009 => "Run `wrangler kv:key list` to see your existing keys", // key errors
+        // TODO: link to more info
+        // limit errors
+        10022 | 10024 | 10030 => "See documentation",
+        // TODO: link to tool for this?
+        // legacy namespace errors
+        10021 | 10035 | 10038 => "Consider moving this namespace",
+        // cloudflare account errors
+        10017 | 10026 => "Workers KV is a paid feature, please upgrade your account (https://www.cloudflare.com/products/workers-kv/)",
+        10001 => "The content you passed in is not an excepted string. Try entering just a string",
+        _ => "Unknown code",
     }
+}
+fn api_put_secret(
+    user: &GlobalUser,
+    target: &Target,
+    name: &str,
+    secret_value: String,
+) -> Result<(), failure::Error> {
+    let msg = format!("Creating the secret for script name {}", target.name);
+    // let response = call_api(target, name, secret_value);
+    let client = http::cf_v4_api_client(user, HttpApiClientConfig::default())?;
 
+    let response = client.request(&CreateSecret {
+        account_identifier: &target.account_id,
+        script_name: &target.name,
+        params: CreateSecretParams {
+            name: name.to_string(),
+            value: secret_value.to_string(),
+        },
+    });
+
+    match response {
+        // TODO: 201 if new secret, 200 if updated and report to user
+        Ok(_) => message::success(&format!("Success! You've uploaded secret {}.", name)),
+        Err(e) => failure::bail!(format!("Formatted error{}", format_error(e))),
+        (_) => print!("some unknown format"),
+    }
+    message::working(&msg);
+    Ok(())
+    // message::success(&format!("Success! You've uploaded secret {}.", name));
+}
+fn api_delete_secret(user: &GlobalUser, target: &Target, name: &str) -> Result<(), failure::Error> {
+    let msg = format!("Deleting the secret {} on script {}.", name, target.name);
+    // let response = call_api(target, name, secret_value);
+    let client = http::cf_v4_api_client(user, HttpApiClientConfig::default())?;
+
+    let response = client.request(&DeleteSecret {
+        account_identifier: &target.account_id,
+        script_name: &target.name,
+        secret_name: name,
+    });
+
+    match response {
+        // TODO: 201 if new secret, 200 if updated and report to user
+        Ok(_) => message::success(&format!("You've deleted the secret {}.", name)),
+        Err(e) => failure::bail!(format!("Formatted error{}", format_error(e))),
+        (_) => print!("some unknown format"),
+    }
+    message::working(&msg);
+    Ok(())
+    // message::success(&format!("Success! You've uploaded secret {}.", name));
+}
+
+pub fn create_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+    let secret_value = interactive_get_string(&format!(
+        "Enter the secret text you'd like assigned to the variable {} on the script named {}",
+        name, target.name
+    ));
+    if secret_value.is_empty() {
+        failure::bail!(format!("Enter a non empty string."))
+    }
     if target.account_id.is_empty() {
         failure::bail!(format!(
             "{} You must provide an account_id in your wrangler.toml before creating a secret!",
             emoji::WARN
         ))
     }
-    put_secret(&name, &user, &target);
-    bind_secret(&name, &user, &target)
-    
+    api_put_secret(&user, &target, name, secret_value)
 }
-
+pub fn delete_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+    let secret_value = interactive_get_string(&format!(
+        "Enter the secret text you'd like assigned to the variable {} on the script named {}",
+        name, target.name
+    ));
+    if secret_value.is_empty() {
+        failure::bail!(format!("Enter a non empty string."))
+    }
+    if target.account_id.is_empty() {
+        failure::bail!(format!(
+            "{} You must provide an account_id in your wrangler.toml before creating a secret!",
+            emoji::WARN
+        ))
+    }
+    api_put_secret(&user, &target, name, secret_value)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,13 +249,13 @@ fn run() -> Result<(), failure::Error> {
                 ))
                 .subcommand(
                     SubCommand::with_name("create")
-                        .about("Create secret")
+                        .about("Create a secret variable to be avalible in script")
                         .arg(secret_name_arg.clone())
                         .arg(environment_arg.clone())
                 )
                 .subcommand(
                     SubCommand::with_name("delete")
-                        .about("Delete secret")
+                        .about("Delete a secret variable from a script")
                         .arg(secret_name_arg.clone())
                         .arg(environment_arg.clone())
                 )
@@ -456,9 +456,6 @@ fn run() -> Result<(), failure::Error> {
             api_token.truncate(api_token.trim_end().len());
             GlobalUser::TokenAuth { api_token }
         } else {
-            // Look here for interactive command for secrets
-            // Rust cloudflare-rs
-            // Endpoint<response return type,params, payload of request>
             message::big_info("We don't recommend using your Global API Key! Please consider using an\n\tAPI Token instead.\n\thttps://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys\n");
             println!("Enter email: ");
             let mut email: String = read!("{}\n");
@@ -591,7 +588,6 @@ fn run() -> Result<(), failure::Error> {
     } else if let Some(secrets_matches) = matches.subcommand_matches("secret") {
         log::info!("Getting project settings");
         let manifest = settings::toml::Manifest::new(config_path)?;
-        // println!("{}", matches.value_of("name").unwrap());
         log::info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;
 
@@ -602,8 +598,6 @@ fn run() -> Result<(), failure::Error> {
                 let target = manifest.get_target(env)?;
                 if let Some(name) = name {
                     commands::secret::create_secret(&name, &user, &target)?;
-                } else {
-                    // TODO throw error
                 }
             }
             ("delete", Some(_delete_matches)) => {
@@ -612,12 +606,9 @@ fn run() -> Result<(), failure::Error> {
                 let target = manifest.get_target(env)?;
                 if let Some(name) = name {
                     commands::secret::delete_secret(&name, &user, &target)?;
-                } else {
-                    // TODO throw error
                 }
             }
             ("list", Some(_list_matches)) => {
-                // let name = _list_matches.value_of("name"); //.unwrap_or("worker");
                 let env = _list_matches.value_of("env");
                 let target = manifest.get_target(env)?;
                 commands::secret::list_secrets(&user, &target)?;
@@ -625,8 +616,6 @@ fn run() -> Result<(), failure::Error> {
             ("", None) => message::warn("secrets expects a subcommand of the action"),
             _ => unreachable!(),
         }
-    // TODO run another command
-    // commands::subdomain::get_subdomain(&user, &target)?;
     } else if let Some(kv_matches) = matches.subcommand_matches("kv:namespace") {
         let manifest = settings::toml::Manifest::new(config_path)?;
         let user = settings::global_user::GlobalUser::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,24 +249,19 @@ fn run() -> Result<(), failure::Error> {
                 ))
                 .subcommand(
                     SubCommand::with_name("create")
-                        .about("Create namespace")
+                        .about("Create secret")
                         .arg(secret_name_arg.clone())
-                        // .arg(
-                        //     Arg::with_name("name")
-                        //     .help("the JSON file of key-value pairs to upload, in form [\"<example-key>\", ...]")
-                        //     .required(true)
-                        //     .takes_value(true)
-                        //     .index(1)
-                        // )
                         .arg(environment_arg.clone())
-                        // .group(secret_group.clone())
                 )
                 .subcommand(
                     SubCommand::with_name("delete")
-                        .about("Delete namespace")
+                        .about("Delete secret")
                         .arg(secret_name_arg.clone())
-
-                        // .group(secret_group.clone())
+                        .arg(environment_arg.clone())
+                )
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List all secrets for a script")
                         .arg(environment_arg.clone())
                 )
         )
@@ -620,6 +615,12 @@ fn run() -> Result<(), failure::Error> {
                 } else {
                     // TODO throw error
                 }
+            }
+            ("list", Some(_list_matches)) => {
+                // let name = _list_matches.value_of("name"); //.unwrap_or("worker");
+                let env = _list_matches.value_of("env");
+                let target = manifest.get_target(env)?;
+                commands::secret::list_secrets(&user, &target)?;
             }
             ("", None) => message::warn("secrets expects a subcommand of the action"),
             _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,25 @@ fn run() -> Result<(), failure::Error> {
                 )
         )
         .subcommand(
+            SubCommand::with_name("secret")
+                .about(&*format!(
+                    "{} Generate a secret that can be referenced in the worker script",
+                    emoji::DANCERS
+                ))
+                .arg(
+                    Arg::with_name("name")
+                        .help("the name of your secret!")
+                        .index(1),
+                )
+                .arg(
+                    Arg::with_name("env")
+                        .help("environment to build")
+                        .short("e")
+                        .long("env")
+                        .takes_value(true)
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("generate")
                 .about(&*format!(
                     "{} Generate a new worker project",
@@ -551,6 +570,24 @@ fn run() -> Result<(), failure::Error> {
             commands::subdomain::set_subdomain(&name, &user, &target)?;
         } else {
             commands::subdomain::get_subdomain(&user, &target)?;
+        }
+    } else if let Some(matches) = matches.subcommand_matches("secret") {
+        log::info!("Getting project settings");
+        let manifest = settings::toml::Manifest::new(config_path)?;
+        let name = matches.value_of("name");
+        let env = matches.value_of("env");
+        let target = manifest.get_target(env)?;
+
+        log::info!("Getting User settings");
+        let user = settings::global_user::GlobalUser::new()?;
+
+        let name = matches.value_of("name");
+
+        if let Some(name) = name {
+            commands::secret::set_secret(&name, &user, &target)?;
+        } else {
+            // TODO run another command
+            // commands::subdomain::get_subdomain(&user, &target)?;
         }
     } else if let Some(kv_matches) = matches.subcommand_matches("kv:namespace") {
         let manifest = settings::toml::Manifest::new(config_path)?;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,2 +1,3 @@
 pub mod emoji;
 pub mod message;
+pub mod utils;

--- a/src/terminal/utils.rs
+++ b/src/terminal/utils.rs
@@ -1,0 +1,26 @@
+// For interactively handling  reading in a string
+pub fn interactive_get_string(prompt_string: &str) -> String {
+    println!("{}", prompt_string);
+    let input: String = read!("{}\n");
+    input
+}
+
+// Truncate all "yes", "no" responses for interactive delete prompt to just "y" or "n".
+const INTERACTIVE_RESPONSE_LEN: usize = 1;
+const YES: &str = "y";
+const NO: &str = "n";
+// For interactively handling deletes (and discouraging accidental deletes).
+// Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
+// and lowercasing logic below.
+pub fn interactive_delete(prompt_string: &str) -> Result<bool, failure::Error> {
+    println!("{} [y/n]", prompt_string);
+    let mut response: String = read!("{}\n");
+    response = response.split_whitespace().collect(); // remove whitespace
+    response.make_ascii_lowercase(); // ensure response is all lowercase
+    response.truncate(INTERACTIVE_RESPONSE_LEN); // at this point, all valid input will be "y" or "n"
+    match response.as_ref() {
+        YES => Ok(true),
+        NO => Ok(false),
+        _ => failure::bail!("Response must either be \"y\" for yes or \"n\" for no"),
+    }
+}


### PR DESCRIPTION
Secrets create, list and delete commands all added.
Note includes:
* Alew's fix for cloudflare-rs http update https://github.com/cloudflare/wrangler/pull/994/commits/90dbe12ce34c33abe6e9bbbc55c36ff8af226382
* Moved KV::interactive_delete to utils to be used across commands

TODOs:

- [ ] Verify error codes and messages (e.g. message for `10007`)
- [ ] [Nice to have] Check 200 v. 201 and give appropriate messaging for create
- [x] Remove debug print outs from format_error