### PR TITLE
Add better error messages without breaking publish

### DIFF
--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -3,6 +3,7 @@ use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 
 use crate::commands::kv;
+use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
@@ -29,7 +30,6 @@ pub fn site(
             message::working(&msg);
             Ok(success.result)
         }
-
         Err(e) => match &e {
             ApiFailure::Error(_status, api_errors) => {
                 if api_errors.errors.iter().any(|e| e.code == 10014) {
@@ -66,20 +66,11 @@ fn get_id_from_namespace_list(
     }
 }
 
-fn get_id_from_namespace_list(
-    client: &impl ApiClient,
-    target: &Target,
-    title: &str,
-) -> Result<WorkersKvNamespace, failure::Error> {
-    let result = kv::namespace::list::call_api(client, target);
-
-    match result {
-        Ok(success) => Ok(success
-            .result
-            .iter()
-            .find(|ns| ns.title == title)
-            .unwrap()
-            .to_owned()),
-        Err(e) => failure::bail!(kv::format_error(e)),
+fn error_suggestions(code: u16) -> &'static str {
+    match code {
+        10026 => "You will need to enable Workers Unlimited for your account before you can use this feature.",
+        10014 => "Namespace already exists, try using a different namespace.",
+        10037 => "Edit your API Token to have correct permissions, or use the 'Edit Cloudflare Workers' API Token template.",
+        _ => "",
     }
 }

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -62,7 +62,7 @@ fn get_id_from_namespace_list(
             .find(|ns| ns.title == title)
             .unwrap()
             .to_owned()),
-        Err(e) => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
+        Err(e) => failure::bail!(kv::format_error(e)),
     }
 }
 

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -1,7 +1,8 @@
 use cloudflare::endpoints::workerskv::WorkersKvNamespace;
+use cloudflare::framework::apiclient::ApiClient;
+use cloudflare::framework::response::ApiFailure;
 
 use crate::commands::kv;
-use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
@@ -28,15 +29,45 @@ pub fn site(
             message::working(&msg);
             Ok(success.result)
         }
-        Err(e) => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
+        Err(e) => match e {
+            ApiFailure::Error(_status, api_errors) => {
+                if api_errors.errors.iter().any(|e| e.code == 10026) {
+                    failure::bail!("You will need to enable Workers Unlimited for your account before you can use this feature.")
+                } else if api_errors.errors.iter().any(|e| e.code == 10014) {
+                    log::info!("Namespace {} already exists.", title);
+
+                    let msg = format!("Using namespace for Workers Site \"{}\"", title);
+                    message::working(&msg);
+
+                    get_id_from_namespace_list(&client, target, &title)
+                } else {
+                    let error_messages: Vec<String> = api_errors
+                        .errors
+                        .iter()
+                        .map(|e| e.message.clone())
+                        .collect();
+                    failure::bail!("ApiError {:?}", error_messages);
+                }
+            }
+            ApiFailure::Invalid(reqwest_err) => failure::bail!("Error: {}", reqwest_err),
+        },
     }
 }
 
-fn error_suggestions(code: u16) -> &'static str {
-    match code {
-        10026 => "You will need to enable Workers Unlimited for your account before you can use this feature.",
-        10014 => "Namespace already exists, try using a different namespace.",
-        10037 => "Edit your API Token to have correct permissions, or use the 'Edit Cloudflare Workers' API Token template.",
-        _ => "",
+fn get_id_from_namespace_list(
+    client: &impl ApiClient,
+    target: &Target,
+    title: &str,
+) -> Result<WorkersKvNamespace, failure::Error> {
+    let result = kv::namespace::list::call_api(client, target);
+
+    match result {
+        Ok(success) => Ok(success
+            .result
+            .iter()
+            .find(|ns| ns.title == title)
+            .unwrap()
+            .to_owned()),
+        Err(e) => failure::bail!(kv::format_error(e)),
     }
 }

--- a/src/commands/kv/namespace/site.rs
+++ b/src/commands/kv/namespace/site.rs
@@ -3,6 +3,7 @@ use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 
 use crate::commands::kv;
+use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
@@ -29,11 +30,9 @@ pub fn site(
             message::working(&msg);
             Ok(success.result)
         }
-        Err(e) => match e {
+        Err(e) => match &e {
             ApiFailure::Error(_status, api_errors) => {
-                if api_errors.errors.iter().any(|e| e.code == 10026) {
-                    failure::bail!("You will need to enable Workers Unlimited for your account before you can use this feature.")
-                } else if api_errors.errors.iter().any(|e| e.code == 10014) {
+                if api_errors.errors.iter().any(|e| e.code == 10014) {
                     log::info!("Namespace {} already exists.", title);
 
                     let msg = format!("Using namespace for Workers Site \"{}\"", title);
@@ -41,15 +40,10 @@ pub fn site(
 
                     get_id_from_namespace_list(&client, target, &title)
                 } else {
-                    let error_messages: Vec<String> = api_errors
-                        .errors
-                        .iter()
-                        .map(|e| e.message.clone())
-                        .collect();
-                    failure::bail!("ApiError {:?}", error_messages);
+                    failure::bail!("{}", http::format_error(e, Some(&error_suggestions)))
                 }
             }
-            ApiFailure::Invalid(reqwest_err) => failure::bail!("Error: {}", reqwest_err),
+            _ => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
         },
     }
 }
@@ -68,6 +62,15 @@ fn get_id_from_namespace_list(
             .find(|ns| ns.title == title)
             .unwrap()
             .to_owned()),
-        Err(e) => failure::bail!(kv::format_error(e)),
+        Err(e) => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
+    }
+}
+
+fn error_suggestions(code: u16) -> &'static str {
+    match code {
+        10026 => "You will need to enable Workers Unlimited for your account before you can use this feature.",
+        10014 => "Namespace already exists, try using a different namespace.",
+        10037 => "Edit your API Token to have correct permissions, or use the 'Edit Cloudflare Workers' API Token template.",
+        _ => "",
     }
 }


### PR DESCRIPTION
This redoes #1329 without breaking `wrangler publish`. Addresses #1157 