### PR TITLE
standardizes colors in stdout

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -6,9 +6,7 @@ use server_config::ServerConfig;
 use crate::commands;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
-use crate::terminal::message;
-
-use console::style;
+use crate::terminal::{message, styles};
 
 /// `wrangler dev` starts a server on a dev machine that routes incoming HTTP requests
 /// to a Cloudflare Workers runtime and returns HTTP responses
@@ -35,9 +33,7 @@ pub fn dev(
 }
 
 fn print_alpha_warning_message() {
-    let wrangler_dev_msg = style("`wrangler dev`").yellow().bold();
-    let feedback_url = style("https://github.com/cloudflare/wrangler/issues/1047")
-        .blue()
-        .bold();
+    let wrangler_dev_msg = styles::highlight("`wrangler dev`");
+    let feedback_url = styles::url("https://github.com/cloudflare/wrangler/issues/1047");
     message::billboard(&format!("{0} is currently unstable and there are likely to be breaking changes!\nFor this reason, we cannot yet recommend using {0} for integration testing.\n\nPlease submit any feedback here: {1}", wrangler_dev_msg, feedback_url));
 }

--- a/src/commands/preview/upload.rs
+++ b/src/commands/preview/upload.rs
@@ -9,10 +9,8 @@ use crate::commands::publish;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
-use crate::terminal::message;
+use crate::terminal::{message, styles};
 use crate::upload;
