### PR TITLE
Alewis/handle sigint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sha2 = "0.8.0"
 tempfile = "3.1.0"
 term_size = "0.3"
 text_io = "0.1.7"
-tokio = { version = "0.2", default-features = false, features = ["io-std", "time", "macros", "process"] }
+tokio = { version = "0.2", default-features = false, features = ["io-std", "time", "macros", "process", "signal", "sync"] }
 tokio-tungstenite = { version = "0.10.1", features = ["tls"] }
 toml = "0.5.5"
 url = "2.1.0"

--- a/src/tail/host.rs
+++ b/src/tail/host.rs
@@ -1,18 +1,26 @@
+use hyper::server::conn::AddrIncoming;
+use hyper::server::Builder;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
-pub struct Host;
+pub struct Host {
+    server: Builder<AddrIncoming>,
+}
 
 impl Host {
-    pub async fn run() -> Result<(), failure::Error> {
+    pub fn new() -> Result<Host, failure::Error> {
         // Start HTTP echo server that prints whatever is posted to it.
         let addr = ([127, 0, 0, 1], 8080).into();
 
+        let server = Server::bind(&addr);
+
+        Ok(Host { server })
+    }
+
+    pub async fn run(self) -> Result<(), failure::Error> {
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(print_logs)) });
 
-        let server = Server::bind(&addr).serve(service);
-
-        server.await?;
+        self.server.serve(service).await?;
 
         Ok(())
     }

--- a/src/tail/log_server.rs
+++ b/src/tail/log_server.rs
@@ -4,19 +4,21 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use tokio::sync::oneshot::Receiver;
 
