### PR TITLE
Add link to latest release to long version.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ fn run() -> Result<(), failure::Error> {
 
     let matches = App::new(format!("{}{} wrangler", emoji::WORKER, emoji::SPARKLES))
         .version(env!("CARGO_PKG_VERSION"))
+        .long_version(&*format!("{}\nFind the latest release here: https://github.com/cloudflare/wrangler/releases/latest", env!("CARGO_PKG_VERSION")))
         .author("The Wrangler Team <wrangler@cloudflare.com>")
         .setting(AppSettings::ArgRequiredElseHelp)
         .setting(AppSettings::DeriveDisplayOrder)


### PR DESCRIPTION
Hello I added a simple link to the latest GitHub release to the long version string. Please let me know if you would prefer a different message.

This is for issue #1023.