### PR TITLE
KV error codes 10017 and 10026 no longer exist

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -34,8 +34,6 @@ fn kv_help(error_code: u16) -> &'static str {
         // TODO: link to tool for this?
         // legacy namespace errors
         10021 | 10035 | 10038 => "Consider moving this namespace",
-        // cloudflare account errors
-        10017 | 10026 => "Workers KV is a paid feature, please upgrade your account (https://www.cloudflare.com/products/workers-kv/)",
         _ => "",
     }
 }

--- a/src/kv/namespace/upsert.rs
+++ b/src/kv/namespace/upsert.rs
@@ -25,9 +25,7 @@ pub fn upsert(
         Ok(success) => Ok(UpsertedNamespace::Created(success.result)),
         Err(e) => match &e {
             ApiFailure::Error(_status, api_errors) => {
-                if api_errors.errors.iter().any(|e| e.code == 10026) {
-                    failure::bail!("{}", http::format_error(e, Some(&error_suggestions)))
-                } else if api_errors.errors.iter().any(|e| e.code == 10014) {
+                if api_errors.errors.iter().any(|e| e.code == 10014) {
                     log::info!("Namespace {} already exists.", title);
 
                     match list(&client, target)?
@@ -47,7 +45,6 @@ pub fn upsert(
 
 fn error_suggestions(code: u16) -> &'static str {
     match code {
-        10026 => "You will need to enable Workers Bundled for your account before you can use this feature.",
         10014 => "Namespace already exists, try using a different namespace.",
         10037 => "Edit your API Token to have correct permissions, or use the 'Edit Cloudflare Workers' API Token template.",
         _ => "",


### PR DESCRIPTION
These error codes became irrelevant once Free KV was released. The API no longer serves these error codes.