### PR TITLE
dont use fixture lock for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,27 +44,27 @@ jobs:
         if: matrix.rust
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.build }}-stable-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-stable-cargo-registry-
+            ${{ matrix.build }}-cargo-registry-
 
       - name: Cache Cargo index
         uses: actions/cache@v1
         if: matrix.rust
         with:
           path: ~/.cargo/git
-          key: ${{ matrix.build }}-stable-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-stable-cargo-index-
+            ${{ matrix.build }}-cargo-index-
 
       - name: Cache Cargo build
         uses: actions/cache@v1
         if: matrix.rust
         with:
-          path: target/release
-          key: ${{ matrix.build }}-stable-release-target-${{ hashFiles('**/Cargo.lock') }}
+          path: target
+          key: ${{ matrix.build }}-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-stable-release-target-
+            ${{ matrix.build }}-target-
 
       - name: Query version number
         id: get_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,25 +45,25 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.build }}-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-${{ matrix.rust }}-cargo-registry-
+            ${{ matrix.build }}-cargo-registry-
 
       - name: Cache Cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
-          key: ${{ matrix.build }}-${{ matrix.rust }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-${{ matrix.rust }}-cargo-index-
+            ${{ matrix.build }}-cargo-index-
 
       - name: Cache Cargo build
         uses: actions/cache@v1
         with:
-          path: target/debug
-          key: ${{ matrix.build }}-${{ matrix.rust }}-debug-target-${{ hashFiles('**/Cargo.lock') }}
+          path: target
+          key: ${{ matrix.build }}-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-${{ matrix.rust }}-debug-target-
+            ${{ matrix.build }}-target-
 
       - name: Install Rust
         run: |
@@ -73,5 +73,4 @@ jobs:
       - name: Run Tests
         run: cargo test
         env:
-          RUST_LOG: warn,wrangler=info
           RUST_BACKTRACE: 1

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -91,7 +91,6 @@ fn parses_same_from_config_path_as_string() {
     env::remove_var("CF_ACCOUNT_ID");
     env::remove_var("CF_ZONE_ID");
     let config_path = toml_fixture_path("environments.toml");
-    eprintln!("{:#?}", &config_path);
     let string_toml = fs::read_to_string(&config_path).unwrap();
 
     let manifest_from_string = Manifest::from_str(&string_toml).unwrap();

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod fixture;
 
 use std::fs;
@@ -369,7 +366,6 @@ fn it_builds_with_webpack_name_output_warn() {
 }
 
 fn build_creates_assets(fixture: &Fixture, script_names: Vec<&str>) -> (String, String) {
-    let _lock = fixture.lock();
     let mut build = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     build.current_dir(fixture.get_path());
     build.arg("build");
@@ -388,7 +384,6 @@ fn build_creates_assets(fixture: &Fixture, script_names: Vec<&str>) -> (String, 
 }
 
 fn build_fails_with(fixture: &Fixture, expected_message: &str) {
-    let _lock = fixture.lock();
     let mut build = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     build.current_dir(fixture.get_path());
     build.arg("build");

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -6,7 +6,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::mem::ManuallyDrop;
 use std::path::PathBuf;
-use std::sync::MutexGuard;
 use std::thread;
 
 use tempfile::TempDir;
@@ -106,16 +105,6 @@ impl Fixture {
         "#,
         );
         self.create_file("workers-site/index.js", "");
-    }
-
-    pub fn lock(&self) -> MutexGuard<'static, ()> {
-        use std::sync::Mutex;
-
-        lazy_static! {
-            static ref ONE_TEST_AT_A_TIME: Mutex<()> = Mutex::new(());
-        }
-
-        ONE_TEST_AT_A_TIME.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod fixture;
 
 use fixture::WranglerToml;
@@ -232,7 +229,6 @@ fn it_previews_with_config_text() {
 }
 
 fn preview_succeeds_with(fixture: &Fixture, env: Option<&str>, expected: &str) {
-    let _lock = fixture.lock();
     env::remove_var("CF_ACCOUNT_ID");
     env::remove_var("CF_ZONE_ID");
     let mut preview = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
@@ -248,8 +244,8 @@ fn preview_succeeds_with(fixture: &Fixture, env: Option<&str>, expected: &str) {
 }
 
 fn preview_succeeds(fixture: &Fixture) {
-    let _lock = fixture.lock();
     env::remove_var("CF_ACCOUNT_ID");
+    env::remove_var("CF_ZONE_ID");
     let mut preview = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     preview.current_dir(fixture.get_path());
     preview.arg("preview").arg("--headless");
@@ -257,8 +253,8 @@ fn preview_succeeds(fixture: &Fixture) {
 }
 
 fn preview_matches_url(fixture: &Fixture, url: &str, expected: &str) {
-    let _lock = fixture.lock();
     env::remove_var("CF_ACCOUNT_ID");
+    env::remove_var("CF_ZONE_ID");
     let mut preview = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     preview.current_dir(fixture.get_path());
     preview.arg("preview").arg("--headless");
@@ -267,8 +263,8 @@ fn preview_matches_url(fixture: &Fixture, url: &str, expected: &str) {
 }
 
 fn preview_not_matches_url(fixture: &Fixture, url: &str, expected: &str) {
-    let _lock = fixture.lock();
     env::remove_var("CF_ACCOUNT_ID");
+    env::remove_var("CF_ZONE_ID");
     let mut preview = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     preview.current_dir(fixture.get_path());
     preview.arg("preview").arg("--headless");


### PR DESCRIPTION
probably fixes #1243

changes: 

1) dont send `RUST_LOG=wrangler,info` since it doesn't provide any extra output anyway
2) cache entire `target` directory
3) since we create a unique temp directory for every fixture we do not need to run tests that use fixtures in parallel. this means that we won't have those intermittent CI errors, and it also means that our tests run slightly faster. _**IFF** my theory holds true and these builds run on each subsequent run_


what led me to believe this was the issue was that the tests appeared to be deadlocking, even when i limited cargo test to one thread (to run them consecutively). this must have meant that we were trying to acquire a lock twice. since we don't really use mutexes elsewhere in the codebase, it must have been the mutex used to run tests with fixtures consecutively. removing it _seems_ to work!