### PR TITLE
1.9.0 rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.9.0-rc.0"
+version = "1.9.0-rc.1"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.9.0-rc.0"
+version = "1.9.0-rc.1"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.9.0-rc.0",
+  "version": "1.9.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.9.0-rc.0",
+  "version": "1.9.0-rc.1",
   "description": "Wrangle your Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
New in this RC:

* port configuration: optionally set the port(s) receiving logs and handling the tunnel metrics server by passing `--port` and `--metrics-port` respectively. These default to 8080/8081, or the first available ephemeral port provided by the OS.

TODO:

- [ ] add test for port selection fn.