### PR TITLE
Alewis/interrupt session start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,8 +341,9 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.6.4"
-source = "git+https://github.com/cloudflare/cloudflare-rs?branch=gabbi/workers-tailing-endpoints#260af00720f105a4e9395fdffce18c87619fbe63"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15d54f4764f67500dccaf08c08a94d31cdac1d52cfa994f5c3b3939847cf5ba"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ billboard = "0.1.0"
 chrome-devtools-rs = { version = "0.0.0-alpha.0", features = ["color"] }
 chrono = "0.4.9"
 clap = "2.32.0"
-cloudflare = { git = "https://github.com/cloudflare/cloudflare-rs", branch = "gabbi/workers-tailing-endpoints" }
+cloudflare = "0.6.5"
 config = "0.10.1"
 console = "0.9.1"
 data-encoding = "2.1.2"

--- a/src/tail/shutdown.rs
+++ b/src/tail/shutdown.rs
@@ -24,6 +24,7 @@ impl ShutdownHandler {
             _ = short_circuit => {}
         }
 
+        eprintln!("Closing tail session...");
         for tx in self.txs {
             // if `tx.send()` returns an error, it is because the receiver has gone out of scope,
             // likely due to the task returning early for some reason, in which case we don't need


### PR DESCRIPTION
during an incident i noticed that if the Session is hung up in trying to get the tunnel url, or in trying to make a call to the API, that it will not respond to a shut down command. This PR updates the Session to use `tokio::select` to listen for a result from either the shutdown receiver or the API tail start. it also adds a small line print when ctrl-c is received in the case that there is any lag before shutting down. Previously ctrl-c simply wouldn't work if the tunnel and session hadn't been established; now it works at all stages, but lags a bit once things have got going. Will address in later refactors.