### PR TITLE
Revert "Clean up apierrors and only include messages"

### DIFF
--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -1,7 +1,8 @@
 use cloudflare::endpoints::workerskv::WorkersKvNamespace;
+use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::ApiFailure;
 
 use crate::commands::kv;
-use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
@@ -28,15 +29,40 @@ pub fn site(
             message::working(&msg);
             Ok(success.result)
         }
-        Err(e) => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
+        Err(e) => match e {
+            ApiFailure::Error(_status, api_errors) => {
+                if api_errors.errors.iter().any(|e| e.code == 10026) {
+                    failure::bail!("You will need to enable Workers Unlimited for your account before you can use this feature.")
+                } else if api_errors.errors.iter().any(|e| e.code == 10014) {
+                    log::info!("Namespace {} already exists.", title);
+
+                    let msg = format!("Using namespace for Workers Site \"{}\"", title);
+                    message::working(&msg);
+
+                    get_id_from_namespace_list(&client, target, &title)
+                } else {
+                    failure::bail!("{:?}", api_errors.errors)
+                }
+            }
+            ApiFailure::Invalid(reqwest_err) => failure::bail!("Error: {}", reqwest_err),
+        },
     }
 }
 
-fn error_suggestions(code: u16) -> &'static str {
-    match code {
-        10026 => "You will need to enable Workers Unlimited for your account before you can use this feature.",
-        10014 => "Namespace already exists, try using a different namespace.",
-        10037 => "Edit your API Token to have correct permissions, or use the 'Edit Cloudflare Workers' API Token template.",
-        _ => "",
+fn get_id_from_namespace_list(
+    client: &impl ApiClient,
+    target: &Target,
+    title: &str,
+) -> Result<WorkersKvNamespace, failure::Error> {
+    let result = kv::namespace::list::call_api(client, target);
+
+    match result {
+        Ok(success) => Ok(success
+            .result
+            .iter()
+            .find(|ns| ns.title == title)
+            .unwrap()
+            .to_owned()),
+        Err(e) => failure::bail!(kv::format_error(e)),
     }
 }


### PR DESCRIPTION
This created an issue with publish where I accidentally removed logic to publish on an existing namespace