### PR TITLE
Fix the link to the update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you don't have `cargo` or `npm` installed, you will need to follow these [add
 
 ## Updating
 
-For information regarding updating Wrangler, click [here](https://workers.cloudflare.com/docs/quickstart/updating-the-cli/).
+For information regarding updating Wrangler, click [here](https://developers.cloudflare.com/workers/cli-wrangler/install-update).
 
 ## Getting Started
 


### PR DESCRIPTION
The old URL now triggers an error page.