### PR TITLE
reinstate kv buckets

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -133,10 +133,12 @@ mod tests {
                 KvNamespace {
                     id: "fake".to_string(),
                     binding: "KV".to_string(),
+                    bucket: None,
                 },
                 KvNamespace {
                     id: "fake".to_string(),
                     binding: "KV".to_string(),
+                    bucket: None,
                 },
             ]),
             name: "test-target".to_string(),

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -61,7 +61,7 @@ pub fn publish(
 
         let feature = if uses_kv_bucket {
             let wrangler_toml = style("`wrangler.toml`").yellow().bold();
-            let issue_link = style("https://github.com/cloudflare/wrangler/issues/new?labels=user+report&template=feature_request.md").blue().bold();
+            let issue_link = style("https://github.com/cloudflare/wrangler/issues/1136").blue().bold();
             let msg = format!("As of 1.9.0, you will no longer be able to specify a bucket for a kv namespace in your {}.\nIf your application depends on this feature, please file an issue with your use case here:\n{}", wrangler_toml, issue_link);
             message::deprecation_warning(&msg);
 

--- a/src/commands/secret/mod.rs
+++ b/src/commands/secret/mod.rs
@@ -59,7 +59,8 @@ pub fn upload_draft_worker(
             for error in &api_errors.errors {
                 if error.code == 10007 {
                     message::working(&format!("Worker {} doesn't exist in the API yet. Creating a draft Worker so we can create new secret.", target.name));
-                    return Some(upload::script(user, target, None));
+                    let upload_client = http::auth_client(None, user);
+                    return Some(upload::script(&upload_client, target, None));
                 } else {
                     return None;
                 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,8 @@
+use std::time::Duration;
+
 use reqwest::blocking::{Client, ClientBuilder};
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use reqwest::redirect::Policy;
-use std::time::Duration;
 
 use crate::install;
 use crate::settings::global_user::GlobalUser;

--- a/src/settings/toml/kv_namespace.rs
+++ b/src/settings/toml/kv_namespace.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -8,6 +9,7 @@ use crate::settings::binding::Binding;
 pub struct KvNamespace {
     pub id: String,
     pub binding: String,
+    pub bucket: Option<PathBuf>,
 }
 
 impl fmt::Display for KvNamespace {

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -48,10 +48,12 @@ fn it_builds_from_environments_config_with_kv() {
     let kv_1 = KvNamespace {
         id: "somecrazylongidentifierstring".to_string(),
         binding: "prodKV-1".to_string(),
+        bucket: None,
     };
     let kv_2 = KvNamespace {
         id: "anotherwaytoolongidstring".to_string(),
         binding: "prodKV-2".to_string(),
+        bucket: None,
     };
 
     match target.kv_namespaces {
@@ -67,10 +69,12 @@ fn it_builds_from_environments_config_with_kv() {
     let kv_1 = KvNamespace {
         id: "somecrazylongidentifierstring".to_string(),
         binding: "stagingKV-1".to_string(),
+        bucket: None,
     };
     let kv_2 = KvNamespace {
         id: "anotherwaytoolongidstring".to_string(),
         binding: "stagingKV-2".to_string(),
+        bucket: None,
     };
     match target.kv_namespaces {
         Some(kv_namespaces) => {

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -49,3 +49,8 @@ pub fn help(msg: &str) {
     let msg = format!("{} {}", emoji::SLEUTH, msg);
     message(&msg);
 }
+
+pub fn deprecation_warning(msg: &str) {
+    let msg = format!("\n\t{} {}", emoji::WARN, msg);
+    message(&msg);
+}

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -51,6 +51,10 @@ pub fn help(msg: &str) {
 }
 
 pub fn deprecation_warning(msg: &str) {
-    let msg = format!("\n\t{} {}", emoji::WARN, msg);
-    message(&msg);
+    let bb =  boxx::builder()
+        .border_style(BorderStyle::Round)
+        .border_color(BorderColor::Red)
+        .margin(1)
+        .build();
+    bb.display(msg);
 }

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -4,13 +4,13 @@ pub mod package;
 
 pub use package::Package;
 
+use reqwest::blocking::Client;
+
 use crate::commands::kv::bucket::AssetManifest;
-use crate::http;
-use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
 pub fn script(
-    user: &GlobalUser,
+    client: &Client,
     target: &Target,
     asset_manifest: Option<AssetManifest>,
 ) -> Result<(), failure::Error> {
@@ -18,12 +18,6 @@ pub fn script(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}",
         target.account_id, target.name,
     );
-
-    let client = if target.site.is_some() {
-        http::auth_client(Some("site"), user)
-    } else {
-        http::auth_client(None, user)
-    };
 
     let script_upload_form = form::build(target, asset_manifest)?;
 


### PR DESCRIPTION
# Overview
in #1115 i removed this feature to clean up the logic around site deploys, however regression  testing revealed that there's a slight possibility that some users might be using this functionality in production and we don't want to introduce that kind of breaking change. This PR re-instates the feature, and smooths it out a little, but also introduces a deprecation warning, as this feature is not well thought out and was not intended to be released in the first place. we  will monitor for responses  to the warning to decide next steps.

# Also happened
to get the "feature" header in to see who uses this crazy side effect, i refactored `upload::script` to take a client as an argument. i actually think this will be beneficial for future unit testing efforts.

# Still TODO
- [x] add a deprecation warning when  the edge case is hit
- [x] add a "feature" header for instances of kv namespace uploads / publishes in service of this edge case.
- [x] use `message::billboard` for deprecation warning
- [x] create and link issue for deprecation feedback