### PR TITLE
Fixes typo in error messages and code comments

### DIFF
--- a/src/commands/dev/server_config/mod.rs
+++ b/src/commands/dev/server_config/mod.rs
@@ -21,7 +21,7 @@ impl ServerConfig {
         let addr = format!("{}:{}", ip, port);
         let listening_address = match TcpListener::bind(&addr) {
             Ok(socket) => socket.local_addr(),
-            Err(_) => failure::bail!("{} is unavailble, try binding to another address with the --port and --ip flags, or stop other `wrangler dev` processes.", &addr)
+            Err(_) => failure::bail!("{} is unavailable, try binding to another address with the --port and --ip flags, or stop other `wrangler dev` processes.", &addr)
         }?;
         let host = host.unwrap_or("https://example.com").to_string();
 

--- a/src/deploy/route.rs
+++ b/src/deploy/route.rs
@@ -15,7 +15,7 @@ pub fn publish_routes(
 ) -> Result<Vec<RouteUploadResult>, failure::Error> {
     // For the moment, we'll just make this call once and make all our decisions based on the response.
     // There is a possibility of race conditions, but we just report back the results and allow the
-    // user to decide how to procede.
+    // user to decide how to proceed.
     let existing_routes = fetch_all(user, &zoned_config.zone_id)?;
 
     let deployed_routes = zoned_config

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -100,7 +100,7 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
                         continue;
                     }
 
-                    let output = fs::read_to_string(&temp_file).expect("could not retrieve ouput");
+                    let output = fs::read_to_string(&temp_file).expect("could not retrieve output");
                     let wranglerjs_output: WranglerjsOutput =
                         serde_json::from_str(&output).expect("could not parse wranglerjs output");
 

--- a/src/wranglerjs/output.rs
+++ b/src/wranglerjs/output.rs
@@ -12,7 +12,7 @@ use std::io::prelude::*;
 pub struct WranglerjsOutput {
     pub wasm: Option<String>,
     pub script: String,
-    // Errors emited by {wranglerjs}, if any
+    // Errors emitted by {wranglerjs}, if any
     pub errors: Vec<String>,
 }
 


### PR DESCRIPTION
- Fixes a typo when using wrangler dev without specifiying a port when default is already in use
- Fixes typos in some error messages and comments within the code

Signed-off-by: Sudheesh Singanamalla <sudheesh@cloudflare.com>