### PR TITLE
[wip] test dev get requests

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod fixture;
 
 use std::fs;

--- a/tests/dev.rs
+++ b/tests/dev.rs
@@ -1,0 +1,71 @@
+pub mod fixture;
+
+use fixture::{Fixture, WranglerToml};
+
+use std::net::TcpListener;
+use std::process::{Command, Output};
+
+use assert_cmd::prelude::*;
+
+#[test]
+fn it_can_handle_get_requests() {
+    let fixture = Fixture::new();
+    let expected_body = "Page Not Found!".to_string();
+    let expected_status = 404;
+    fixture.create_file(
+        "index.js",
+        &format!(
+            r#"
+        addEventListener('fetch', event => {{
+            event.respondWith(handleRequest(event.request))
+        }})
+        
+        async function handleRequest(request) {{
+            return new Response('{}', {{ status: {} }})
+        }}
+    "#,
+            &expected_body, expected_status
+        ),
+    );
+
+    fixture.create_default_package_json();
+
+    let wrangler_toml = WranglerToml::javascript("test-dev-get-requests");
+    fixture.create_wrangler_toml(wrangler_toml);
+    let (host, output) = wrangler_dev(&fixture, Vec::new());
+    let response = reqwest::blocking::get(&host).expect("could not get response");
+    assert_eq!(response.status(), expected_status);
+    let body = response.text().expect("could not get response body");
+    println!("\n\n---\nBODY\n\n{}\n\n---\n", body);
+    assert_eq!(body, expected_body);
+    let output = String::from_utf8_lossy(&output.stdout);
+    println!("\n\n---\nOUTPUT\n\n{}\n\n---\n", output);
+    assert!(output.contains(&expected_status.to_string()));
+}
+
+fn wrangler_dev(fixture: &Fixture, args: Vec<String>) -> (String, Output) {
+    let _lock = fixture.lock();
+    let mut dev = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    dev.current_dir(fixture.get_path());
+    dev.arg("dev");
+    for arg in args {
+        dev.arg(&arg);
+    }
+    let port = find_available_port();
+    dev.arg("--port").arg(port.to_string());
+    let output = dev
+        .output()
+        .unwrap_or_else(|_| panic!("could not start command {:?}", dev));
+    let host = format!("http://localhost:{}", port);
+    (host, output)
+}
+
+fn find_available_port() -> u16 {
+    for port in 1025..65535 {
+        if let Ok(_) = TcpListener::bind(("127.0.0.1", port)) {
+            return port;
+        }
+    }
+
+    panic!("Could not find a usable port");
+}

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 mod wrangler_toml;
 pub use wrangler_toml::{EnvConfig, KvConfig, SiteConfig, WranglerToml, TEST_ENV_NAME};
 

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod fixture;
 
 use fixture::WranglerToml;


### PR DESCRIPTION
will fix #969 

- [x] test response body from request
- [x] test response status from request
- [ ] test response status in output logs
- [ ] test console.logs in output logs

running into an issue with testing what's in stdout, not quite sure what to do here i got very lost in the weeds of std docs. added some printlns to see what's happening, and it seems like the outptut i want is sent straight to normal stdout whereas the output i want to test against is not complete (looks like it only captures a little bit at the very beginning before we send the request from the main thread)

```console
$ cargo test -- --nocapture

running 1 test
[2020-03-19 16:00:29] GET example.com/ HTTP/1.1 404 Not Found
test it_can_handle_get_requests ... FAILED

failures:

---- it_can_handle_get_requests stdout ----
Created fixture at /var/folders/xw/4ttxd3d12t79cv0cb78gwhzc0000gn/T/.tmpUMNOzB


---
BODY

Page Not Found!

---



---
OUTPUT

`wrangler dev` is currently unstable and there are likely to be breaking changes!
For this reason, we cannot yet recommend using `wrangler dev` for integration testing.

Please submit any feedback here: https://github.com/cloudflare/wrangler/issues/1047
💁  JavaScript project found. Skipping unnecessary build!
💁  watching "./"


---

thread 'it_can_handle_get_requests' panicked at 'assertion failed: output.contains(&expected_status.to_string())', tests/dev.rs:44:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    it_can_handle_get_requests
```

i might need to use `spawn`? or `Stdio::piped`? or something like that? I'm really not sure