### PR TITLE
Pin dependency version for wasmpack and cargo-generate

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -13,7 +13,7 @@ pub fn build(target: &Target) -> Result<(), failure::Error> {
             message::info("JavaScript project found. Skipping unnecessary build!")
         }
         TargetType::Rust => {
-            let binary_path = install::install_wasmpack()?;
+            let binary_path = install::install_wasm_pack()?;
             let args = ["build", "--target", "no-modules"];
 
             let command = command(&args, &binary_path);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -13,12 +13,7 @@ pub fn build(target: &Target) -> Result<(), failure::Error> {
             message::info("JavaScript project found. Skipping unnecessary build!")
         }
         TargetType::Rust => {
-            let tool_name = "wasm-pack";
-            let tool_author = "rustwasm";
-            let is_binary = true;
-            let version = install::get_latest_version(tool_name)?;
-            let binary_path =
-                install::install(tool_name, tool_author, is_binary, version)?.binary(tool_name)?;
+            let binary_path = install::install_wasmpack()?;
             let args = ["build", "--target", "no-modules"];
 
             let command = command(&args, &binary_path);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -52,12 +52,7 @@ pub fn generate(
 }
 
 pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
-    let tool_name = "cargo-generate";
-    let tool_author = "ashleygwilliams";
-    let is_binary = true;
-    let version = install::get_latest_version(tool_name)?;
-    let binary_path =
-        install::install(tool_name, tool_author, is_binary, version)?.binary(tool_name)?;
+    let binary_path = install::install_cargo_generate()?;
 
     let args = ["generate", "--git", template, "--name", name, "--force"];
 

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
-pub const WASMPACK_VERSION: &str = "0.9.1";
+pub const WASM_PACK_VERSION: &str = "0.9.1";
 pub const GENERATE_VERSION: &str = "0.5.0";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,0 +1,2 @@
+pub const WASMPACK_VERSION: &str = "0.9.2";
+pub const GENERATE_VERSION: &str = "0.5.0";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
-pub const WASMPACK_VERSION: &str = "0.9.2";
+pub const WASMPACK_VERSION: &str = "0.9.1";
 pub const GENERATE_VERSION: &str = "0.5.0";

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -1,3 +1,4 @@
+pub mod dependencies;
 mod krate;
 pub mod target;
 
@@ -21,6 +22,22 @@ lazy_static! {
 enum ToolDownload {
     NeedsInstall(Version),
     InstalledAt(Download),
+}
+
+pub fn install_cargo_generate() -> Result<PathBuf, failure::Error> {
+    let tool_name = "cargo-generate";
+    let tool_author = "ashleygwilliams";
+    let is_binary = true;
+    let version = Version::parse(dependencies::GENERATE_VERSION)?;
+    install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
+}
+
+pub fn install_wasmpack() -> Result<PathBuf, failure::Error> {
+    let tool_name = "wasm-pack";
+    let tool_author = "rustwasm";
+    let is_binary = true;
+    let version = Version::parse(dependencies::WASMPACK_VERSION)?;
+    install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
 }
 
 pub fn install(
@@ -59,7 +76,9 @@ fn tool_needs_update(
     // we shouldn't fail, we should just re-install for them
     if let Ok(current_installation) = current_installation {
         if let Some((installed_version, installed_location)) = current_installation {
-            if installed_version == target_version {
+            if installed_version.major == target_version.major
+                && installed_version >= target_version
+            {
                 return Ok(ToolDownload::InstalledAt(Download::at(&installed_location)));
             }
         }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -32,11 +32,11 @@ pub fn install_cargo_generate() -> Result<PathBuf, failure::Error> {
     install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
 }
 
-pub fn install_wasmpack() -> Result<PathBuf, failure::Error> {
+pub fn install_wasm_pack() -> Result<PathBuf, failure::Error> {
     let tool_name = "wasm-pack";
     let tool_author = "rustwasm";
     let is_binary = true;
-    let version = Version::parse(dependencies::WASMPACK_VERSION)?;
+    let version = Version::parse(dependencies::WASM_PACK_VERSION)?;
     install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
 }
 

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -55,7 +55,7 @@ pub fn watch_and_build(
             });
         }
         TargetType::Rust => {
-            let binary_path = install::install_wasmpack()?;
+            let binary_path = install::install_wasm_pack()?;
             let args = ["build", "--target", "no-modules"];
 
             thread::spawn(move || {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -55,12 +55,7 @@ pub fn watch_and_build(
             });
         }
         TargetType::Rust => {
-            let tool_name = "wasm-pack";
-            let tool_author = "rustwasm";
-            let is_binary = true;
-            let version = install::get_latest_version(tool_name)?;
-            let binary_path =
-                install::install(tool_name, tool_author, is_binary, version)?.binary(tool_name)?;
+            let binary_path = install::install_wasmpack()?;
             let args = ["build", "--target", "no-modules"];
 
             thread::spawn(move || {

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -169,11 +169,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
 
     // export WASM_PACK_PATH for use by wasm-pack-plugin
     // https://github.com/wasm-tool/wasm-pack-plugin/blob/caca20df84782223f002735a8a2e99b2291f957c/plugin.js#L13
-    let tool_name = "wasm-pack";
-    let tool_author = "rustwasm";
-    let version = install::get_latest_version(tool_name)?;
-    let wasm_pack_path =
-        install::install(tool_name, tool_author, true, version)?.binary("wasm-pack")?;
+    let wasm_pack_path = install::install_wasmpack()?;
     command.env("WASM_PACK_PATH", wasm_pack_path);
 
     // create a temp file for IPC with the wranglerjs process


### PR DESCRIPTION
This PR would make it so that wasmpack and cargo-generate have a fixed version set in `src/install/dependencies.rs`. It would pull a new version if there the package is not installed, the package has a different major version, or the package is older than the fixed target version.

Resolves #1240?