### PR TITLE
remove webpack specific change

### DIFF
--- a/src/wranglerjs/bundle.rs
+++ b/src/wranglerjs/bundle.rs
@@ -42,6 +42,24 @@ impl Bundle {
             wasm_file.write_all(&wasm)?;
         }
 
+        if self.has_wasm() {
+            script_file.write_all(
+                format!(
+                    r#"
+                        WebAssembly.instantiateStreaming =
+                            async function instantiateStreaming(req, importObject) {{
+                          const module = {};
+                          return {{
+                            module,
+                            instance: new WebAssembly.Instance(module, importObject)
+                          }}
+                        }};
+                    "#,
+                    self.get_wasm_binding()
+                )
+                .as_bytes(),
+            )?;
+        }
         script_file.write_all(wranglerjs_output.script.as_bytes())?;
 
         Ok(())
@@ -56,7 +74,7 @@ impl Bundle {
     }
 
     pub fn get_wasm_binding(&self) -> String {
-        "wasm".to_string()
+        "WASM_MODULE".to_string()
     }
 
     pub fn script_path(&self) -> PathBuf {

--- a/wranglerjs/index.js
+++ b/wranglerjs/index.js
@@ -95,29 +95,6 @@ function filterByExtension(ext) {
   const compiler = webpack(config);
   const fullConfig = compiler.options;
 
-  // Override the {FetchCompileWasmTemplatePlugin} and inject our new runtime.
-  const [
-    fetchCompileWasmTemplatePlugin
-  ] = compiler.hooks.thisCompilation.taps.filter(
-    tap => tap.name === "FetchCompileWasmTemplatePlugin"
-  );
-  fetchCompileWasmTemplatePlugin.fn = function(compilation) {
-    const mainTemplate = compilation.mainTemplate;
-    const generateLoadBinaryCode = () => `
-      // Fake fetch response
-      Promise.resolve({
-        arrayBuffer() { return Promise.resolve(${args["wasm-binding"]}); }
-      });
-    `;
-
-    const plugin = new WasmMainTemplatePlugin({
-      generateLoadBinaryCode,
-      mangleImports: false,
-      supportsStreaming: false
-    });
-    plugin.apply(mainTemplate);
-  };
-
   let lastHash = "";
   const compilerCallback = (err, stats) => {
     if (err) {


### PR DESCRIPTION
We used to hook directly into webpack internals to rewrite the runtime
that loads Wasm to make it point to the Worker binding instead of a
network fetch.

This change removes the webpack specific change and injects a generic
runtime to load Wasm from the binding.

Demo of the webpack's generated code: https://gist.github.com/xtuc/1a96d6793a3729016a518416ecf5b585#file-demo-js-L2-L9. I used https://github.com/xtuc/rust-webpack-worker-demo to test.