-
-use console::style;
 
 #[derive(Debug, Deserialize)]
 struct Preview {
@@ -101,10 +99,10 @@ pub fn upload(
             }
         }
         None => {
-            let wrangler_config_msg = style("`wrangler config`").yellow().bold();
-            let docs_url_msg = style("https://developers.cloudflare.com/workers/tooling/wrangler/configuration/#using-environment-variables").blue().bold();
+            let wrangler_config_msg = styles::highlight("`wrangler config`");
+            let docs_url_msg = styles::url("https://developers.cloudflare.com/workers/tooling/wrangler/configuration/#using-environment-variables");
             message::billboard(
-                &format!("You have not provided your Cloudflare credentials.\n\nPlease run {} or visit\n{}\nfor info on authenticating with environment variables.", wrangler_config_msg, docs_url_msg)
+            &format!("You have not provided your Cloudflare credentials.\n\nPlease run {} or visit\n{}\nfor info on authenticating with environment variables.", wrangler_config_msg, docs_url_msg)
             );
 
             message::info("Running preview without authentication.");

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1,8 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use console::style;
-
 use crate::commands;
 use crate::commands::kv;
 use crate::commands::kv::bucket::{sync, upload_files};
@@ -11,7 +9,7 @@ use crate::deploy;
 use crate::http::{self, Feature};
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::{DeployConfig, KvNamespace, Target};
-use crate::terminal::{emoji, message};
+use crate::terminal::{emoji, message, styles};
 use crate::upload;
 
 pub fn publish(
@@ -59,10 +57,8 @@ pub fn publish(
         let uses_kv_bucket = sync_non_site_buckets(target, user, verbose)?;
 
         let upload_client = if uses_kv_bucket {
-            let wrangler_toml = style("`wrangler.toml`").yellow().bold();
-            let issue_link = style("https://github.com/cloudflare/wrangler/issues/1136")
-                .blue()
-                .bold();
+            let wrangler_toml = styles::highlight("`wrangler.toml`");
+            let issue_link = styles::url("https://github.com/cloudflare/wrangler/issues/1136");
             let msg = format!("As of 1.9.0, you will no longer be able to specify a bucket for a kv namespace in your {}.\nIf your application depends on this feature, please file an issue with your use case here:\n{}", wrangler_toml, issue_link);
             message::deprecation_warning(&msg);
 

--- a/src/commands/whoami/mod.rs
+++ b/src/commands/whoami/mod.rs
@@ -1,13 +1,12 @@
 use crate::http;
 use crate::settings::global_user::GlobalUser;
-use crate::terminal::{emoji, message};
+use crate::terminal::{emoji, message, styles};
 
 use cloudflare::endpoints::account::{self, Account};
 use cloudflare::endpoints::user::GetUserDetails;
 use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 
-use console::Style;
 use prettytable::{Cell, Row, Table};
 
 pub fn whoami(user: &GlobalUser) -> Result<(), failure::Error> {
@@ -36,19 +35,18 @@ pub fn whoami(user: &GlobalUser) -> Result<(), failure::Error> {
     let mut msg = format!("{} You are logged in with {}!\n", emoji::WAVING, auth);
     let num_permissions_missing = missing_permissions.len();
     if num_permissions_missing > 0 {
-        let bold_yellow = Style::new().bold().yellow();
-        let config_msg = bold_yellow.apply_to("`wrangler config`");
-        let whoami_msg = bold_yellow.apply_to("`wrangler whoami`");
+        let config_msg = styles::highlight("`wrangler config`");
+        let whoami_msg = styles::highlight("`wrangler whoami`");
         if missing_permissions.len() == 1 {
             msg.push_str(&format!(
                 "\nYour token is missing the '{}' permission.",
-                bold_yellow.apply_to(missing_permissions.get(0).unwrap())
+                styles::highlight(missing_permissions.get(0).unwrap())
             ));
         } else if missing_permissions.len() == 2 {
             msg.push_str(&format!(
                 "\nYour token is missing the '{}' and '{}' permissions.",
-                bold_yellow.apply_to(missing_permissions.get(0).unwrap()),
-                bold_yellow.apply_to(missing_permissions.get(1).unwrap())
+                styles::highlight(missing_permissions.get(0).unwrap()),
+                styles::highlight(missing_permissions.get(1).unwrap())
             ));
         }
         msg.push_str(&format!("\n\nPlease generate a new token and authenticate with {}\nfor more information when running {}", config_msg, whoami_msg));

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg, ArgGroup, SubCommand};
 use commands::HTTPMethod;
-use console::style;
 use exitfailure::ExitFailure;
 
 use url::Url;
@@ -20,7 +19,7 @@ use wrangler::installer;
 use wrangler::settings;
 use wrangler::settings::global_user::GlobalUser;
 use wrangler::settings::toml::TargetType;
-use wrangler::terminal::{emoji, interactive, message};
+use wrangler::terminal::{emoji, interactive, message, styles};
 
 fn main() -> Result<(), ExitFailure> {
     env_logger::init();
@@ -518,16 +517,12 @@ fn run() -> Result<(), failure::Error> {
 
     let config_path = Path::new("./wrangler.toml");
 
-    let not_recommended_msg = style("(Not Recommended)").red().bold();
-    let recommended_cmd_msg = style("`wrangler config --api-key`").yellow().bold();
-    let api_token_url = style("https://dash.cloudflare.com/profile/api-tokens")
-        .blue()
-        .bold();
-    let token_support_url = style(
+    let not_recommended_msg = styles::warning("(Not Recommended)");
+    let recommended_cmd_msg = styles::highlight("`wrangler config --api-key`");
+    let api_token_url = styles::url("https://dash.cloudflare.com/profile/api-tokens");
+    let token_support_url = styles::url(
         "https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys",
-    )
-    .blue()
-    .bold();
+    );
 
     if let Some(matches) = matches.subcommand_matches("config") {
         // If api-key flag isn't present, use the default auth option (API token)
@@ -658,8 +653,14 @@ fn run() -> Result<(), failure::Error> {
 
         let release = matches.is_present("release");
         if release {
-            message::warn("wrangler publish --release is deprecated and behaves exactly the same as wrangler publish.");
-            message::warn("See https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments for more information.");
+            let publish_release_msg = styles::highlight("`wrangler publish --release`");
+            let publish_msg = styles::highlight("`wrangler publish`");
+            let environments_url = styles::url("https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments");
+            message::warn(&format!(
+                "{} is deprecated and behaves exactly the same as {}.",
+                publish_release_msg, publish_msg
+            ));
+            message::warn(&format!("See {} for more information.", environments_url));
         }
 
         log::info!("Getting project settings");

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -7,7 +7,7 @@ use config;
 use serde::{Deserialize, Serialize};
 
 use crate::settings::{Environment, QueryEnvironment};
-use crate::terminal::emoji;
+use crate::terminal::{emoji, styles};
 
 const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 
@@ -107,9 +107,13 @@ impl GlobalUser {
         match global_user {
             Ok(user) => Ok(user),
             Err(_) => {
+                let wrangler_config_msg = styles::highlight("`wrangler config`");
+                let vars_msg = styles::url("https://developers.cloudflare.com/workers/tooling/wrangler/configuration/#using-environment-variables");
                 let msg = format!(
-                    "{} Your authentication details are improperly configured.\nPlease run `wrangler config` or visit\nhttps://developers.cloudflare.com/workers/tooling/wrangler/configuration/#using-environment-variables\nfor info on configuring with environment variables",
+                    "{} Your authentication details are improperly configured.\nPlease run {} or visit\n{}\nfor info on configuring with environment variables",
                     emoji::WARN,
+                    wrangler_config_msg,
+                    vars_msg
                 );
                 log::info!("{:?}", config);
                 failure::bail!(msg)

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -16,8 +16,7 @@ use crate::settings::toml::kv_namespace::KvNamespace;
 use crate::settings::toml::site::Site;
 use crate::settings::toml::target_type::TargetType;
 use crate::settings::toml::Target;
-use crate::terminal::emoji;
-use crate::terminal::message;
+use crate::terminal::{emoji, message, styles};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Manifest {
@@ -302,12 +301,17 @@ impl Manifest {
         let has_env_fields = !env_fields.is_empty();
         let mut needs_new_line = false;
         if has_top_level_fields || has_env_fields {
+            let toml_msg = styles::highlight("wrangler.toml");
+            let account_id_msg = styles::highlight("account_id");
+            let zone_id_msg = styles::highlight("zone_id");
+            let dash_url = styles::url("https://dash.cloudflare.com");
             message::help(
-                "You will need to update the following fields in the created wrangler.toml file before continuing:"
+                &format!("You will need to update the following fields in the created {} file before continuing:", toml_msg)
             );
-            message::help(
-                "You can find your account_id and zone_id in the right sidebar of the zone overview tab at https://dash.cloudflare.com"
-            );
+            message::help(&format!(
+                "You can find your {} and {} in the right sidebar of the zone overview tab at {}",
+                account_id_msg, zone_id_msg, dash_url
+            ));
             if has_top_level_fields {
                 needs_new_line = true;
                 for top_level_field in top_level_fields {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,3 +1,4 @@
 pub mod emoji;
 pub mod interactive;
 pub mod message;
+pub mod styles;

--- a/src/terminal/styles.rs
+++ b/src/terminal/styles.rs
@@ -1,0 +1,13 @@
+use console::{style, StyledObject};
+
+pub fn url(msg: &str) -> StyledObject<&str> {
+    style(msg).blue().bold()
+}
+
+pub fn warning(msg: &str) -> StyledObject<&str> {
+    style(msg).red().bold()
+}
+
+pub fn highlight(msg: &str) -> StyledObject<&str> {
+    style(msg).yellow().bold()
+}


### PR DESCRIPTION
adds `crate::terminal::styles` and removes usage of `console::style` elsewhere

three fns:

`styles::url` makes it blueeee
`styles::highlight` makes it yellloowww
`styles::warning` makes it reeeeddd