### PR TITLE
Structured output for `publish` happy path

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,5 +1,5 @@
 use crate::settings::toml::{Target, TargetType};
-use crate::terminal::message::{Message, StdOut};
+use crate::terminal::message::{Message, StdErr};
 use crate::terminal::styles;
 use crate::wranglerjs;
 use crate::{commands, install};
@@ -49,7 +49,7 @@ pub fn build_target(target: &Target) -> Result<String, failure::Error> {
 }
 
 pub fn command(args: &[&str], binary_path: &PathBuf) -> Command {
-    StdOut::working("Compiling your project to WebAssembly...");
+    StdErr::working("Compiling your project to WebAssembly...");
 
     let mut c = if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -13,7 +13,7 @@ use crate::kv::bulk::put;
 use crate::kv::bulk::BATCH_KEY_MAX;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
-use crate::terminal::message::{Message, StdOut};
+use crate::terminal::message::{Message, StdErr};
 pub fn run(
     target: &Target,
     user: &GlobalUser,
@@ -40,7 +40,7 @@ pub fn run(
 
     let len = pairs.len();
 
-    StdOut::working(&format!("uploading {} key value pairs", len));
+    StdErr::working(&format!("uploading {} key value pairs", len));
     let progress_bar = if len > BATCH_KEY_MAX {
         let pb = ProgressBar::new(len as u64);
         pb.set_style(ProgressStyle::default_bar().template("{wide_bar} {pos}/{len}\n{msg}"));
@@ -55,6 +55,6 @@ pub fn run(
         pb.finish_with_message(&format!("uploaded {} key value pairs", len));
     }
 
-    StdOut::success("Success");
+    StdErr::success("Success");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -559,6 +559,13 @@ fn run() -> Result<(), failure::Error> {
                         .long("release")
                         .takes_value(false)
                         .help("[deprecated] alias of wrangler publish")
+                )
+                .arg(
+                    Arg::with_name("output")
+                    .short("o")
+                    .long("output")
+                    .takes_value(true)
+                    .possible_value("json")
                 ),
         )
         .subcommand(
@@ -855,8 +862,9 @@ fn run() -> Result<(), failure::Error> {
         let env = matches.value_of("env");
         let mut target = manifest.get_target(env, is_preview)?;
         let deploy_config = manifest.deploy_config(env)?;
-
-        commands::publish(&user, &mut target, deploy_config)?;
+        let output_option =
+            matches.is_present("output") && matches.value_of("output") == Some("json");
+        commands::publish(&user, &mut target, deploy_config, output_option)?;
     } else if let Some(matches) = matches.subcommand_matches("subdomain") {
         log::info!("Getting project settings");
         let config_path = Path::new(

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -22,7 +22,7 @@ use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 use crate::kv::namespace::{upsert, UpsertedNamespace};
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::{KvNamespace, Target};
-use crate::terminal::message::{Message, StdOut};
+use crate::terminal::message::{Message, StdErr};
 pub const KEY_MAX_SIZE: usize = 512;
 // Oddly enough, metadata.len() returns a u64, not usize.
 pub const VALUE_MAX_SIZE: u64 = 10 * 1024 * 1024;
@@ -42,13 +42,13 @@ pub fn add_namespace(
     let site_namespace = match upsert(target, &user, title)? {
         UpsertedNamespace::Created(namespace) => {
             let msg = format!("Created namespace for Workers Site \"{}\"", namespace.title);
-            StdOut::working(&msg);
+            StdErr::working(&msg);
 
             namespace
         }
         UpsertedNamespace::Reused(namespace) => {
             let msg = format!("Using namespace for Workers Site \"{}\"", namespace.title);
-            StdOut::working(&msg);
+            StdErr::working(&msg);
 
             namespace
         }

--- a/src/sites/sync.rs
+++ b/src/sites/sync.rs
@@ -10,7 +10,7 @@ use crate::http;
 use crate::kv::key::KeyList;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
-use crate::terminal::message::{Message, StdOut};
+use crate::terminal::message::{Message, StdErr};
 
 pub fn sync(
     target: &Target,
@@ -57,7 +57,7 @@ pub fn sync(
         .map(|key| key.to_owned())
         .collect();
 
-    StdOut::success("Success");
+    StdErr::success("Success");
     Ok((to_upload, to_delete, asset_manifest))
 }
 

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -1,6 +1,7 @@
 use super::emoji;
 
 use billboard::{Billboard, BorderColor, BorderStyle};
+use serde::Serialize;
 
 pub trait Message {
     fn message(msg: &str);
@@ -42,6 +43,9 @@ pub trait Message {
 
     fn billboard(msg: &str);
     fn deprecation_warning(msg: &str);
+    fn json_out<T>(value: &T)
+    where
+        T: ?Sized + Serialize;
 }
 
 pub struct StdOut;
@@ -68,6 +72,13 @@ impl Message for StdOut {
             .build();
         bb.display(msg);
     }
+
+    fn json_out<T>(value: &T)
+    where
+        T: ?Sized + Serialize,
+    {
+        println!("{}", &serde_json::to_string(value).unwrap());
+    }
 }
 
 pub struct StdErr;
@@ -83,5 +94,11 @@ impl Message for StdErr {
 
     fn deprecation_warning(_msg: &str) {
         panic!("Can't display billboard warning to stderr.")
+    }
+    fn json_out<T>(_value: &T)
+    where
+        T: ?Sized + Serialize,
+    {
+        panic!("Json output intended for stdout, not stderr.")
     }
 }

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -23,7 +23,7 @@ use semver::Version;
 
 use crate::install;
 use crate::settings::toml::Target;
-use crate::terminal::message::{Message, StdOut};
+use crate::terminal::message::{Message, StdErr, StdOut};
 use crate::upload::package::Package;
 use crate::watch::{wait_for_changes, COOLDOWN_PERIOD};
 
@@ -126,7 +126,7 @@ fn write_wranglerjs_output(
     custom_webpack: bool,
 ) -> Result<(), failure::Error> {
     if output.has_errors() {
-        StdOut::user_error(output.get_errors().as_str());
+        StdErr::user_error(output.get_errors().as_str());
         if custom_webpack {
             failure::bail!(
             "webpack returned an error. Try configuring `entry` in your webpack config relative to the current working directory, or setting `context = __dirname` in your webpack config."


### PR DESCRIPTION
Previous behavior = new behavior without flag :
```
nat@davidson:~/demo-site$ wrangler publish > output
✨  Built successfully, built project size is 13 KiB.
🌀  Using namespace for Workers Site "__demo-site-workers_sites_assets"
✨  Success
🌀  Uploading site files
nat@davidson:~/demo-site$ cat output
✨  Successfully published your script to https://demo-site.nats.workers.dev
```
New behavior with flag:
```
nat@davidson:~/demo-site$ wrangler publish -o json > output
✨  Built successfully, built project size is 13 KiB.
🌀  Using namespace for Workers Site "__demo-site-workers_sites_assets"
✨  Success
🌀  Uploading site files
✨  Successfully published your script to https://demo-site.nats.workers.dev
nat@davidson:~/demo-site$ cat output
{"success":true,"name":"demo-site","urls":["https://demo-site.nats.workers.dev"]}

```