### PR TITLE
wip vendor cloudflared

### DIFF
--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,3 @@
 pub const WASM_PACK_VERSION: &str = "0.9.1";
 pub const GENERATE_VERSION: &str = "0.5.0";
+pub const CLOUDFLARED_VERSION: &str = "2020.6.6";

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -38,6 +38,14 @@ pub fn install_wasm_pack() -> Result<PathBuf, failure::Error> {
     install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
 }
 
+pub fn install_cloudflared() -> Result<PathBuf, failure::Error> {
+    let tool_name = "cloudflared";
+    let tool_author = "cloudflare";
+    let is_binary = true;
+    let version = Version::parse(dependencies::CLOUDFLARED_VERSION)?;
+    install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
+}
+
 pub fn install(
     tool_name: &str,
     owner: &str,

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -20,9 +20,7 @@ use session::Session;
 use shutdown::ShutdownHandler;
 use tunnel::Tunnel;
 
-use console::style;
 use tokio::runtime::Runtime as TokioRuntime;
-use which::which;
 
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
@@ -38,7 +36,6 @@ impl Tail {
         metrics_port: u16,
         verbose: bool,
     ) -> Result<(), failure::Error> {
-        is_cloudflared_installed()?;
         print_startup_message(&target.name, tunnel_port, metrics_port);
 
         let mut runtime = TokioRuntime::new()?;
@@ -85,18 +82,6 @@ impl Tail {
                 Err(e) => Err(e),
             }
         })
-    }
-}
-
-fn is_cloudflared_installed() -> Result<(), failure::Error> {
-    // this can be removed once we automatically install cloudflared
-    if which("cloudflared").is_err() {
-        let install_url = style("https://developers.cloudflare.com/argo-tunnel/downloads/")
-            .blue()
-            .bold();
-        failure::bail!("You must install cloudflared to use wrangler tail.\n\nInstallation instructions can be found here:\n{}", install_url);
-    } else {
-        Ok(())
     }
 }
 

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -6,6 +6,8 @@ use tokio::process::Child;
 use tokio::process::Command;
 use tokio::sync::oneshot::Receiver;
 
+use crate::install::install_cloudflared;
+
 pub struct Tunnel {
     child: Child,
 }
@@ -21,16 +23,13 @@ impl Tunnel {
         metrics_port: u16,
         verbose: bool,
     ) -> Result<Tunnel, failure::Error> {
-        let tool_name = PathBuf::from("cloudflared");
-        // TODO: Finally get cloudflared release binaries distributed on GitHub so we could
-        // simply uncomment the line below.
-        // let binary_path = install::install(tool_name, "cloudflare")?.binary(tool_name)?;
+        let binary_path = install_cloudflared()?;
 
         let tunnel_url = format!("localhost:{}", tunnel_port);
         let metrics_url = format!("localhost:{}", metrics_port);
         let args = ["tunnel", "--url", &tunnel_url, "--metrics", &metrics_url];
 
-        let mut command = command(&args, &tool_name, verbose);
+        let mut command = command(&args, &binary_path, verbose);
         let command_name = format!("{:?}", command);
 
         let child = command


### PR DESCRIPTION
very close - need to update lasso to not be so opinionated about install URLs, it's requesting https://workers.cloudflare.com/get-binary/cloudflare/cloudflared/v2020.6.6/x86_64-apple-darwin.tar.gz when it should remove the `v` from `v2020.6.6`.

also need to test how it works if you have a more recent version installed locally.

---

actually it seems like their github releases do not include macos versions yet ☹️ 