### PR TITLE
Alewis/handle api errors

### DIFF
--- a/src/tail/session.rs
+++ b/src/tail/session.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use regex::Regex;
 use reqwest;
 use tokio::sync::oneshot::error::TryRecvError;
-use tokio::sync::oneshot::Receiver;
+use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::time::{delay_for, Delay};
 
 use cloudflare::endpoints::workers::{CreateTail, CreateTailParams, SendTailHeartbeat};
@@ -28,6 +28,7 @@ impl Session {
         target: Target,
         user: GlobalUser,
         mut shutdown_rx: Receiver<()>,
+        tx: Sender<()>,
     ) -> Result<(), failure::Error> {
         let client = http::cf_v4_api_client_async(&user, HttpApiClientConfig::default())?;
 
@@ -77,7 +78,10 @@ impl Session {
                     }
                 }
             }
-            Err(e) => failure::bail!(http::format_error(e, None)),
+            Err(e) => {
+                tx.send(()).unwrap();
+                failure::bail!(http::format_error(e, None))
+            }
         }
     }
 }

--- a/src/tail/shutdown.rs
+++ b/src/tail/shutdown.rs
@@ -1,0 +1,38 @@
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+
+pub enum Signal {
+    Continue,
+    ShutDown,
+}
+
+#[derive(Default)]
+pub struct ShutdownHandler {
+    txs: Vec<Sender<()>>,
+}
+
+impl ShutdownHandler {
+    pub fn new() -> ShutdownHandler {
+        ShutdownHandler::default()
+    }
+
+    pub fn subscribe(&mut self) -> Receiver<()> {
+        let (tx, rx) = channel();
+        self.txs.push(tx);
+
+        rx
+    }
+
+/// handle_sigint waits on a ctrl_c from the system and sends messages to each registered
+/// transmitter when it is received.
+    pub async fn run(self) -> Result<(), failure::Error> {
+        tokio::signal::ctrl_c().await?;
+        for tx in self.txs {
+            // if `tx.send()` returns an error, it is because the receiver has gone out of scope,
+            // likely due to the task returning early for some reason, in which case we don't need
+            // to tell that task to shut down because it already has.
+            tx.send(()).ok();
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
there's a lot i want to clean up about this, like the way channels are kind of created and chucked all over the place in the main runtime procedure, but this at least gets us to where wrangler will exit on an API error. next we'll add nicer error messages.