### PR TITLE
Fix kv:namespace create --preview

### DIFF
--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -18,7 +18,10 @@ pub fn run(
     kv::validate_target(&target)?;
     validate_binding(binding)?;
 
-    let title = format!("{}-{}", target.name, binding);
+    let mut title = format!("{}-{}", target.name, binding);
+    if is_preview {
+        title.push_str("_preview");
+    }
     let msg = format!("Creating namespace with title \"{}\"", title);
     message::working(&msg);
 


### PR DESCRIPTION
we need to make different titles for preview namespaces on `kv:namespace create --preview` so they don't clash! should have caught this earlier, glad we dont need a point release. (this is why you test your documentation 😉 )