### PR TITLE
Add output option for wrangler publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,9 +1521,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "opaque-debug"
@@ -2977,6 +2977,7 @@ dependencies = [
  "log 0.4.11",
  "notify",
  "number_prefix 0.4.0",
+ "once_cell",
  "openssl",
  "percent-encoding 2.1.0",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ log = "0.4.11"
 notify = "4.0.15"
 number_prefix = "0.4.0"
 openssl = { version = "0.10.29", optional = true }
+once_cell = "1.4.1"
 percent-encoding = "2.1.0"
 predicates = "1.0.5"
 prettytable-rs = "0.8.0"

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -4,7 +4,7 @@ use clap::ArgMatches;
 
 use crate::build;
 use crate::settings::toml::Manifest;
-
+use crate::terminal;
 use super::DEFAULT_CONFIG_PATH;
 
 pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
@@ -14,5 +14,16 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
     let manifest = Manifest::new(&config_path)?;
     let env = matches.value_of("env");
     let target = &manifest.get_target(env, false)?;
+    if matches.is_present("output") {
+        if matches.value_of("output") == Some("json") {
+            terminal::message::set_output_type(terminal::message::OutputType::Json)
+        }
+        else {
+            terminal::message::user_error("json is the only valid value for output flag");
+        }
+    }
+    else {
+        terminal::message::set_output_type(terminal::message::OutputType::Human)
+    }
     build(&target)
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -17,8 +17,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
     if matches.is_present("output") {
         if matches.value_of("output") == Some("json") {
             terminal::message::set_output_type(terminal::message::OutputType::Json)
-        }
-        else {
+        } else {
             terminal::message::user_error("json is the only valid value for output flag");
         }
         let result = build(&target);
@@ -26,14 +25,13 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
             name: Some(target.name.clone()),
             success: match result {
                 Ok(_) => Some("true".to_string()),
-                Err(_) => Some("false".to_string())
+                Err(_) => Some("false".to_string()),
             },
             url: None,
         };
         terminal::message::jsonout(&jsonoutput);
         result
-    }
-    else {
+    } else {
         terminal::message::set_output_type(terminal::message::OutputType::Human);
         build(&target)
     }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -14,12 +14,8 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
     let manifest = Manifest::new(&config_path)?;
     let env = matches.value_of("env");
     let target = &manifest.get_target(env, false)?;
