### PR TITLE
wip add cors options

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -16,9 +16,10 @@ pub fn dev(
     host: Option<&str>,
     port: Option<&str>,
     ip: Option<&str>,
+    allowed_origins: &[&str],
     verbose: bool,
 ) -> Result<(), failure::Error> {
-    let server_config = ServerConfig::new(host, ip, port)?;
+    let server_config = ServerConfig::new(host, ip, port, allowed_origins)?;
 
     // we can remove this once the feature has stabilized
     print_alpha_warning_message();

--- a/src/commands/dev/server_config/mod.rs
+++ b/src/commands/dev/server_config/mod.rs
@@ -4,10 +4,13 @@ mod listening_address;
 use host::Host;
 use listening_address::ListeningAddress;
 
+use http::Uri;
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub host: Host,
     pub listening_address: ListeningAddress,
+    pub allowed_origins: Vec<Uri>,
 }
 
 impl ServerConfig {
@@ -15,17 +18,22 @@ impl ServerConfig {
         host: Option<&str>,
         ip: Option<&str>,
         port: Option<&str>,
+        allowed_origins: &[&str],
     ) -> Result<Self, failure::Error> {
         let port = port.unwrap_or("8787");
         let ip = ip.unwrap_or("localhost");
         let host = host.unwrap_or("https://example.com").to_string();
-
+        let allowed_origins = allowed_origins
+            .into_iter()
+            .map(|o| o.parse::<Uri>().expect("failed to parse allowed origin"))
+            .collect();
         let listening_address = ListeningAddress::new(ip, port)?;
         let host = Host::new(&host)?;
 
         Ok(ServerConfig {
             host,
             listening_address,
+            allowed_origins,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,6 +446,13 @@ fn run() -> Result<(), failure::Error> {
                         .takes_value(true)
                 )
                 .arg(
+                    Arg::with_name("cors")
+                        .long("cors")
+                        .takes_value(true)
+                        .multiple(true)
+                        .help("turns on CORS for your local development server, pass the origins you want to allow requests from")
+                )
+                .arg(
                     Arg::with_name("verbose")
                         .long("verbose")
                         .takes_value(false)
@@ -666,8 +673,9 @@ fn run() -> Result<(), failure::Error> {
         let env = matches.value_of("env");
         let target = manifest.get_target(env)?;
         let user = settings::global_user::GlobalUser::new().ok();
+        let allowed_origins: Vec<&str> = matches.values_of("cors").unwrap().collect();
         let verbose = matches.is_present("verbose");
-        commands::dev::dev(target, user, host, port, ip, verbose)?;
+        commands::dev::dev(target, user, host, port, ip, &allowed_origins, verbose)?;
     } else if matches.subcommand_matches("whoami").is_some() {
         log::info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;


### PR DESCRIPTION
this doesn't work yet but im thinking of making `--cors` take an allowed origin and setting `Access-Control-Allow-Origin` depending on that arg.

`wrangler dev` wouldn't do anything different
`wrangler dev --cors localhost:3000` would allow requests from `localhost:3000`
`wrangler dev --cors localhost:3000 --cors localhost:3001` would allow requests from `localhost:3000` and `localhost:3001`.

cc @tibotiber @PierBover @dhaynespls 