### PR TITLE
low hanging clippy warnings

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -20,10 +20,8 @@ pub fn generate(
         Err(_) => true,
     };
 
-    let new_name: String;
-
-    if dirname_exists {
-        new_name = match generate_name(name) {
+    let new_name = if dirname_exists {
+        match generate_name(name) {
             Ok(val) => val,
             Err(_) => {
                 log::debug!(
@@ -32,10 +30,10 @@ pub fn generate(
                 );
                 String::from(name)
             }
-        };
+        }
     } else {
-        new_name = String::from(name);
-    }
+        String::from(name)
+    };
 
     log::info!("Generating a new worker project with name '{}'", new_name);
     run_generate(&new_name, template)?;
@@ -74,7 +72,7 @@ fn generate_name(name: &str) -> Result<String, failure::Error> {
     let mut new_name = construct_name(&name, num);
 
     while entry_names.contains(&OsString::from(&new_name)) {
-        num = num + 1;
+        num += 1;
         new_name = construct_name(&name, num);
     }
     Ok(new_name)

--- a/src/fixtures/mod.rs
+++ b/src/fixtures/mod.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::thread;
 
 use tempfile::TempDir;
-use toml;
 
 const BUNDLE_OUT: &str = "worker";
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -22,9 +22,7 @@ use std::io;
 use std::path::Path;
 use std::process;
 
-use atty;
 use failure::{self, bail, ResultExt};
-use which;
 
 pub fn install() -> ! {
     if let Err(e) = do_install() {

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -76,7 +76,7 @@ pub fn preview(
         }
 
         // Make a the initial request to the URL
-        client_request(&request_payload, &script_id, &sites_preview);
+        client_request(&request_payload, &script_id, sites_preview);
 
         let broadcaster = server.broadcaster();
         thread::spawn(move || server.run());
@@ -96,7 +96,7 @@ pub fn preview(
             ))?;
         }
 
-        client_request(&request_payload, &script_id, &sites_preview);
+        client_request(&request_payload, &script_id, sites_preview);
     }
 
     Ok(())
@@ -118,7 +118,7 @@ fn open_browser(url: &str) -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn client_request(payload: &RequestPayload, script_id: &String, sites_preview: &bool) {
+fn client_request(payload: &RequestPayload, script_id: &str, sites_preview: bool) {
     let client = http::client();
 
     let method = &payload.method;
@@ -132,7 +132,7 @@ fn client_request(payload: &RequestPayload, script_id: &String, sites_preview: &
         HttpMethod::Post => post(&url, &cookie, &body, &client).unwrap(),
     };
 
-    let msg = if *sites_preview {
+    let msg = if sites_preview {
         "Your Worker is a Workers Site, please preview it in browser window.".to_string()
     } else {
         format!("Your Worker responded with: {}", worker_res)
@@ -141,8 +141,8 @@ fn client_request(payload: &RequestPayload, script_id: &String, sites_preview: &
 }
 
 fn get(
-    url: &String,
-    cookie: &String,
+    url: &str,
+    cookie: &str,
     client: &reqwest::blocking::Client,
 ) -> Result<String, failure::Error> {
     let res = client.get(url).header("Cookie", cookie).send();
@@ -150,8 +150,8 @@ fn get(
 }
 
 fn post(
-    url: &String,
-    cookie: &String,
+    url: &str,
+    cookie: &str,
     body: &Option<String>,
     client: &reqwest::blocking::Client,
 ) -> Result<String, failure::Error> {
@@ -159,7 +159,7 @@ fn post(
         Some(s) => client
             .post(url)
             .header("Cookie", cookie)
-            .body(format!("{}", s))
+            .body(s.to_string())
             .send(),
         None => client.post(url).header("Cookie", cookie).send(),
     };
@@ -183,7 +183,7 @@ fn watch_for_changes(
 
     while let Ok(_) = rx.recv() {
         if let Ok(new_id) = upload(&mut target, user, sites_preview, verbose) {
-            let script_id = format!("{}", new_id);
+            let script_id = new_id.to_string();
 
             let msg = FiddleMessage {
                 session_id: request_payload.session.clone(),
@@ -201,7 +201,7 @@ fn watch_for_changes(
                 }
             }
 
-            client_request(&request_payload, &script_id, &sites_preview);
+            client_request(&request_payload, &script_id, sites_preview);
         }
     }
 

--- a/src/preview/request_payload.rs
+++ b/src/preview/request_payload.rs
@@ -51,7 +51,7 @@ impl RequestPayload {
         }
     }
 
-    pub fn cookie(&self, script_id: &String) -> String {
+    pub fn cookie(&self, script_id: &str) -> String {
         format!(
             "__ew_fiddle_preview={}{}{}{}",
             script_id, self.session, self.https, self.domain

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use cloudflare::framework::auth::Credentials;
-use config;
 use serde::{Deserialize, Serialize};
 
 use crate::settings::{Environment, QueryEnvironment};

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -35,7 +35,7 @@ impl Tunnel {
 
         let child = command
             .spawn()
-            .expect(&format!("{} failed to spawn", command_name));
+            .unwrap_or_else(|_| panic!("{} failed to spawn", command_name));
 
         Ok(Tunnel { child })
     }


### PR DESCRIPTION
this doesn't eradicate all of our clippy warnings; i left the `dev` directory alone, as well as a couple of "too many arguments" and something that i didn't quite understand.