### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cloudflare/workers/wrangler will be requested for
+# review when someone opens a pull request.
+
+*   @cloudflare/wrangler


### PR DESCRIPTION
Specifies @cloudflare/wrangler team as default reviewer for wrangler.

Docs are here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners