### PR TITLE
dont wasm-opt in test

### DIFF
--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -160,6 +160,9 @@ fn it_can_preview_rust_project() {
         [profile.release]
         # Tell `rustc` to optimize for small code size.
         opt-level = "s"
+
+        [package.metadata.wasm-pack.profile.release]
+        wasm-opt = false
     "#,
     );
 


### PR DESCRIPTION
should fix #1468 - wasm-opt gets run when you compile in release mode with wasm-pack by default. unfortuately it sometimes fails and is also just kinda slow... disabling it for our e2e test as we shouldnt be the ones testing wasm-opt functionality in the first place.