### PR TITLE
Route requests to subdomains on zone

### DIFF
--- a/src/commands/dev/edge/server/http.rs
+++ b/src/commands/dev/edge/server/http.rs
@@ -44,27 +44,39 @@ pub async fn http(
                 let req_method = parts.method.to_string();
                 let now: DateTime<Local> = Local::now();
                 let path = get_path_as_str(&parts.uri);
+                let mut full_host = host;
+                if let Some(host) = parts.uri.host() {
+                    if let Some(last_dot) = host.rfind('.') {
+                        full_host.insert_str(0, &host[..=last_dot]);
+                    }
+                } else {
+                    println!(
+                        "Request has no host header. Going to use base host {}",
+                        full_host
+                    );
+                }
                 async move {
                     let mut resp = preview_request(
                         Request::from_parts(parts, body),
                         client,
                         preview_token.to_owned(),
-                        host.clone(),
+                        full_host.clone(),
                         upstream_protocol,
                     )
                     .await?;
 
-                    rewrite_redirect(&mut resp, &host, &local_host, false);
+                    rewrite_redirect(&mut resp, &full_host, &local_host, false);
 
                     println!(
                         "[{}] {} {}{} {:?} {}",
                         now.format("%Y-%m-%d %H:%M:%S"),
                         req_method,
-                        host,
+                        full_host,
                         path,
                         version,
                         resp.status()
                     );
+
                     Ok::<_, failure::Error>(resp)
                 }
             }))


### PR DESCRIPTION
closes #1546 #1529

wrangler now preserves subdomain/s when rewriting requests for `wrangler dev`. 
If you have a worker at foo.example.com, requests to foo.localhost now hit that worker instead of example.com. If you are making requests to wrangler dev outside of the browser, you will need to resolve the subdomain.localhost host by adding it to your local /etc/hosts. IE 
```
127.0.0.1 foo.localhost
::1 foo.localhost
```