### PR TITLE
Update bug report template link to "update CLI" docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,10 @@
 ---
-name: 🐛 Bug report
+name: "\U0001F41B Bug report"
 about: Something's not quite right? You're in the right place!
+title: ''
 labels: user report
+assignees: ''
+
 ---
 
 ### 🐛 Bug Report
@@ -11,7 +14,7 @@ labels: user report
 
   Before opening a new issue, please:
   * search for existing issues: https://github.com/cloudflare/wrangler/issues
-  * make sure you are using the latest release: https://workers.cloudflare.com/docs/quickstart/updating-the-cli/
+  * make sure you are using the latest release: https://developers.cloudflare.com/workers/cli-wrangler/install-update#update
   
   Thanks! -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,10 @@
 ---
-name: 💡 Feature request
+name: "\U0001F4A1 Feature request"
 about: Suggest a feature for wrangler
+title: ''
 labels: user report
+assignees: ''
+
 ---
 
 ### 💡 Feature request


### PR DESCRIPTION
In #1517 , @jasoncoombs points out that the link in our bug report template to the "update your CLI" instructions now 404s, after the recent docs updates.

I only intended to update the link, but when I used the UI-based workflow to update templates, it also proposed the other included changes.  🤷 