### PR TITLE
Module upload format + custom build commands + durable object support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +371,19 @@ dependencies = [
  "slog-term",
  "sloggers",
  "url",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
 ]
 
 [[package]]
@@ -699,6 +718,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -2770,6 +2795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
+dependencies = [
+ "chrono",
+ "combine",
+ "linked-hash-map 0.5.4",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +3020,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
@@ -3221,6 +3272,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite",
  "toml",
+ "toml_edit",
  "twox-hash",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tokio-native-tls = "0.1.0"
 tokio-rustls = "0.14.1"
 tokio-tungstenite = { version = "0.11.0", features = ["tls"] }
 toml = "0.5.8"
+toml_edit = "0.2.0"
 twox-hash = "1.6.0"
 url = "2.2.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -125,6 +125,7 @@ mod tests {
             site: None,
             vars: None,
             text_blobs: None,
+            build: None,
         };
         assert!(kv::get_namespace_id(&target_with_dup_kv_bindings, "").is_err());
     }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -72,6 +72,12 @@ pub fn publish(
         }
         Err(e) => Err(e),
     }?;
+
+    // We verify early here, so we don't perform pre-upload tasks if the upload will fail
+    if let Some(build_config) = &target.build {
+        build_config.verify_upload_dir()?;
+    }
+
     if let Some(site_config) = &target.site {
         let path = &site_config.bucket.clone();
         validate_bucket_location(path)?;

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -17,13 +17,13 @@ use log::info;
 use url::Url;
 use ws::{Sender, WebSocket};
 
-use crate::build::build_target;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message::{Message, StdOut};
 use crate::terminal::open_browser;
 use crate::watch::watch_and_build;
+use crate::{build::build_target, settings::toml::ScriptFormat};
 
 pub fn preview(
     mut target: Target,
@@ -31,6 +31,11 @@ pub fn preview(
     options: PreviewOpt,
     verbose: bool,
 ) -> Result<(), failure::Error> {
+    if let Some(build) = &target.build {
+        if matches!(build.upload_format, ScriptFormat::Modules) {
+            failure::bail!("wrangler preview does not support previewing modules scripts. Please use wrangler dev instead.");
+        }
+    }
     build_target(&target)?;
 
     let sites_preview: bool = target.site.is_some();

--- a/src/settings/metadata.rs
+++ b/src/settings/metadata.rs
@@ -1,9 +1,0 @@
-use serde::Serialize;
-
-use crate::settings::binding::Binding;
-
-#[derive(Serialize, Debug)]
-pub struct Metadata {
-    pub body_part: String,
-    pub bindings: Vec<Binding>,
-}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -2,7 +2,6 @@ pub mod binding;
 mod environment;
 mod global_config;
 pub mod global_user;
-pub mod metadata;
 pub mod toml;
 
 pub use environment::{Environment, QueryEnvironment};

--- a/src/settings/toml/builder.rs
+++ b/src/settings/toml/builder.rs
@@ -18,6 +18,8 @@ pub struct Builder {
     #[serde(default = "upload_dir")]
     pub upload_dir: PathBuf,
     pub upload_format: ScriptFormat,
+    pub upload_include: Option<Vec<String>>,
+    pub upload_exclude: Option<Vec<String>>,
     #[serde(default = "watch_dir")]
     pub watch_dir: PathBuf,
 }

--- a/src/settings/toml/builder.rs
+++ b/src/settings/toml/builder.rs
@@ -1,0 +1,113 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use super::ScriptFormat;
+
+const UPLOAD_DIR: &str = "dist";
+const WATCH_DIR: &str = "src";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Builder {
+    command: Option<String>,
+    #[serde(default = "project_root")]
+    pub cwd: PathBuf,
+    #[serde(default = "upload_dir")]
+    pub upload_dir: PathBuf,
+    pub upload_format: ScriptFormat,
+    #[serde(default = "watch_dir")]
+    pub watch_dir: PathBuf,
+}
+
+fn project_root() -> PathBuf {
+    env::current_dir().unwrap()
+}
+
+fn upload_dir() -> PathBuf {
+    project_root().join(UPLOAD_DIR)
+}
+
+fn watch_dir() -> PathBuf {
+    project_root().join(WATCH_DIR)
+}
+
+impl Builder {
+    pub fn verify_watch_dir(&self) -> Result<(), failure::Error> {
+        let watch_canonical = match self.watch_dir.canonicalize() {
+            Ok(path) => path,
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => failure::bail!(
+                "Your provided watch_dir {} does not exist.",
+                self.watch_dir.display()
+            ),
+            Err(e) => failure::bail!(
+                "Error encountered when verifying watch_dir: {}, provided path: {}",
+                e,
+                self.watch_dir.display()
+            ),
+        };
+        let root_canonical = project_root().canonicalize()?;
+        if watch_canonical == root_canonical {
+            failure::bail!("Wrangler doesn't support using the project root as the watch_dir.");
+        }
+        if !self.watch_dir.is_dir() {
+            failure::bail!(format!(
+                "A path was provided for watch_dir that is not a directory: {}",
+                self.watch_dir.display()
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn verify_upload_dir(&self) -> Result<(), failure::Error> {
+        let upload_canonical = match self.upload_dir.canonicalize() {
+            Ok(path) => path,
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => failure::bail!(
+                "Your provided upload_dir {} does not exist.",
+                self.upload_dir.display()
+            ),
+            Err(e) => failure::bail!(
+                "Error encountered when verifying upload_dir: {}, provided path: {}",
+                e,
+                self.upload_dir.display()
+            ),
+        };
+        let root_canonical = project_root().canonicalize()?;
+        if upload_canonical == root_canonical {
+            failure::bail!("Wrangler doesn't support using the project root as the upload_dir.");
+        }
+        if !self.upload_dir.is_dir() {
+            failure::bail!(format!(
+                "A path was provided for upload_dir that is not a directory: {}",
+                self.upload_dir.display()
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn build_command(&self) -> Option<(&str, Command)> {
+        match &self.command {
+            Some(cmd) => {
+                let mut c = if cfg!(target_os = "windows") {
+                    let args: Vec<&str> = cmd.split_whitespace().collect();
+                    let mut c = Command::new("cmd");
+                    c.arg("/C");
+                    c.args(args.as_slice());
+                    c
+                } else {
+                    let mut c = Command::new("sh");
+                    c.arg("-c");
+                    c.arg(cmd);
+                    c
+                };
+
+                c.current_dir(&self.cwd);
+
+                Some((cmd, c))
+            }
+            None => None,
+        }
+    }
+}

--- a/src/settings/toml/environment.rs
+++ b/src/settings/toml/environment.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_with::rust::string_empty_as_none;
 
+use crate::settings::toml::builder::Builder;
 use crate::settings::toml::kv_namespace::ConfigKvNamespace;
 use crate::settings::toml::route::RouteConfig;
 use crate::settings::toml::site::Site;
@@ -21,6 +22,7 @@ pub struct Environment {
     #[serde(default, with = "string_empty_as_none")]
     pub zone_id: Option<String>,
     pub webpack_config: Option<String>,
+    pub build: Option<Builder>,
     pub private: Option<bool>,
     pub site: Option<Site>,
     #[serde(alias = "kv-namespaces")]

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -11,6 +11,7 @@ use serde_with::rust::string_empty_as_none;
 
 use crate::commands::{validate_worker_name, DEFAULT_CONFIG_PATH};
 use crate::deploy::{self, DeployTarget, DeploymentSet};
+use crate::settings::toml::builder::Builder;
 use crate::settings::toml::dev::Dev;
 use crate::settings::toml::environment::Environment;
 use crate::settings::toml::kv_namespace::{ConfigKvNamespace, KvNamespace};
@@ -40,6 +41,7 @@ pub struct Manifest {
     #[serde(default, with = "string_empty_as_none")]
     pub zone_id: Option<String>,
     pub webpack_config: Option<String>,
+    pub build: Option<Builder>,
     pub private: Option<bool>,
     // TODO: maybe one day, serde toml support will allow us to serialize sites
     // as a TOML inline table (this would prevent confusion with environments too!)
@@ -290,6 +292,7 @@ impl Manifest {
             target_type,                                 // Top level
             account_id: self.account_id.clone(),         // Inherited
             webpack_config: self.webpack_config.clone(), // Inherited
+            build: self.build.clone(),                   // Inherited
             // importantly, the top level name will be modified
             // to include the name of the environment
             name: self.name.clone(), // Inherited
@@ -308,6 +311,9 @@ impl Manifest {
             }
             if let Some(webpack_config) = &environment.webpack_config {
                 target.webpack_config = Some(webpack_config.clone());
+            }
+            if let Some(build) = &environment.build {
+                target.build = Some(build.clone());
             }
 
             // don't inherit kv namespaces because it is an anti-pattern to use the same namespaces across multiple environments

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -87,60 +87,91 @@ impl Manifest {
         config_path: &PathBuf,
         site: Option<Site>,
     ) -> Result<Manifest, failure::Error> {
-        let config_file = config_path.join("wrangler.toml");
-        let template_config_content = fs::read_to_string(&config_file);
-        let template_config = match &template_config_content {
-            Ok(content) => {
-                let config: Manifest = toml::from_str(content)?;
-                config.warn_on_account_info();
-                if let Some(target_type) = &target_type {
-                    if config.target_type != *target_type {
-                        StdOut::warn(&format!("The template recommends the \"{}\" type. Using type \"{}\" may cause errors, we recommend changing the type field in wrangler.toml to \"{}\"", config.target_type, target_type, config.target_type));
-                    }
-                }
-                Ok(config)
-            }
-            Err(err) => Err(err),
-        };
-        let mut template_config = match template_config {
-            Ok(config) => config,
-            Err(err) => {
-                log::info!("Error parsing template {}", err);
-                log::debug!("template content {:?}", template_config_content);
+        let config_file = &config_path.join("wrangler.toml");
+        let config_template_str = fs::read_to_string(config_file).unwrap_or_else(|err| {
+            log::info!("Error reading config template: {}", err);
+            log::info!("Using default instead");
+            toml::to_string_pretty(&Manifest::default())
+                .expect("serializing the default toml should never fail")
+        });
+
+        let config_template =
+            toml::from_str::<Manifest>(&config_template_str).unwrap_or_else(|err| {
+                log::info!("Error parsing config template: {}", err);
+                log::info!("Using default instead");
                 Manifest::default()
-            }
-        };
+            });
 
-        let default_workers_dev = match &template_config.route {
-            Some(route) => {
-                if route.is_empty() {
-                    Some(true)
-                } else {
-                    None
-                }
-            }
-            None => Some(true),
-        };
-
-        template_config.name = name;
-        template_config.workers_dev = default_workers_dev;
+        config_template.warn_on_account_info();
         if let Some(target_type) = &target_type {
-            template_config.target_type = target_type.clone();
+            if config_template.target_type != *target_type {
+                StdOut::warn(&format!("The template recommends the \"{}\" type. Using type \"{}\" may cause errors, we recommend changing the type field in wrangler.toml to \"{}\"", config_template.target_type, target_type, config_template.target_type));
+            }
         }
 
-        if let Some(arg_site) = site {
-            if template_config.site.is_none() {
-                template_config.site = Some(arg_site);
+        let default_workers_dev = match &config_template.route {
+            Some(route) if route.is_empty() => Some(true),
+            None => Some(true),
+            _ => None,
+        };
+
+        /*
+         * We use toml-edit for actually changing the template provided wrangler.toml,
+         * since toml-edit is a format-preserving parser. Elsewhere, we use only toml-rs,
+         * as only toml-rs supports serde.
+         */
+
+        let mut config_template_doc =
+            config_template_str
+                .parse::<toml_edit::Document>()
+                .map_err(|err| {
+                    failure::err_msg(format!(
+                        "toml_edit failed to parse config template. {}",
+                        err
+                    ))
+                })?;
+
+        config_template_doc["name"] = toml_edit::value(name);
+        if let Some(default_workers_dev) = default_workers_dev {
+            config_template_doc["workers_dev"] = toml_edit::value(default_workers_dev);
+        }
+        if let Some(target_type) = &target_type {
+            config_template_doc["target_type"] = toml_edit::value(target_type.to_string());
+        }
+        if let Some(site) = site {
+            if config_template.site.is_none() {
+                config_template_doc["site"]["bucket"] =
+                    toml_edit::value(site.bucket.to_string_lossy().as_ref());
+
+                if let Some(entry_point) = &site.entry_point {
+                    config_template_doc["site"]["entry_point"] =
+                        toml_edit::value(entry_point.to_string_lossy().as_ref());
+                }
+                if let Some(include) = &site.include {
+                    let mut arr = toml_edit::Array::default();
+                    include.iter().for_each(|i| {
+                        arr.push(i.as_ref()).unwrap();
+                    });
+                    config_template_doc["site"]["include"] = toml_edit::value(arr);
+                }
+                if let Some(exclude) = &site.exclude {
+                    let mut arr = toml_edit::Array::default();
+                    exclude.iter().for_each(|i| {
+                        arr.push(i.as_ref()).unwrap();
+                    });
+                    config_template_doc["site"]["exclude"] = toml_edit::value(arr);
+                }
             }
         }
 
         // TODO: https://github.com/cloudflare/wrangler/issues/773
 
-        let toml = toml::to_string(&template_config)?;
+        let toml = config_template_doc.to_string_in_original_order();
+        let manifest = toml::from_str::<Manifest>(&toml)?;
 
         log::info!("Writing a wrangler.toml file at {}", config_file.display());
         fs::write(&config_file, &toml)?;
-        Ok(template_config)
+        Ok(manifest)
     }
 
     pub fn worker_name(&self, env_arg: Option<&str>) -> String {

--- a/src/settings/toml/mod.rs
+++ b/src/settings/toml/mod.rs
@@ -1,17 +1,21 @@
+mod builder;
 mod dev;
 mod environment;
 mod kv_namespace;
 mod manifest;
 mod route;
+mod script_format;
 mod site;
 mod target;
 mod target_type;
 mod triggers;
 
+pub use builder::Builder;
 pub use environment::Environment;
 pub use kv_namespace::{ConfigKvNamespace, KvNamespace};
 pub use manifest::Manifest;
 pub use route::{Route, RouteConfig};
+pub use script_format::ScriptFormat;
 pub use site::Site;
 pub use target::Target;
 pub use target_type::TargetType;

--- a/src/settings/toml/script_format.rs
+++ b/src/settings/toml/script_format.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum ScriptFormat {
+    #[serde(rename = "service-worker")]
+    ServiceWorker,
+    #[serde(rename = "modules")]
+    Modules,
+}
+
+impl fmt::Display for ScriptFormat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            Self::ServiceWorker => "service-worker",
+            Self::Modules => "modules",
+        };
+        write!(f, "{}", printable)
+    }
+}
+
+impl FromStr for ScriptFormat {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "service-worker" => Ok(Self::ServiceWorker),
+            "modules" => Ok(Self::Modules),
+            _ => failure::bail!("{} is not a valid script format!", s),
+        }
+    }
+}

--- a/src/settings/toml/site.rs
+++ b/src/settings/toml/site.rs
@@ -13,7 +13,7 @@ const SITE_ENTRY_POINT: &str = "workers-site";
 pub struct Site {
     pub bucket: PathBuf,
     #[serde(rename = "entry-point")]
-    entry_point: Option<PathBuf>,
+    pub entry_point: Option<PathBuf>,
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
 }

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -1,3 +1,4 @@
+use super::builder::Builder;
 use super::kv_namespace::KvNamespace;
 use super::site::Site;
 use super::target_type::TargetType;
@@ -14,6 +15,7 @@ pub struct Target {
     pub name: String,
     pub target_type: TargetType,
     pub webpack_config: Option<String>,
+    pub build: Option<Builder>,
     pub site: Option<Site>,
     pub vars: Option<HashMap<String, String>>,
     pub text_blobs: Option<HashMap<String, PathBuf>>,

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -24,7 +24,7 @@ impl Target {
         self.kv_namespaces.push(kv_namespace);
     }
 
-    pub fn build_dir(&self) -> Result<PathBuf, std::io::Error> {
+    pub fn package_dir(&self) -> Result<PathBuf, std::io::Error> {
         // if `site` is configured, we want to isolate worker code
         // and build artifacts away from static site application code.
         match &self.site {

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -318,6 +318,7 @@ mod tests {
             target_type: TargetType::JavaScript,
             webpack_config: None,
             site: Some(site),
+            build: None,
             vars: None,
             text_blobs: None,
         }

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -72,10 +72,10 @@ pub fn build(
         }
         TargetType::JavaScript => {
             log::info!("JavaScript project detected. Publishing...");
-            let build_dir = target.build_dir()?;
-            let package = Package::new(&build_dir)?;
+            let package_dir = target.package_dir()?;
+            let package = Package::new(&package_dir)?;
 
-            let script_path = package.main(&build_dir)?;
+            let script_path = package.main(&package_dir)?;
 
             let assets = ProjectAssets::new(
                 script_path,
@@ -90,8 +90,8 @@ pub fn build(
         TargetType::Webpack => {
             log::info!("webpack project detected. Publishing...");
             // TODO: https://github.com/cloudflare/wrangler/issues/850
-            let build_dir = target.build_dir()?;
-            let bundle = wranglerjs::Bundle::new(&build_dir);
+            let package_dir = target.package_dir()?;
+            let bundle = wranglerjs::Bundle::new(&package_dir);
 
             let script_path = bundle.script_path();
 

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -1,3 +1,4 @@
+mod modules_worker;
 mod plain_text;
 mod project_assets;
 mod service_worker;
@@ -9,18 +10,23 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
+use ignore::overrides::{Override, OverrideBuilder};
+use ignore::WalkBuilder;
+
 use crate::settings::binding;
-use crate::settings::toml::{Target, TargetType};
+use crate::settings::toml::{Builder, ScriptFormat, Target, TargetType};
 use crate::sites::AssetManifest;
 use crate::wranglerjs;
 
 use plain_text::PlainText;
-use project_assets::ServiceWorkerAssets;
+use project_assets::{ModulesAssets, ServiceWorkerAssets};
 use text_blob::TextBlob;
 use wasm_module::WasmModule;
 
 // TODO: https://github.com/cloudflare/wrangler/issues/1083
 use super::{krate, Package};
+
+use self::project_assets::Module;
 
 pub fn build(
     target: &Target,
@@ -70,23 +76,76 @@ pub fn build(
 
             service_worker::build_form(&assets, session_config)
         }
-        TargetType::JavaScript => {
-            log::info!("JavaScript project detected. Publishing...");
-            let package_dir = target.package_dir()?;
-            let package = Package::new(&package_dir)?;
+        TargetType::JavaScript => match &target.build {
+            Some(config) => match &config.upload_format {
+                ScriptFormat::ServiceWorker => {
+                    log::info!("Plain JavaScript project detected. Publishing...");
+                    let package_dir = target.package_dir()?;
+                    let package = Package::new(&package_dir)?;
+                    let script_path = package.main(&package_dir)?;
 
-            let script_path = package.main(&package_dir)?;
+                    let assets = ServiceWorkerAssets::new(
+                        script_path,
+                        wasm_modules,
+                        kv_namespaces.to_vec(),
+                        text_blobs,
+                        plain_texts,
+                    )?;
 
-            let assets = ServiceWorkerAssets::new(
-                script_path,
-                wasm_modules,
-                kv_namespaces.to_vec(),
-                text_blobs,
-                plain_texts,
-            )?;
+                    service_worker::build_form(&assets, session_config)
+                }
+                ScriptFormat::Modules => {
+                    let package_dir = target.package_dir()?;
+                    let package = Package::new(&package_dir)?;
+                    let main_module = package.module(&package_dir)?;
+                    let main_module_name = filename_from_path(&main_module)
+                        .ok_or_else(|| failure::err_msg("filename required for main module"))?;
 
-            service_worker::build_form(&assets, session_config)
-        }
+                    let ignore = build_ignore(config, &package_dir)?;
+                    let modules_iter = WalkBuilder::new(config.upload_dir.clone())
+                        .standard_filters(false)
+                        .hidden(true)
+                        .overrides(ignore)
+                        .build();
+
+                    let mut modules: Vec<Module> = vec![];
+
+                    for entry in modules_iter {
+                        let entry = entry?;
+                        let path = entry.path();
+                        if path.is_file() {
+                            log::info!("Adding module {}", path.display());
+                            modules.push(Module::new(path.to_owned())?);
+                        }
+                    }
+
+                    let assets = ModulesAssets::new(
+                        main_module_name,
+                        modules,
+                        kv_namespaces.to_vec(),
+                        plain_texts,
+                    )?;
+
+                    modules_worker::build_form(&assets, session_config)
+                }
+            },
+            None => {
+                log::info!("Plain JavaScript project detected. Publishing...");
+                let package_dir = target.package_dir()?;
+                let package = Package::new(&package_dir)?;
+                let script_path = package.main(&package_dir)?;
+
+                let assets = ServiceWorkerAssets::new(
+                    script_path,
+                    wasm_modules,
+                    kv_namespaces.to_vec(),
+                    text_blobs,
+                    plain_texts,
+                )?;
+
+                service_worker::build_form(&assets, session_config)
+            }
+        },
         TargetType::Webpack => {
             log::info!("webpack project detected. Publishing...");
             // TODO: https://github.com/cloudflare/wrangler/issues/850
@@ -128,8 +187,13 @@ fn get_asset_manifest_blob(asset_manifest: AssetManifest) -> Result<String, fail
     Ok(asset_manifest)
 }
 
-fn filename_from_path(path: &PathBuf) -> Option<String> {
+fn filestem_from_path(path: &PathBuf) -> Option<String> {
     path.file_stem()?.to_str().map(|s| s.to_string())
+}
+
+fn filename_from_path(path: &PathBuf) -> Option<String> {
+    path.file_name()
+        .map(|filename| filename.to_string_lossy().into_owned())
 }
 
 fn build_generated_dir() -> Result<(), failure::Error> {
@@ -150,4 +214,22 @@ fn concat_js(name: &str) -> Result<(), failure::Error> {
 
     fs::write("./worker/generated/script.js", js.as_bytes())?;
     Ok(())
+}
+
+fn build_ignore(config: &Builder, directory: &Path) -> Result<Override, failure::Error> {
+    let mut overrides = OverrideBuilder::new(directory);
+    // If `include` present, use it and don't touch the `exclude` field
+    if let Some(included) = &config.upload_include {
+        for i in included {
+            overrides.add(&i)?;
+            log::info!("Including {}", i);
+        }
+    } else if let Some(excluded) = &config.upload_exclude {
+        for e in excluded {
+            overrides.add(&format!("!{}", e))?;
+            log::info!("Ignoring {}", e);
+        }
+    }
+
+    Ok(overrides.build()?)
 }

--- a/src/upload/form/modules_worker.rs
+++ b/src/upload/form/modules_worker.rs
@@ -1,0 +1,75 @@
+use std::fs::File;
+
+use reqwest::blocking::multipart::{Form, Part};
+use serde::Serialize;
+
+use crate::settings::binding::Binding;
+
+use super::ModulesAssets;
+
+#[derive(Serialize, Debug)]
+struct Metadata {
+    pub main_module: String,
+    pub bindings: Vec<Binding>,
+}
+
+pub fn build_form(
+    assets: &ModulesAssets,
+    session_config: Option<serde_json::Value>,
+) -> Result<Form, failure::Error> {
+    let mut form = Form::new();
+
+    // The preview service in particular streams the request form, and requires that the
+    // "metadata" part be set first, so this order is important.
+    form = add_metadata(form, assets)?;
+    form = add_files(form, assets)?;
+    if let Some(session_config) = session_config {
+        form = add_session_config(form, session_config)?
+    }
+
+    log::info!("building form");
+    log::info!("{:#?}", &form);
+
+    Ok(form)
+}
+
+fn add_files(mut form: Form, assets: &ModulesAssets) -> Result<Form, failure::Error> {
+    for module in &assets.modules {
+        let file_name = module
+            .filename()
+            .ok_or_else(|| failure::err_msg("a filename is required for each module"))?;
+        let part = Part::reader(File::open(module.path.clone())?)
+            .mime_str(module.module_type.content_type())?
+            .file_name(file_name.clone());
+        form = form.part(file_name.clone(), part);
+    }
+    Ok(form)
+}
+
+fn add_metadata(mut form: Form, assets: &ModulesAssets) -> Result<Form, failure::Error> {
+    let metadata_json = serde_json::json!(&Metadata {
+        main_module: assets.main_module.clone(),
+        bindings: assets.bindings(),
+    });
+
+    let metadata = Part::text(metadata_json.to_string())
+        .file_name("metadata.json")
+        .mime_str("application/json")?;
+
+    form = form.part("metadata", metadata);
+
+    Ok(form)
+}
+
+fn add_session_config(
+    mut form: Form,
+    session_config: serde_json::Value,
+) -> Result<Form, failure::Error> {
+    let wrangler_session_config = Part::text(session_config.to_string())
+        .file_name("")
+        .mime_str("application/json")?;
+
+    form = form.part("wrangler-session-config", wrangler_session_config);
+
+    Ok(form)
+}

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 use failure::format_err;
 
 use super::binding::Binding;
-use super::filename_from_path;
 use super::plain_text::PlainText;
 use super::text_blob::TextBlob;
 use super::wasm_module::WasmModule;
+use super::{filename_from_path, filestem_from_path};
 
 use crate::settings::toml::KvNamespace;
 
@@ -28,7 +28,7 @@ impl ServiceWorkerAssets {
         text_blobs: Vec<TextBlob>,
         plain_texts: Vec<PlainText>,
     ) -> Result<Self, failure::Error> {
-        let script_name = filename_from_path(&script_path).ok_or_else(|| {
+        let script_name = filestem_from_path(&script_path).ok_or_else(|| {
             format_err!("filename should not be empty: {}", script_path.display())
         })?;
 
@@ -71,5 +71,99 @@ impl ServiceWorkerAssets {
 
     pub fn script_path(&self) -> PathBuf {
         self.script_path.clone()
+    }
+}
+
+pub struct Module {
+    pub path: PathBuf,
+    pub module_type: ModuleType,
+}
+
+impl Module {
+    pub fn new(path: PathBuf) -> Result<Module, failure::Error> {
+        let extension = path
+            .extension()
+            .ok_or_else(|| {
+                failure::err_msg(format!(
+                    "File {} lacks an extension. An extension is required to determine module type",
+                    path.display()
+                ))
+            })?
+            .to_string_lossy();
+
+        let module_type = match extension.as_ref() {
+            "mjs" => ModuleType::ES6,
+            "js" => ModuleType::CommonJS,
+            "wasm" => ModuleType::Wasm,
+            "txt" => ModuleType::Text,
+            _ => ModuleType::Data,
+        };
+
+        Ok(Module { path, module_type })
+    }
+
+    pub fn filename(&self) -> Option<String> {
+        filename_from_path(&self.path)
+    }
+}
+
+pub enum ModuleType {
+    ES6,
+    CommonJS,
+    Wasm,
+    Text,
+    Data,
+}
+
+impl ModuleType {
+    pub fn content_type(&self) -> &str {
+        match &self {
+            Self::ES6 => "application/javascript+module",
+            Self::CommonJS => "application/javascript",
+            Self::Wasm => "application/wasm",
+            Self::Text => "text/plain",
+            Self::Data => "application/octet-stream",
+        }
+    }
+}
+
+pub struct ModulesAssets {
+    pub main_module: String,
+    pub modules: Vec<Module>,
+    pub kv_namespaces: Vec<KvNamespace>,
+    pub plain_texts: Vec<PlainText>,
+}
+
+impl ModulesAssets {
+    pub fn new(
+        main_module: String,
+        modules: Vec<Module>,
+        kv_namespaces: Vec<KvNamespace>,
+        plain_texts: Vec<PlainText>,
+    ) -> Result<Self, failure::Error> {
+        Ok(Self {
+            main_module,
+            modules,
+            kv_namespaces,
+            plain_texts,
+        })
+    }
+
+    pub fn bindings(&self) -> Vec<Binding> {
+        let mut bindings = Vec::new();
+
+        // Bindings that refer to a `part` of the uploaded files
+        // in the service-worker format, are now modules.
+
+        for kv in &self.kv_namespaces {
+            let binding = kv.binding();
+            bindings.push(binding);
+        }
+        for plain_text in &self.plain_texts {
+            let binding = plain_text.binding();
+            bindings.push(binding);
+        }
+
+        bindings
     }
 }

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -11,7 +11,7 @@ use super::wasm_module::WasmModule;
 use crate::settings::toml::KvNamespace;
 
 #[derive(Debug)]
-pub struct ProjectAssets {
+pub struct ServiceWorkerAssets {
     script_name: String,
     script_path: PathBuf,
     pub wasm_modules: Vec<WasmModule>,
@@ -20,7 +20,7 @@ pub struct ProjectAssets {
     pub plain_texts: Vec<PlainText>,
 }
 
-impl ProjectAssets {
+impl ServiceWorkerAssets {
     pub fn new(
         script_path: PathBuf,
         wasm_modules: Vec<WasmModule>,

--- a/src/upload/form/service_worker.rs
+++ b/src/upload/form/service_worker.rs
@@ -1,0 +1,78 @@
+use reqwest::blocking::multipart::{Form, Part};
+use serde::Serialize;
+
+use crate::settings::binding::Binding;
+
+use super::ServiceWorkerAssets;
+
+#[derive(Serialize, Debug)]
+struct Metadata {
+    pub body_part: String,
+    pub bindings: Vec<Binding>,
+}
+
+pub fn build_form(
+    assets: &ServiceWorkerAssets,
+    session_config: Option<serde_json::Value>,
+) -> Result<Form, failure::Error> {
+    let mut form = Form::new();
+
+    // The preview service in particular streams the request form, and requires that the
+    // "metadata" part be set first, so this order is important.
+    form = add_metadata(form, assets)?;
+    form = add_files(form, assets)?;
+    if let Some(session_config) = session_config {
+        form = add_session_config(form, session_config)?
+    }
+
+    log::info!("building form");
+    log::info!("{:#?}", &form);
+
+    Ok(form)
+}
+
+fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, failure::Error> {
+    form = form.file(assets.script_name(), assets.script_path())?;
+
+    for wasm_module in &assets.wasm_modules {
+        form = form.file(wasm_module.filename(), wasm_module.path())?;
+    }
+
+    for text_blob in &assets.text_blobs {
+        let part = Part::text(text_blob.data.clone())
+            .file_name(text_blob.binding.clone())
+            .mime_str("text/plain")?;
+
+        form = form.part(text_blob.binding.clone(), part);
+    }
+
+    Ok(form)
+}
+
+fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, failure::Error> {
+    let metadata_json = serde_json::json!(&Metadata {
+        body_part: assets.script_name(),
+        bindings: assets.bindings(),
+    });
+
+    let metadata = Part::text(metadata_json.to_string())
+        .file_name("metadata.json")
+        .mime_str("application/json")?;
+
+    form = form.part("metadata", metadata);
+
+    Ok(form)
+}
+
+fn add_session_config(
+    mut form: Form,
+    session_config: serde_json::Value,
+) -> Result<Form, failure::Error> {
+    let wrangler_session_config = Part::text(session_config.to_string())
+        .file_name("")
+        .mime_str("application/json")?;
+
+    form = form.part("wrangler-session-config", wrangler_session_config);
+
+    Ok(form)
+}

--- a/src/upload/form/text_blob.rs
+++ b/src/upload/form/text_blob.rs
@@ -1,6 +1,9 @@
 use super::binding::Binding;
 use serde::{Deserialize, Serialize};
 
+// Note: This is only used for service-worker scripts.
+// modules scripts use the universal Module class instead of this.
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TextBlob {
     pub data: String,

--- a/src/upload/form/wasm_module.rs
+++ b/src/upload/form/wasm_module.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use failure::format_err;
 
 use super::binding::Binding;
-use super::filename_from_path;
+use super::filestem_from_path;
+
+// Note: This is only used for service-worker scripts.
+// modules scripts use the universal Module class instead of this.
 
 #[derive(Debug)]
 pub struct WasmModule {
@@ -14,7 +17,7 @@ pub struct WasmModule {
 
 impl WasmModule {
     pub fn new(path: PathBuf, binding: String) -> Result<Self, failure::Error> {
-        let filename = filename_from_path(&path)
+        let filename = filestem_from_path(&path)
             .ok_or_else(|| format_err!("filename should not be empty: {}", path.display()))?;
 
         Ok(Self {

--- a/src/upload/package.rs
+++ b/src/upload/package.rs
@@ -7,6 +7,8 @@ use serde::{self, Deserialize};
 pub struct Package {
     #[serde(default)]
     main: PathBuf,
+    #[serde(default)]
+    module: PathBuf,
 }
 impl Package {
     pub fn main(&self, package_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
@@ -23,16 +25,30 @@ impl Package {
             Ok(self.main.clone())
         }
     }
+    pub fn module(&self, package_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
+        if self.module == PathBuf::from("") {
+            failure::bail!(
+                "The `module` key in your `package.json` file is required when using the module script format; please specify the entry point of your Worker.",
+            )
+        } else if !package_dir.join(&self.module).exists() {
+            failure::bail!(
+                "The entrypoint of your Worker ({}) could not be found.",
+                self.module.display()
+            )
+        } else {
+            Ok(self.module.clone())
+        }
+    }
 }
 
 impl Package {
-    pub fn new(pkg_path: &PathBuf) -> Result<Package, failure::Error> {
-        let manifest_path = pkg_path.join("package.json");
+    pub fn new(package_dir: &PathBuf) -> Result<Package, failure::Error> {
+        let manifest_path = package_dir.join("package.json");
         if !manifest_path.is_file() {
             failure::bail!(
                 "Your JavaScript project is missing a `package.json` file; is `{}` the \
                  wrong directory?",
-                pkg_path.display()
+                package_dir.display()
             )
         }
 

--- a/src/upload/package.rs
+++ b/src/upload/package.rs
@@ -9,12 +9,12 @@ pub struct Package {
     main: PathBuf,
 }
 impl Package {
-    pub fn main(&self, build_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
+    pub fn main(&self, package_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
         if self.main == PathBuf::from("") {
             failure::bail!(
                 "The `main` key in your `package.json` file is required; please specify the entry point of your Worker.",
             )
-        } else if !build_dir.join(&self.main).exists() {
+        } else if !package_dir.join(&self.main).exists() {
             failure::bail!(
                 "The entrypoint of your Worker ({}) could not be found.",
                 self.main.display()

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -3,10 +3,10 @@ use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
 pub use watcher::wait_for_changes;
 
-use crate::build::command;
 use crate::settings::toml::{Target, TargetType};
 use crate::terminal::message::{Message, StdOut};
 use crate::wranglerjs;
+use crate::{build::command, build_target};
 use crate::{commands, install};
 
 use notify::{self, RecursiveMode, Watcher};
@@ -28,27 +28,54 @@ pub fn watch_and_build(
     tx: Option<mpsc::Sender<()>>,
 ) -> Result<(), failure::Error> {
     let target_type = &target.target_type;
+    let build = target.build.clone();
     match target_type {
         TargetType::JavaScript => {
-            thread::spawn(move || {
+            let target = target.clone();
+            thread::spawn::<_, Result<(), failure::Error>>(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
-                let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1)).unwrap();
+                let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1))?;
 
-                watcher
-                    .watch(JAVASCRIPT_PATH, RecursiveMode::Recursive)
-                    .unwrap();
-                StdOut::info(&format!("watching {:?}", &JAVASCRIPT_PATH));
+                match build {
+                    None => {
+                        watcher.watch(JAVASCRIPT_PATH, RecursiveMode::Recursive)?;
+                        StdOut::info(&format!("watching {:?}", &JAVASCRIPT_PATH));
 
-                loop {
-                    match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {
-                        Ok(_path) => {
-                            if let Some(tx) = tx.clone() {
-                                tx.send(()).expect("--watch change message failed to send");
+                        loop {
+                            match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {
+                                Ok(_path) => {
+                                    if let Some(tx) = tx.clone() {
+                                        tx.send(()).expect("--watch change message failed to send");
+                                    }
+                                }
+                                Err(e) => {
+                                    log::debug!("{:?}", e);
+                                    StdOut::user_error("Something went wrong while watching.")
+                                }
                             }
                         }
-                        Err(e) => {
-                            log::debug!("{:?}", e);
-                            StdOut::user_error("Something went wrong while watching.")
+                    }
+                    Some(config) => {
+                        config.verify_watch_dir()?;
+                        watcher.watch(config.watch_dir, notify::RecursiveMode::Recursive)?;
+
+                        loop {
+                            match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {
+                                Ok(_path) => match build_target(&target) {
+                                    Ok(output) => {
+                                        StdOut::success(&output);
+                                        if let Some(tx) = tx.clone() {
+                                            tx.send(())
+                                                .expect("--watch change message failed to send");
+                                        }
+                                    }
+                                    Err(e) => StdOut::user_error(&e.to_string()),
+                                },
+                                Err(e) => {
+                                    log::debug!("{:?}", e);
+                                    StdOut::user_error("Something went wrong while watching.")
+                                }
+                            }
                         }
                     }
                 }

--- a/src/wranglerjs/bundle.rs
+++ b/src/wranglerjs/bundle.rs
@@ -18,9 +18,9 @@ pub struct Bundle {
 // We call a {Bundle} the output of a {Bundler}; representing what {Webpack}
 // produces.
 impl Bundle {
-    pub fn new(build_dir: &PathBuf) -> Bundle {
+    pub fn new(package_dir: &PathBuf) -> Bundle {
         Bundle {
-            out: build_dir.join(BUNDLE_OUT),
+            out: package_dir.join(BUNDLE_OUT),
         }
     }
 

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -153,13 +153,13 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
         env_dep_installed(tool)?;
     }
 
-    let build_dir = target.build_dir()?;
+    let package_dir = target.package_dir()?;
 
     if let Some(site) = &target.site {
         site.scaffold_worker()?;
     }
 
-    run_npm_install(&build_dir).expect("could not run `npm install`");
+    run_npm_install(&package_dir).expect("could not run `npm install`");
 
     let node = which::which("node").unwrap();
     let mut command = Command::new(node);
@@ -176,7 +176,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
         temp_file.to_str().unwrap().to_string()
     ));
 
-    let bundle = Bundle::new(&build_dir);
+    let bundle = Bundle::new(&package_dir);
 
     command.arg(format!("--wasm-binding={}", bundle.get_wasm_binding()));
 
@@ -196,7 +196,7 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::E
     if let Some(webpack_config_path) = custom_webpack_config_path {
         build_with_custom_webpack(&mut command, &webpack_config_path);
     } else {
-        build_with_default_webpack(&mut command, &build_dir)?;
+        build_with_default_webpack(&mut command, &package_dir)?;
     }
 
     Ok((command, temp_file, bundle))
@@ -211,11 +211,11 @@ fn build_with_custom_webpack(command: &mut Command, webpack_config_path: &PathBu
 
 fn build_with_default_webpack(
     command: &mut Command,
-    build_dir: &PathBuf,
+    package_dir: &PathBuf,
 ) -> Result<(), failure::Error> {
-    let package = Package::new(&build_dir)?;
-    let package_main = build_dir
-        .join(package.main(&build_dir)?)
+    let package = Package::new(&package_dir)?;
+    let package_main = package_dir
+        .join(package.main(&package_dir)?)
         .to_str()
         .unwrap()
         .to_string();


### PR DESCRIPTION
- [x] remove linter and add custom build options as part of JS TargetType

JS projects with current config options will continue to work the same.
if a `[builder-config]` section is added, a custom build command can be configured. Wrangler will handle watching for changes and running the build command for the user.

- [x] support uploading in module format

when the `script-format` field in `[builder-config]` is set to `modules`, we should upload using the new modules format, uploading each file in `builder-config.output_dir` as a module.

The `main_module` is determined by looking at the `module` field in `package.json`. this should point to the *bundled* module in the output directory.

for `service-worker` builds, the behavior is the same as always: the `main` field in `package.json` is what will be uploaded, so this should be the output of your build tool.

- [x] support creating/implementing durable object namespaces
- [x] support binding/using durable object namespaces

This PR closes a lot of tickets with the same general theme (I hit xyz build edge case and I need a new feature to fix it/I want to use newer webpack version/I don't want to use webpack) that all come down to the limitations of wrangler's current build setup. Custom builds will allow users to setup their own build step, which wrangler will upload the results of unmodified to the API.

closes #206
closes #820  
closes #954
partially addresses #1102 
closes #1397 (just make custom build script)
closes #1550
closes #1557
closes #1558