### PR TITLE
use bulk api client directly in bulk action code

### DIFF
--- a/src/commands/kv/bulk/mod.rs
+++ b/src/commands/kv/bulk/mod.rs
@@ -3,26 +3,3 @@ pub mod put;
 
 pub use delete::run as delete;
 pub use put::run as put;
-
-use std::time::Duration;
-
-use cloudflare::framework::auth::Credentials;
-use cloudflare::framework::{Environment, HttpApiClient, HttpApiClientConfig};
-
-use crate::http::feature::headers;
-use crate::settings::global_user::GlobalUser;
-
-// Create a special API client that has a longer timeout than usual, given that KV operations
-// can be lengthy if payloads are large.
-fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
-    let config = HttpApiClientConfig {
-        http_timeout: Duration::from_secs(5 * 60),
-        default_headers: headers(None),
-    };
-
-    HttpApiClient::new(
-        Credentials::from(user.to_owned()),
-        config,
-        Environment::Production,
-    )
-}

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -15,8 +15,6 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message;
 
-use super::bulk_api_client;
-
 pub fn run(
     target: &Target,
     user: &GlobalUser,
@@ -52,7 +50,6 @@ pub fn run(
         None
     };
 
-    let client = bulk_api_client(user)?;
     while !pairs.is_empty() {
         let p: Vec<KeyValuePair> = if pairs.len() > MAX_PAIRS {
             pairs.drain(0..MAX_PAIRS).collect()
@@ -60,7 +57,7 @@ pub fn run(
             pairs.drain(0..).collect()
         };
 
-        put(&client, target, namespace_id, &p)?;
+        put(target, &user, namespace_id, &p)?;
 
         if let Some(pb) = &progress_bar {
             pb.inc(p.len() as u64);


### PR DESCRIPTION
fixes a bug introduced in 1.10.0 that failed to extend the timeout for bulk operations during Site publishing.