### PR TITLE
removes --release from publish help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -470,6 +470,7 @@ fn run() -> Result<(), failure::Error> {
                 )
                 .arg(
                     Arg::with_name("release")
+                        .hidden(true)
                         .long("release")
                         .takes_value(false)
                         .help("[deprecated] alias of wrangler publish")


### PR DESCRIPTION
we deprecated this a while ago, we can still make it behave the same (alias of wrangler publish) but remove it from the help text :)

before

```console
$ wrangler publish --help
wrangler-publish 
🆙  Publish your worker to the orange cloud

USAGE:
    wrangler publish [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
        --release    [deprecated] alias of wrangler publish
        --verbose    toggle verbose output

OPTIONS:
    -e, --env <env>    environments to publish to
```

after

```console
$ wrangler publish --help
wrangler-publish 
🆙  Publish your worker to the orange cloud

USAGE:
    wrangler publish [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
        --verbose    toggle verbose output

OPTIONS:
    -e, --env <env>    environments to publish to
```