### PR TITLE
Pass wrangler env to webpack

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -6,7 +6,7 @@ use crate::{commands, install};
 use std::path::PathBuf;
 use std::process::Command;
 
-pub fn build(target: &Target) -> Result<(), failure::Error> {
+pub fn build(target: &Target, build_env: Option<String>) -> Result<(), failure::Error> {
     let target_type = &target.target_type;
     match target_type {
         TargetType::JavaScript => {
@@ -22,7 +22,7 @@ pub fn build(target: &Target) -> Result<(), failure::Error> {
             commands::run(command, &command_name)?;
         }
         TargetType::Webpack => {
-            wranglerjs::run_build(target)?;
+            wranglerjs::run_build(target, build_env)?;
         }
     }
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -13,5 +13,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
     let manifest = Manifest::new(&config_path)?;
     let env = matches.value_of("env");
     let target = &manifest.get_target(env, false)?;
-    build(&target)
+
+    let env = env.map(|s| s.to_string());
+    build(&target, env)
 }

--- a/src/commands/dev/gcs/mod.rs
+++ b/src/commands/dev/gcs/mod.rs
@@ -23,6 +23,7 @@ pub fn dev(
     user: Option<GlobalUser>,
     server_config: ServerConfig,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
     // setup the session
     let session_id = get_session_id()?;
@@ -61,6 +62,7 @@ pub fn dev(
                 Arc::clone(&preview_id),
                 &session_id,
                 verbose,
+                build_env,
             )
         });
     }

--- a/src/commands/dev/gcs/watch.rs
+++ b/src/commands/dev/gcs/watch.rs
@@ -14,9 +14,10 @@ pub fn watch_for_changes(
     preview_id: Arc<Mutex<String>>,
     session_id: &str,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
     let (sender, receiver) = mpsc::channel();
-    watch_and_build(&target, Some(sender))?;
+    watch_and_build(&target, build_env, Some(sender))?;
 
     while receiver.recv().is_ok() {
         let user = user.clone();

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -17,6 +17,7 @@ pub fn dev(
     port: Option<u16>,
     ip: Option<&str>,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
     let server_config = ServerConfig::new(host, ip, port)?;
 
@@ -24,12 +25,12 @@ pub fn dev(
     print_alpha_warning_message();
 
     // before serving requests we must first build the Worker
-    build(&target)?;
+    build(&target, build_env.clone())?;
 
     // eventually we will have two modes - edge and gcs
     // edge for authenticated users and gcs for unauthenticated
     // for now, always route to gcs
-    gcs::dev(target, user, server_config, verbose)
+    gcs::dev(target, user, server_config, verbose, build_env)
 }
 
 fn print_alpha_warning_message() {

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -7,6 +7,7 @@ pub fn run(
     user: Option<GlobalUser>,
     options: PreviewOpt,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
-    preview(target, user, options, verbose)
+    preview(target, user, options, verbose, build_env)
 }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -16,11 +16,12 @@ pub fn publish(
     target: &mut Target,
     deploy_config: DeployConfig,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
     validate_target_required_fields_present(target)?;
 
     // Build the script before uploading.
-    build(&target)?;
+    build(&target, build_env)?;
 
     if let Some(site_config) = &target.site {
         let path = &site_config.bucket.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -715,7 +715,8 @@ fn run() -> Result<(), failure::Error> {
             headless,
         };
 
-        commands::preview(target, user, options, verbose)?;
+        let env = env.map(|s| s.to_string());
+        commands::preview(target, user, options, verbose, env)?;
     } else if let Some(matches) = matches.subcommand_matches("dev") {
         log::info!("Starting dev server");
         let port: Option<u16> = matches
@@ -729,7 +730,8 @@ fn run() -> Result<(), failure::Error> {
         let target = manifest.get_target(env, is_preview)?;
         let user = settings::global_user::GlobalUser::new().ok();
         let verbose = matches.is_present("verbose");
-        commands::dev::dev(target, user, host, port, ip, verbose)?;
+        let env = env.map(|s| s.to_string());
+        commands::dev::dev(target, user, host, port, ip, verbose, env)?;
     } else if matches.subcommand_matches("whoami").is_some() {
         log::info!("Getting User settings");
         let user = settings::global_user::GlobalUser::new()?;
@@ -759,7 +761,8 @@ fn run() -> Result<(), failure::Error> {
 
         let verbose = matches.is_present("verbose");
 
-        commands::publish(&user, &mut target, deploy_config, verbose)?;
+        let env = env.map(|s| s.to_string());
+        commands::publish(&user, &mut target, deploy_config, verbose, env)?;
     } else if let Some(matches) = matches.subcommand_matches("subdomain") {
         log::info!("Getting project settings");
         let manifest = settings::toml::Manifest::new(config_path)?;

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -30,8 +30,9 @@ pub fn preview(
     user: Option<GlobalUser>,
     options: PreviewOpt,
     verbose: bool,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
-    build(&target)?;
+    build(&target, build_env.clone())?;
 
     let sites_preview: bool = target.site.is_some();
 
@@ -69,6 +70,7 @@ pub fn preview(
             verbose,
             options.headless,
             request_payload,
+            build_env,
         )?;
     } else {
         if !options.headless {
@@ -166,11 +168,12 @@ fn watch_for_changes(
     verbose: bool,
     headless: bool,
     request_payload: RequestPayload,
+    build_env: Option<String>,
 ) -> Result<(), failure::Error> {
     let sites_preview: bool = target.site.is_some();
 
     let (tx, rx) = channel();
-    watch_and_build(&target, Some(tx))?;
+    watch_and_build(&target, build_env, Some(tx))?;
 
     while rx.recv().is_ok() {
         if let Ok(new_id) = upload(&mut target, user, sites_preview, verbose) {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -25,6 +25,7 @@ const RUST_IGNORE: &[&str] = &["pkg", "target", "worker/generated"];
 // outputting a build event to tx.
 pub fn watch_and_build(
     target: &Target,
+    build_env: Option<String>,
     tx: Option<mpsc::Sender<()>>,
 ) -> Result<(), failure::Error> {
     let target_type = &target.target_type;
@@ -102,7 +103,7 @@ pub fn watch_and_build(
             });
         }
         TargetType::Webpack => {
-            wranglerjs::run_build_and_watch(target, tx)?;
+            wranglerjs::run_build_and_watch(target, build_env, tx)?;
         }
     }
 

--- a/wranglerjs/index.js
+++ b/wranglerjs/index.js
@@ -39,9 +39,11 @@ function filterByExtension(ext) {
     config = require(join(process.cwd(), args["webpack-config"]));
   }
 
+  const env = args["webpack-env"];
+
   // Check if the config is a function and await it either way in
   // case the result is a Promise
-  config = await (typeof config === "function" ? config({}) : config);
+  config = await (typeof config === "function" ? config(env) : config);
 
   if (Array.isArray(config)) {
     throw error(


### PR DESCRIPTION
Closes https://github.com/cloudflare/wrangler/issues/521

This change passes the first argument `env` when webpack exposes a
function to the env passed to wrangler.

The object form of webpack's env is not supported, `env` will always be
a single string.