### PR TITLE
Made stderr from browser process to /dev/null

### DIFF
--- a/src/terminal/browser.rs
+++ b/src/terminal/browser.rs
@@ -7,6 +7,7 @@ pub fn open_browser(url: &str) -> Result<(), failure::Error> {
         Command::new("cmd")
             .args(&["/C", &windows_cmd])
             .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()?;
     } else if cfg!(target_os = "linux") {
         let linux_cmd = format!(r#"xdg-open "{}""#, url);
@@ -14,6 +15,7 @@ pub fn open_browser(url: &str) -> Result<(), failure::Error> {
             .arg("-c")
             .arg(&linux_cmd)
             .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()?;
     } else {
         let mac_cmd = format!(r#"open "{}""#, url);
@@ -21,6 +23,7 @@ pub fn open_browser(url: &str) -> Result<(), failure::Error> {
             .arg("-c")
             .arg(&mac_cmd)
             .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()?;
     };
 


### PR DESCRIPTION
Just realized that this might make users get a bunch of random output in their terminal. Probably should be put in a point release