### PR TITLE
🔐1.11.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
+checksum = "caae68055714ff28740f310927e04f2eba76ff580b16fb18ed90073ee71646f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41194be16cf333d81c5c8cbc060d606f333f5fc9e2c44ad7315cb37fb6be2a87"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits 0.2.12",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.33+curl-7.71.1"
+version = "0.4.34+curl-7.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9818ea018327f79c811612f29b9834d2abddbe7db81460a2d5c7e12946b337"
+checksum = "ad4eff0be6985b7e709f64b5a541f700e9ad1407190a29f4884319eb663ed1d6"
 dependencies = [
  "cc",
  "libc",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
 name = "difference"
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
@@ -715,9 +715,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e500da2fab70bdc43f8f0e0b350a227f31c72311c56aba48f01d5cd62bb0345b"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
  "autocfg",
 ]
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1205,9 +1205,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -2148,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
  "libc",
@@ -2284,9 +2284,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2579,9 +2579,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
  "log 0.4.11",
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static",
 ]
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.11.0-rc.0"
+version = "1.11.0-rc.1"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.11.0-rc.0"
+version = "1.11.0-rc.1"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/README.md
+++ b/npm/README.md
@@ -88,9 +88,14 @@ $ wrangler publish
 
   Additionally, you can configure different [environments](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments).
 
+
+### 🔓 `login`
+
+  Authenticate Wrangler with your Cloudflare login. This will prompt you with a Cloudflare account login page and is the alternative to `wrangler config`.
+
 ### 🔧 `config`
 
-  Configure your global Cloudflare user. This is an interactive command that will prompt you for your API token:
+  Authenticate Wrangler with a Cloudflare API Token. This is an interactive command that will prompt you for your API token:
 
   ```bash
   wrangler config

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.11.0-rc.0",
+  "version": "1.11.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.11.0-rc.0",
+  "version": "1.11.0-rc.1",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
## What's changed?

Release Candidate 1 adds `wrangler login`, a new way to easily authenticate wrangler using your Cloudflare username and password. Just type `wrangler login`, follow the login process, and you'll be authenticated. Release Candidate 1 also adds extra features to `wrangler dev`. You can now change the protocol of the local server `wrangler dev` creates and how those requests are forwarded with the `--local-protocol` and `--upstream-protocol` arguments. For example, this is what it would look like if you wanted the local server to use https:
```console
$ wrangler dev --local-protocol=https
💁  JavaScript project found. Skipping unnecessary build!
💁  watching "./"
👂  Listening on https://127.0.0.1:8787
💁  Generated certificate is not verified, browsers will give a warning and curl will require `--insecure`
[2020-08-13 12:03:39] GET worker.ftc.workers.dev/ HTTP/1.1 200 OK
```

Finally the arguments for `wrangler dev` can now be set in your `wrangler.toml` under the `[dev]` section. All arguments other than host are valid.
```toml
name = "worker"
type = "javascript"
account_id = "acountidslkfdjskldfjslkdjfls"
workers_dev = true
route = ""
zone_id = "zoneidjalsdkfjlskd324svadvdf"

[dev]
ip="127.0.0.1"
port=8787
local_protocol="http"
upstream_protocol="https"
```

## Installation

```sh
npm i @cloudflare/wrangler@beta -g
```
## Creating a project

The documentation below assumes you have some familiarity with Wrangler and are already developing Workers. If this is not the case that is OK, come back after you've read through our [Quickstart](https://developers.cloudflare.com/workers/quickstart/) and have gotten up and running with Wrangler.

### Testing the new `wrangler dev`

If you're already familiar with `wrangler dev`, you'll know that it spins up a development server that you can use to test the functionality of your Worker. With this release, `wrangler dev` will now connect directly to an instance of the Cloudflare Workers runtime running on the same servers that your code runs on in production. This will enable you to use the Cache API and should eliminate any inconsistency between responses from `wrangler dev` and your production worker.

#### Behavior Changes

- `wrangler dev` will now treat the worker you're developing like it would when you run `wrangler publish`. This means you will need to specify `workers_dev` or `zone_id` and `route` in your project's configuration file before using `wrangler dev`.
- For workers running on your own domain, your development worker will only run on the `routes` specified in your configuration file. Lets say that in production you have a worker running on `example.com/*` and you want to start development of a new worker with a route `example.com/test`. In this scenario, when you run `wrangler dev`, and then `curl 127.0.0.1:8787` you will get a response from the worker currently running in production at the route `example.com/*`. If you want to test your preview worker, you will need to `curl 127.0.0.1:8787/test`. In this scenario, the request host in the Workers runtime would be https://example.com
- For workers running on workers.dev, the request host will be https://projectname.yoursubdomain.workers.dev
- You can now test your Worker's caching behavior with the Cache API
- You can now test your Worker with `event.request.cf` (no longer `undefined`)
- The `--host` flag is now only used when you are not an authenticated Cloudflare user

#### Feedback

We'd like to know if you notice any different behavior between requests made to a `wrangler dev` instance, and requests made after you publish your Worker. We want your experience with `wrangler dev` to match what you see in production. If you'd like to provide feedback on `wrangler dev`, you can comment on [this issue](https://github.com/cloudflare/wrangler/issues/1047) or file a new one! Just make sure to prefix your issue title with `[dev]`.