### PR TITLE
[dev] fix: properly route to new preview id after reload

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -97,13 +97,13 @@ async fn serve(
     // create a closure that hyper will use later to handle HTTP requests
     let make_service = make_service_fn(move |_| {
         let client = client.to_owned();
-        let preview_id = preview_id.lock().unwrap().to_owned();
         let server_config = server_config.to_owned();
+        let preview_id = preview_id.to_owned();
         async move {
             Ok::<_, failure::Error>(service_fn(move |req| {
                 let client = client.to_owned();
-                let preview_id = preview_id.to_owned();
                 let server_config = server_config.to_owned();
+                let preview_id = preview_id.lock().unwrap().to_owned();
                 let version = req.version();
                 let (parts, body) = req.into_parts();
                 let req_method = parts.method.to_string();


### PR DESCRIPTION
Fixes #1082 and might fix #1107

We keep `preview_id` in an `Arc<Mutex` so that when a reload is detected on another thread, the dev server can properly route new requests to the new preview_id. Previously, the server would only attempt to acquire the lock every couple of minutes. After moving the lock acquisition to `service_fn` from `make_service_fn`, the lock is acquired on every request, making sure that each request is going to the right version of the script.