-pub struct Host {
+pub struct LogServer {
     server: Builder<AddrIncoming>,
     rx: Receiver<()>,
 }
 
-impl Host {
-    pub fn new(rx: Receiver<()>) -> Host {
+/// LogServer is just a basic HTTP server running locally; it listens for POST requests on the root
+/// path and simply prints the JSON body of each request as its own line to STDOUT.
+impl LogServer {
+    pub fn new(rx: Receiver<()>) -> LogServer {
         // Start HTTP echo server that prints whatever is posted to it.
         let addr = ([127, 0, 0, 1], 8080).into();
 
         let server = Server::bind(&addr);
 
-        Host { server, rx }
+        LogServer { server, rx }
     }
 
     pub async fn run(self) -> Result<(), failure::Error> {
@@ -24,10 +26,12 @@ impl Host {
 
         let server = self.server.serve(service);
 
-        let rx = self.rx;
+        // The shutdown receiver listens for a one shot message from our sigint handler as a signal
+        // to gracefully shut down the hyper server.
+        let shutdown_rx = self.rx;
 
         let graceful = server.with_graceful_shutdown(async {
-            rx.await.ok();
+            shutdown_rx.await.ok();
         });
 
         graceful.await?;
@@ -40,6 +44,8 @@ async fn print_logs(req: Request<Body>) -> Result<Response<Body>, hyper::Error> 
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => {
             let whole_body = hyper::body::to_bytes(req.into_body()).await?;
+            // TODO: at some point I would like to send this body as a message to a central writer
+            // rather than just using println!, but this works just fine for now.
             println!(
                 "{}",
                 std::str::from_utf8(&whole_body).expect("failed to deserialize tail log body")

--- a/src/tail/log_server.rs
+++ b/src/tail/log_server.rs
@@ -18,7 +18,10 @@ impl LogServer {
 
         let server = Server::bind(&addr);
 
-        LogServer { server, shutdown_rx }
+        LogServer {
+            server,
+            shutdown_rx,
+        }
     }
 
     pub async fn run(self) -> Result<(), failure::Error> {

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -19,9 +19,10 @@ impl Tail {
         let mut runtime = TokioRuntime::new()?;
 
         runtime.block_on(async {
+            let log_host = Host::new()?;
             let tunnel_process = Tunnel::new()?;
             let res = tokio::try_join!(
-                Host::run(),
+                log_host.run(),
                 tunnel_process.run(),
                 Session::run(&target, &user)
             );

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -1,7 +1,8 @@
 /// The Tail feature for Wrangler is the Workers ecosystem answer to the need for live
 /// log collection in production. When a user runs `wrangler tail`, several things happen:
 ///     1. A simple HTTP server (LogServer) is started and begins listening for requests on localhost:8080
-///     2. An [Argo Tunnel](TODO) instance (Tunnel) is started using [cloudflared](TODO), exposing the
+///     2. An [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) instance (Tunnel) is started
+///        using [cloudflared](https://developers.cloudflare.com/argo-tunnel/downloads/), exposing the
 ///        LogServer to the internet on a randomly generated URL.
 ///     3. Wrangler initiates a tail Session by making a request to the Workers API /tail endpoint,
 ///        providing the Tunnel URL as an argument.

--- a/src/tail/session.rs
+++ b/src/tail/session.rs
@@ -55,6 +55,12 @@ impl Session {
 
                 loop {
                     match shutdown_rx.try_recv() {
+                        // this variant of the [TryRecvError](https://docs.rs/tokio/0.2.16/tokio/sync/oneshot/error/enum.TryRecvError.html)
+                        // occurs when the receiver listens for a message and the channel is empty;
+                        // in this case, it means that we have not received a shutdown command and
+                        // can continue with our task. The other variant would indicate that the
+                        // sender has been dropped, in which case we want to follow shut down as if
+                        // we received the signal.
                         Err(TryRecvError::Empty) => {
                             if delay.is_elapsed() {
                                 let heartbeat_result =

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -12,6 +12,11 @@ pub struct Tunnel {
     child: Child,
 }
 
+/// Tunnel wraps a child process that runs cloudflared and forwards requests from the Trace Worker
+/// in the runtime to our local LogServer instance. We wrap it in a struct primarily to hold the
+/// state of the child process so that upon receipt of a SIGINT message we can more swiftly kill it
+/// and wait on its output; otherwise we end up leaving it behind when wrangler exits and this
+/// causes problems if it still exists the next time we start up a tail.
 impl Tunnel {
     pub fn new() -> Result<Tunnel, failure::Error> {
         let tool_name = PathBuf::from("cloudflared");

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::str;
-use std::thread;
-use std::time::Duration;
 
 use log::log_enabled;
 use log::Level::Info;
@@ -16,11 +14,6 @@ pub struct Tunnel {
 
 impl Tunnel {
     pub fn new() -> Result<Tunnel, failure::Error> {
-        // TODO: remove sleep!! Can maybe use channel to signal from http server thread to argo tunnel
-        // thread that the server is ready on port 8080 and prepared for the cloudflared CLI to open an
-        // Argo Tunnel to it.
-        thread::sleep(Duration::from_secs(5));
-
         let tool_name = PathBuf::from("cloudflared");
         // TODO: Finally get cloudflared release binaries distributed on GitHub so we could simply uncomment
         // the line below.

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -43,6 +43,9 @@ impl Tunnel {
         self.shutdown().await
     }
 
+    /// shutdown is relatively simple, it sends a second `kill` signal to the child process,
+    /// short-circuiting cloudflared's "graceful shutdown" period. this approach has been endorsed
+    /// by the team who maintains cloudflared as safe practice.
     pub async fn shutdown(mut self) -> Result<(), failure::Error> {
         let pid = self.child.id();
         if let Err(e) = self.child.kill() {

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -38,15 +38,15 @@ impl Tunnel {
         Ok(Tunnel { child })
     }
 
-    pub async fn run(self, rx: Receiver<()>) -> Result<(), failure::Error> {
-        rx.await?;
+    pub async fn run(self, shutdown_rx: Receiver<()>) -> Result<(), failure::Error> {
+        shutdown_rx.await?;
         self.shutdown().await
     }
 
     pub async fn shutdown(mut self) -> Result<(), failure::Error> {
-        // eprintln!("killing cloudflared");
+        let pid = self.child.id();
         if let Err(e) = self.child.kill() {
-            failure::bail!("failed to kill cloudflared: {}", e)
+            failure::bail!("failed to kill cloudflared: {}\ncloudflared will eventually exit, or you can explicitly kill it by running `kill {}`", e, pid)
         } else {
             self.child.wait_with_output().await?;
 

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -15,7 +15,7 @@ pub struct Tunnel {
 /// Tunnel wraps a child process that runs cloudflared and forwards requests from the Trace Worker
 /// in the runtime to our local LogServer instance. We wrap it in a struct primarily to hold the
 /// state of the child process so that upon receipt of a SIGINT message we can more swiftly kill it
-/// and wait on its output; otherwise we end up leaving it behind when wrangler exits and this
+/// and wait on its output; otherwise we leave an orphaned process when wrangler exits and this
 /// causes problems if it still exists the next time we start up a tail.
 impl Tunnel {
     pub fn new() -> Result<Tunnel, failure::Error> {


### PR DESCRIPTION
# Overview

Previously, if you `ctrl-c`'d out of `wrangler tail`, wrangler would leave an orphaned child process for `cloudflared` spinning on a "graceful shutdown". This PR introduces changes that catch `ctrl-c` and manually send a second `kill` signal to the child process, as well as gracefully stopping the localhost server and discontinuing heartbeat messages to the Workers API. There's also a little clean up task in here that starts the log server before joining all the async tasks, which removes the need to "sleep" in the Tunnel task before spinning up cloudflared.

## Still TODO based on usage testing:
- [x] handle ctrl-c before  `try_join`

I'll list the changes in this PR here by commit message:

## Changes

**add host new method to initialize server before tunnel**
previously the tunnel function would sleep for a short time to ensure that the http server had started up before it tried to spin up a tunnel pointing to it. in this pr, i move the port binding step to an initializer function on `Host` and call it before running it as a task, ensuring that the server already exists before Tunnel tries to do its thing.

**handle ctrl_c nicely using channels**
this is the meat of the PR, and a lot happens here.
* rather than passing all futures directly to `tokio::try_join` to run concurrently, we instead `spawn` each task and pass their JoinHandles in to `try_join`. This is based on the following instruction from the [tokio documentation](https://docs.rs/tokio/0.2.15/tokio/macro.try_join.html#runtime-characteristics):
> If parallelism is required, spawn each async expression using tokio::spawn and pass the join handle to `try_join!`.
* introduce a fourth task, `handle_sigint`, whose sole purpose is to listen for `ctrl-c` and send messages to each of the other tasks so that they might shut down properly.
* introduce three `oneshot` channels and pass the transmitters to `handle_sigint`, and their receivers to each task; each task handles this in its own special way:
  * `Host` uses the receiver in its callback to `with_graceful_shutdown`, which is a convenience method provided by hyper but I assume it is to complete in flight requests etc before exiting.
  * `Tunnel` uses the receiver to "double-tap" the kill call to the cloudflared process and wait on its output before exiting. If the double-tap turns out to be premature, we can always put a delay on it.
  * `Session` now uses a `Delay` rather than `thread::sleep` to space out heartbeat calls, and all of its execution code is wrapped in a call to `rx.try_recv`, which will cause the task to exit upon receipt of the signal from our sigint handler.