### PR TITLE
feat: accept ipv4/6 for default dev

### DIFF
--- a/src/commands/dev/server_config/listening_address.rs
+++ b/src/commands/dev/server_config/listening_address.rs
@@ -19,7 +19,7 @@ impl ListeningAddress {
     }
 
     fn as_str(&self) -> String {
-        self.address.to_string().replace("[::1]", "localhost")
+        self.address.to_string().replace("[::]", "localhost")
     }
 }
 

--- a/src/commands/dev/server_config/mod.rs
+++ b/src/commands/dev/server_config/mod.rs
@@ -17,7 +17,7 @@ impl ServerConfig {
         port: Option<&str>,
     ) -> Result<Self, failure::Error> {
         let port = port.unwrap_or("8787");
-        let ip = ip.unwrap_or("localhost");
+        let ip = ip.unwrap_or("[::]");
         let host = host.unwrap_or("https://example.com").to_string();
 
         let listening_address = ListeningAddress::new(ip, port)?;


### PR DESCRIPTION
Fixes #1198 

This is not a breaking change, just makes `wrangler dev` listen on both IPv4 and IPv6 

`curl http://localhost:8787` always worked
`curl --ipv4 http://localhost:8787` didn't work before and now does

_**juicy deets**_

From the [Wikipedia article on localhost](https://en.wikipedia.org/wiki/Localhost)
> The name localhost normally resolves to the IPv4 loopback address 127.0.0.1, and to the IPv6 loopback address ::1

Unfortunately for us, `localhost` was only resolving to the IPv6 loopback address `::1` and not the IPv4 address `127.0.0.1`. Switching the input from `localhost` to `[::]` makes our hyper server listen on both IPv4 and IPv6.