### PR TITLE
allow kv_namespaces in toml

### DIFF
--- a/src/fixtures/wrangler_toml.rs
+++ b/src/fixtures/wrangler_toml.rs
@@ -36,7 +36,7 @@ pub struct EnvConfig {
     pub webpack_config: Option<&'static str>,
     pub private: Option<bool>,
     pub site: Option<SiteConfig>,
-    #[serde(rename = "kv-namespaces")]
+    #[serde(alias = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<KvConfig>>,
     pub vars: Option<HashMap<&'static str, &'static str>>,
 }
@@ -94,7 +94,7 @@ pub struct WranglerToml {
     pub webpack_config: Option<&'static str>,
     pub private: Option<bool>,
     pub env: Option<HashMap<&'static str, EnvConfig>>,
-    #[serde(rename = "kv-namespaces")]
+    #[serde(alias = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<KvConfig>>,
     pub site: Option<SiteConfig>,
     pub vars: Option<HashMap<&'static str, &'static str>>,

--- a/src/settings/toml/environment.rs
+++ b/src/settings/toml/environment.rs
@@ -21,7 +21,7 @@ pub struct Environment {
     pub webpack_config: Option<String>,
     pub private: Option<bool>,
     pub site: Option<Site>,
-    #[serde(rename = "kv-namespaces")]
+    #[serde(alias = "kv-namespaces")]
     pub kv_namespaces: Option<Vec<ConfigKvNamespace>>,
     pub vars: Option<HashMap<String, String>>,
 }


### PR DESCRIPTION
fixes #1408 -

```
when KV namespace support was initially added to Wrangler, we documented using `kv-namespaces` in `wrangler.toml`. Unfortunately, the `-` was not consistent with other fields such as `zone_id` and `account_id`, so the decision was made to allow both `kv-namespaces` and `kv_namespaces`. When this change was introduced, it worked with top level `kv_namespaces` entries, but not in environments. This is now fixed! You can now use `kv_namespaces` everywhere you can use `kv-namespaces`.
```