### PR TITLE
Disable nightly builds due to upstream crate parsing issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,8 @@ jobs:
         build:
           [
             linux-stable,
-            linux-nightly,
             macos-stable,
-            macos-nightly,
             windows-stable,
-            windows-nightly,
           ]
         include:
           - build: linux-stable
@@ -28,15 +25,6 @@ jobs:
           - build: windows-stable
             os: windows-latest
             rust: stable
-          - build: linux-nightly
-            os: ubuntu-latest
-            rust: nightly
-          - build: macos-nightly
-            os: macos-latest
-            rust: nightly
-          - build: windows-nightly
-            os: windows-latest
-            rust: nightly
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1380

Working around https://github.com/rust-lang/cargo/issues/8351