### PR TITLE
Better port selection

### DIFF
--- a/src/commands/tail/mod.rs
+++ b/src/commands/tail/mod.rs
@@ -1,15 +1,53 @@
+use std::net::{SocketAddr, TcpListener};
+
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::tail::Tail;
 
-pub fn start(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
-    // Note that we use eprintln!() throughout this file; this is because we want any
+const DEFAULT_TUNNEL_PORT: u16 = 8080;
+const DEFAULT_METRICS_PORT: u16 = 8081;
+
+pub fn start(
+    target: &Target,
+    user: &GlobalUser,
+    tunnel_port: Option<u16>,
+    metrics_port: Option<u16>,
+) -> Result<(), failure::Error> {
+    let tunnel_port = find_open_port(tunnel_port, DEFAULT_TUNNEL_PORT)?;
+    let metrics_port = find_open_port(metrics_port, DEFAULT_METRICS_PORT)?;
+
+    // Note that we use eprintln!() throughout this module; this is because we want any
     // helpful output to not be mixed with actual log JSON output, so we use this macro
     // to print messages to stderr instead of stdout (where log output is printed).
     eprintln!(
-        "Setting up log streaming from Worker script \"{}\" to Wrangler. This may take a few seconds...",
-        target.name
+        "Setting up log streaming from Worker script \"{}\". Using ports {} and {}. This may take a few seconds...",
+        target.name,
+        tunnel_port,
+        metrics_port,
     );
 
-    Tail::run(target.clone(), user.clone())
+    Tail::run(target.clone(), user.clone(), tunnel_port, metrics_port)
+}
+
+/// Find open port takes two arguments: an Optional requested port, and a default port.
+fn find_open_port(requested: Option<u16>, default: u16) -> Result<u16, failure::Error> {
+    if let Some(port) = requested {
+        let addr = format!("127.0.0.1:{}", port);
+        match TcpListener::bind(addr) {
+            Ok(socket) => Ok(socket.local_addr()?.port()),
+            Err(_) => failure::bail!("the specified port {} is unavailable", port),
+        }
+    } else {
+        // try to use the default port; else get an ephemeral port from the OS
+        let addrs = [
+            SocketAddr::from(([127, 0, 0, 1], default)),
+            // Binding to port 0 effectively asks the OS to provide the next available
+            // ephemeral port: https://www.grc.com/port_0.htm
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+        ];
+
+        let socket = TcpListener::bind(&addrs[..])?;
+
+        Ok(socket.local_addr()?.port())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -524,6 +524,19 @@ fn run() -> Result<(), failure::Error> {
                         .long("env")
                         .takes_value(true)
                 )
+                .arg(
+                    Arg::with_name("tunnel_port")
+                        .help("port to accept tail log requests")
+                        .short("p")
+                        .long("port")
+                        .takes_value(true)
+                )
+                .arg(
+                    Arg::with_name("metrics_port")
+                        .help("provides endpoint for cloudflared metrics. used to retrieve tunnel url")
+                        .long("metrics")
+                        .takes_value(true)
+                )
         )
         .get_matches();
 
@@ -897,10 +910,16 @@ fn run() -> Result<(), failure::Error> {
         let manifest = settings::toml::Manifest::new(config_path)?;
         let env = matches.value_of("env");
         let target = manifest.get_target(env)?;
-
         let user = settings::global_user::GlobalUser::new()?;
 
-        commands::tail::start(&target, &user)?;
+        let tunnel_port: Option<u16> = matches
+            .value_of("tunnel_port")
+            .map(|p| p.parse().expect("--port expects a number"));
+        let metrics_port: Option<u16> = matches
+            .value_of("metrics_port")
+            .map(|p| p.parse().expect("--metrics expects a number"));
+
+        commands::tail::start(&target, &user, tunnel_port, metrics_port)?;
     }
     Ok(())
 }

--- a/src/tail/log_server.rs
+++ b/src/tail/log_server.rs
@@ -12,9 +12,9 @@ pub struct LogServer {
 /// LogServer is just a basic HTTP server running locally; it listens for POST requests on the root
 /// path and simply prints the JSON body of each request as its own line to STDOUT.
 impl LogServer {
-    pub fn new(shutdown_rx: Receiver<()>) -> LogServer {
+    pub fn new(port: u16, shutdown_rx: Receiver<()>) -> LogServer {
         // Start HTTP echo server that prints whatever is posted to it.
-        let addr = ([127, 0, 0, 1], 8080).into();
+        let addr = ([127, 0, 0, 1], port).into();
 
         let server = Server::bind(&addr);
 

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -18,15 +18,15 @@ pub struct Tunnel {
 /// and wait on its output; otherwise we leave an orphaned process when wrangler exits and this
 /// causes problems if it still exists the next time we start up a tail.
 impl Tunnel {
-    pub fn new() -> Result<Tunnel, failure::Error> {
+    pub fn new(tunnel_port: u16, metrics_port: u16) -> Result<Tunnel, failure::Error> {
         let tool_name = PathBuf::from("cloudflared");
         // TODO: Finally get cloudflared release binaries distributed on GitHub so we could
         // simply uncomment the line below.
         // let binary_path = install::install(tool_name, "cloudflare")?.binary(tool_name)?;
 
-        // TODO: allow user to pass in their own ports in case ports 8080 (used by cloudflared)
-        // and 8081 (used by cloudflared metrics) are both already being used.
-        let args = ["tunnel", "--metrics", "localhost:8081"];
+        let tunnel_url = format!("localhost:{}", tunnel_port);
+        let metrics_url = format!("localhost:{}", metrics_port);
+        let args = ["tunnel", "--url", &tunnel_url, "--metrics", &metrics_url];
 
         let mut command = command(&args, &tool_name);
         let command_name = format!("{:?}", command);


### PR DESCRIPTION
* provide flags for both tunnel and metrics server port configuration
* if a port is explicitly set, fail if it is unavailable
* if no port is set, try a default, else request one from the OS

closes #1178 