### PR TITLE
Asset Manifest QOL improvements

### DIFF
--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -213,7 +213,7 @@ fn get_digest(value: String) -> Result<String, failure::Error> {
     let mut hasher = Sha256::new();
     hasher.input(value);
     let digest = hasher.result();
-    let hex_digest = HEXLOWER.encode(digest.as_ref());
+    let hex_digest = HEXLOWER.encode(digest.as_ref())[0..9].to_string();
     Ok(hex_digest)
 }
 

--- a/src/commands/kv/bucket/mod.rs
+++ b/src/commands/kv/bucket/mod.rs
@@ -36,7 +36,7 @@ pub fn directory_keys_values(
     match &fs::metadata(directory) {
         Ok(file_type) if file_type.is_dir() => {
             let mut upload_vec: Vec<KeyValuePair> = Vec::new();
-            let mut asset_manifest: AssetManifest = AssetManifest::new();
+            let mut asset_manifest = AssetManifest::new();
 
             let dir_walker = get_dir_iterator(target, directory)?;
 
@@ -80,31 +80,6 @@ pub fn directory_keys_values(
         }
         Err(e) => Err(format_err!("{}", e)),
     }
-}
-
-// Returns only the hashed keys for a directory's files.
-fn directory_keys_only(target: &Target, directory: &Path) -> Result<Vec<String>, failure::Error> {
-    let mut key_vec: Vec<String> = Vec::new();
-
-    let dir_walker = get_dir_iterator(target, directory)?;
-
-    for entry in dir_walker {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.is_file() {
-            let value = std::fs::read(path)?;
-
-            // Need to base64 encode value
-            let b64_value = base64::encode(&value);
-
-            let (_, key) = generate_path_and_key(path, directory, Some(b64_value))?;
-
-            validate_key_size(&key)?;
-
-            key_vec.push(key);
-        }
-    }
-    Ok(key_vec)
 }
 
 // Ensure that all files in upload directory do not exceed the MAX_VALUE_SIZE (this ensures that

--- a/src/commands/kv/bucket/sync.rs
+++ b/src/commands/kv/bucket/sync.rs
@@ -17,7 +17,6 @@ pub fn sync(
     user: &GlobalUser,
     namespace_id: &str,
     path: &Path,
-    verbose: bool,
 ) -> Result<(Vec<KeyValuePair>, Vec<String>, AssetManifest), failure::Error> {
     kv::validate_target(target)?;
     // First, find all changed files in given local directory (aka files that are now stale
@@ -39,7 +38,7 @@ pub fn sync(
     }
 
     let (pairs, asset_manifest): (Vec<KeyValuePair>, AssetManifest) =
-        directory_keys_values(target, path, verbose)?;
+        directory_keys_values(target, path)?;
 
     let to_upload = filter_files(pairs.clone(), &remote_keys);
 

--- a/src/commands/preview/upload.rs
+++ b/src/commands/preview/upload.rs
@@ -65,7 +65,7 @@ pub fn upload(
 
                     let path = Path::new(&site_config.bucket);
                     let (to_upload, to_delete, asset_manifest) =
-                        sync(target, user, &site_namespace.id, path, verbose)?;
+                        sync(target, user, &site_namespace.id, path)?;
 
                     // First, upload all existing files in given directory
                     if verbose {

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -32,8 +32,7 @@ pub fn publish(
 
         let site_namespace = add_site_namespace(user, target, false)?;
 
-        let (to_upload, to_delete, asset_manifest) =
-            sync(target, user, &site_namespace.id, &path, verbose)?;
+        let (to_upload, to_delete, asset_manifest) = sync(target, user, &site_namespace.id, &path)?;
 
         // First, upload all existing files in bucket directory
         if verbose {
@@ -179,8 +178,7 @@ pub fn sync_non_site_buckets(
         if let Some(path) = &namespace.bucket {
             is_using_non_site_bucket = true;
             validate_bucket_location(path)?;
-            let (to_upload, to_delete, _) =
-                kv::bucket::sync(target, user, &namespace.id, path, verbose)?;
+            let (to_upload, to_delete, _) = kv::bucket::sync(target, user, &namespace.id, path)?;
             // First, upload all existing files in bucket directory
             if verbose {
                 message::info("Preparing to upload updated files...");


### PR DESCRIPTION
- Shrink size of asset manifest by reducing hash length from 64 to 10
- Removes `--verbose` flag in favor of a spinner that tells you what file it's adding to the asset manifest
- Doesn't compute the asset manifest hashes twice (it used to)

![spinner_gif](https://user-images.githubusercontent.com/9408157/76907177-8f202e00-6873-11ea-87c2-699257de784b.gif)

for once my commits are actually (fairly) logically grouped if you want to review one commit at a time