-    if matches.is_present("output") {
-        if matches.value_of("output") == Some("json") {
-            terminal::message::set_output_type(terminal::message::OutputType::Json)
-        } else {
-            terminal::message::user_error("json is the only valid value for output flag");
-        }
+    if matches.is_present("output") && matches.value_of("output") == Some("json") {
+        terminal::message::set_output_type(terminal::message::OutputType::Json);
         let result = build(&target);
         let jsonoutput = terminal::message::PublishOutput {
             name: Some(target.name.clone()),

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -21,9 +21,20 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
         else {
             terminal::message::user_error("json is the only valid value for output flag");
         }
+        let result = build(&target);
+        let jsonoutput = terminal::message::PublishOutput {
+            name: Some(target.name.clone()),
+            success: match result {
+                Ok(_) => Some("true".to_string()),
+                Err(_) => Some("false".to_string())
+            },
+            url: None,
+        };
+        terminal::message::jsonout(&jsonoutput);
+        result
     }
     else {
-        terminal::message::set_output_type(terminal::message::OutputType::Human)
+        terminal::message::set_output_type(terminal::message::OutputType::Human);
+        build(&target)
     }
-    build(&target)
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -24,10 +24,10 @@ pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
         let jsonoutput = terminal::message::PublishOutput {
             name: Some(target.name.clone()),
             success: match result {
-                Ok(_) => Some("true".to_string()),
-                Err(_) => Some("false".to_string()),
+                Ok(_) => Some(true),
+                Err(_) => Some(false),
             },
-            url: None,
+            urls: Vec::new(),
         };
         terminal::message::jsonout(&jsonoutput);
         result

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use clap::ArgMatches;
 
+use super::DEFAULT_CONFIG_PATH;
 use crate::build;
 use crate::settings::toml::Manifest;
 use crate::terminal;
-use super::DEFAULT_CONFIG_PATH;
 
 pub fn run(matches: &ArgMatches) -> Result<(), failure::Error> {
     log::info!("Getting project settings");

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -67,7 +67,7 @@ pub fn publish(
                 name: Some(target.name.clone()),
                 success: match result {
                     Ok(_) => Some(true),
-                    Err(_) => Some(true),
+                    Err(_) => Some(false),
                 },
                 urls: Vec::new(),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,6 +565,13 @@ fn run() -> Result<(), failure::Error> {
                         .long("release")
                         .takes_value(false)
                         .help("[deprecated] alias of wrangler publish")
+                )
+                .arg(
+                    Arg::with_name("output")
+                    .short("o")
+                    .long("output")
+                    .takes_value(true)
+                    .help("Machine or human readable output")
                 ),
         )
         .subcommand(
@@ -861,7 +868,15 @@ fn run() -> Result<(), failure::Error> {
         let env = matches.value_of("env");
         let mut target = manifest.get_target(env, is_preview)?;
         let deploy_config = manifest.deploy_config(env)?;
-
+        if matches.is_present("output") {
+            if matches.value_of("output") == Some("json") {
+                message::set_output_type(message::OutputType::Json)
+            } else {
+                message::user_error("json is the only valid value for output flag");
+            }
+        } else {
+            message::set_output_type(message::OutputType::Human);
+        }
         commands::publish(&user, &mut target, deploy_config)?;
     } else if let Some(matches) = matches.subcommand_matches("subdomain") {
         log::info!("Getting project settings");

--- a/src/main.rs
+++ b/src/main.rs
@@ -445,7 +445,7 @@ fn run() -> Result<(), failure::Error> {
                     .short("o")
                     .long("output")
                     .takes_value(true)
-                    .help("Machine or human readable output")
+                    .possible_value("json")
                 )
                 .arg(wrangler_file.clone())
                 .arg(silent_verbose_arg.clone()),
@@ -571,7 +571,7 @@ fn run() -> Result<(), failure::Error> {
                     .short("o")
                     .long("output")
                     .takes_value(true)
-                    .help("Machine or human readable output")
+                    .possible_value("json")
                 ),
         )
         .subcommand(
@@ -868,12 +868,8 @@ fn run() -> Result<(), failure::Error> {
         let env = matches.value_of("env");
         let mut target = manifest.get_target(env, is_preview)?;
         let deploy_config = manifest.deploy_config(env)?;
-        if matches.is_present("output") {
-            if matches.value_of("output") == Some("json") {
-                message::set_output_type(message::OutputType::Json)
-            } else {
-                message::user_error("json is the only valid value for output flag");
-            }
+        if matches.is_present("output") && matches.value_of("output") == Some("json") {
+            message::set_output_type(message::OutputType::Json)
         } else {
             message::set_output_type(message::OutputType::Human);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,6 +440,13 @@ fn run() -> Result<(), failure::Error> {
                         .long("env")
                         .takes_value(true)
                 )
+                .arg(
+                    Arg::with_name("output")
+                    .short("o")
+                    .long("output")
+                    .takes_value(true)
+                    .help("Machine or human readable output")
+                )
                 .arg(wrangler_file.clone())
                 .arg(silent_verbose_arg.clone()),
         )

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -1,9 +1,33 @@
 use super::emoji;
+use once_cell::sync::OnceCell;
 
 use billboard::{Billboard, BorderColor, BorderStyle};
 
+pub enum OutputType {
+    Json,
+    Human
+}
+
+static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
+
+pub fn set_output_type(typ: OutputType) {
+    OUTPUT_TYPE.set(typ);
+}
+
 fn message(msg: &str) {
-    println!("{}", msg);
+    match OUTPUT_TYPE.get() {
+        Some(OutputType::Json) => {
+            println!("json");
+            eprintln!("{}", msg);
+        }
+        Some(OutputType::Human) => {
+            println!("human");
+            println!("{}", msg);
+        }
+        _ => {
+            panic!("output not defined")
+        }
+    }
 }
 
 pub fn billboard(msg: &str) {

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -21,12 +21,7 @@ pub struct PublishOutput {
 static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
 
 pub fn set_output_type(typ: OutputType) {
-    match OUTPUT_TYPE.set(typ) {
-        Ok(_) => {}
-        Err(_) => {
-            message(&"Output type already set".to_string());
-        }
-    }
+    let _ = OUTPUT_TYPE.set(typ);
 }
 
 pub fn is_json_output() -> bool {

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -4,6 +4,7 @@ use once_cell::sync::OnceCell;
 use billboard::{Billboard, BorderColor, BorderStyle};
 use serde::{Deserialize, Serialize};
 
+#[derive(PartialEq)]
 pub enum OutputType {
     Json,
     Human,
@@ -11,10 +12,10 @@ pub enum OutputType {
 
 #[derive(Serialize, Deserialize)]
 pub struct PublishOutput {
-    pub success: Option<String>,
+    pub success: Option<bool>,
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub urls: Vec<String>,
 }
 
 static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
@@ -26,6 +27,10 @@ pub fn set_output_type(typ: OutputType) {
             message(&"Output type already set".to_string());
         }
     }
+}
+
+pub fn is_json_output() -> bool {
+    OUTPUT_TYPE.get() == Some(&OutputType::Json)
 }
 
 // Always goes to stdout

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -39,7 +39,7 @@ where
 fn message(msg: &str) {
     match OUTPUT_TYPE.get() {
         Some(OutputType::Json) => {
-            eprintln!("{}", msg);
+            log::info!("{}", msg);
         }
         _ => {
             println!("{}", msg);

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -20,7 +20,13 @@ pub struct PublishOutput {
 static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
 
 pub fn set_output_type(typ: OutputType) {
-    OUTPUT_TYPE.set(typ);
+    match OUTPUT_TYPE.set(typ) {
+        Ok(_) => {}
+        Err(_) => {
+            let msg = format!("Output type already set");
+            message(&msg);
+        }
+    }
 }
 
 // Always goes to stdout

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -6,15 +6,15 @@ use serde::{Deserialize, Serialize};
 
 pub enum OutputType {
     Json,
-    Human
+    Human,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct PublishOutput {
-    pub success : Option<String>,
-    pub name : Option<String>,
+    pub success: Option<String>,
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url : Option<String>,
+    pub url: Option<String>,
 }
 
 static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
@@ -26,8 +26,9 @@ pub fn set_output_type(typ: OutputType) {
 // Always goes to stdout
 pub fn jsonout<T>(value: &T)
 where
-    T: ?Sized + Serialize, {
-        println!("{}", &serde_json::to_string(value).unwrap());
+    T: ?Sized + Serialize,
+{
+    println!("{}", &serde_json::to_string(value).unwrap());
 }
 
 fn message(msg: &str) {
@@ -38,9 +39,7 @@ fn message(msg: &str) {
         Some(OutputType::Human) => {
             println!("{}", msg);
         }
-        _ => {
-            panic!("output not defined")
-        }
+        _ => panic!("output not defined"),
     }
 }
 

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -23,8 +23,7 @@ pub fn set_output_type(typ: OutputType) {
     match OUTPUT_TYPE.set(typ) {
         Ok(_) => {}
         Err(_) => {
-            let msg = format!("Output type already set");
-            message(&msg);
+            message(&"Output type already set".to_string());
         }
     }
 }

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -2,10 +2,19 @@ use super::emoji;
 use once_cell::sync::OnceCell;
 
 use billboard::{Billboard, BorderColor, BorderStyle};
+use serde::{Deserialize, Serialize};
 
 pub enum OutputType {
     Json,
     Human
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublishOutput {
+    pub success : Option<String>,
+    pub name : Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url : Option<String>,
 }
 
 static OUTPUT_TYPE: OnceCell<OutputType> = OnceCell::new();
@@ -14,14 +23,19 @@ pub fn set_output_type(typ: OutputType) {
     OUTPUT_TYPE.set(typ);
 }
 
+// Always goes to stdout
+pub fn jsonout<T>(value: &T)
+where
+    T: ?Sized + Serialize, {
+        println!("{}", &serde_json::to_string(value).unwrap());
+}
+
 fn message(msg: &str) {
     match OUTPUT_TYPE.get() {
         Some(OutputType::Json) => {
-            println!("json");
             eprintln!("{}", msg);
         }
         Some(OutputType::Human) => {
-            println!("human");
             println!("{}", msg);
         }
         _ => {

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -41,10 +41,9 @@ fn message(msg: &str) {
         Some(OutputType::Json) => {
             eprintln!("{}", msg);
         }
-        Some(OutputType::Human) => {
+        _ => {
             println!("{}", msg);
         }
-        _ => panic!("output not defined"),
     }
 }
 


### PR DESCRIPTION
`wrangler build | publish --output json`

Wrangler supports structured output for core commands `build` and `publish`. `JSON` string goes to stdout, stderr displays user output.

js
```
nat@cf:~/examplejs$wrangler build
💁  JavaScript project found. Skipping unnecessary build!
nat@cf:~/examplejs$wrangler build --output json
{"success":true,"name":"examplejs"}
nat@davidson:~/examplejs$ ../wrangler/target/debug/wrangler publish --output json

```
^ No output. Confused why that is happening as the logic to create structured output in the publish path should be the same regardless of project type.
Webpack `build` and `publish`
```
nat@davidson:~/demo-site$ ../wrangler/target/debug/wrangler build --output json
{"success":true,"name":"demo-site"}
nat@davidson:~/demo-site$ ../wrangler/target/debug/wrangler publish --output json
{"success":true,"name":"demo-site","urls":["https://demo-site.nats.workers.dev"]}

```

I'm unfamiliar with assert_cmd and will ramp up on that to make some solid tests.