### PR TITLE
🐛  Fix broken hyperlink 🔗  to the update doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you don't have `cargo` or `npm` installed, you will need to follow these [add
 
 ## Updating
 
-For information regarding updating Wrangler, click [here](https://workers.cloudflare.com/docs/quickstart/updating-the-cli/).
+For information regarding updating Wrangler, click [here](https://developers.cloudflare.com/workers/cli-wrangler/install-update#update).
 
 ## Getting Started
 


### PR DESCRIPTION
### Summary

Currently, the link to the wrangler CLI update docs points to a broken page in README as shown in the GIF below.

![broken-link-demo min](https://user-images.githubusercontent.com/5674762/91332663-412d3000-e7ec-11ea-8458-336e41c5ce9a.gif)

This PR fixes that.