### PR TITLE
Fixes a typo in the ip argument description text for dev

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -432,7 +432,7 @@ fn run() -> Result<(), failure::Error> {
                 )
                 .arg(
                     Arg::with_name("ip")
-                        .help("ip to listsen on. defaults to localhost")
+                        .help("ip to listen on. defaults to localhost")
                         .short("i")
                         .long("ip")
                         .takes_value(true)


### PR DESCRIPTION
Fixes a typo in the ip argument description text for dev.

Before:
`ip to listsen on. defaults to localhost` 

After:
`ip to listen on. defaults to localhost`