### PR TITLE
Feature/monorepo support

### DIFF
--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -234,7 +234,7 @@ fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
 
     if !dir.join("node_modules").exists() {
         // no dir in current path, search for closest
-        match find_closest_dir("node_modules", dir.as_path()) {
+        match find_closest("node_modules", dir.as_path()) {
             Some(_) => log::info!("skipping npm install because node_modules exists in parent dir"),
             None => {
                 let mut command = build_npm_command();
@@ -262,7 +262,7 @@ fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
     Ok(())
 }
 
-// find closest (up-the-tree) location of a file or dir
+// find closest (bottom-up traversal) location of a file or dir
 fn find_closest<'a>(name: &str, path: &'a Path) -> Option<&'a Path>{
     if has_dir(name, path) {
         return Option::from(path);

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -263,7 +263,7 @@ fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
 }
 
 // find closest (bottom-up traversal) location of a file or dir
-fn find_closest<'a>(name: &str, path: &'a Path) -> Option<&'a Path>{
+fn find_closest<'a>(name: &str, path: &'a Path) -> Option<&'a Path> {
     if has_dir(name, path) {
         return Option::from(path);
     }
@@ -272,7 +272,7 @@ fn find_closest<'a>(name: &str, path: &'a Path) -> Option<&'a Path>{
     let parent = path.parent();
     match parent {
         Some(parent_path) => find_closest(name, parent_path),
-        None => None
+        None => None,
     }
 }
 


### PR DESCRIPTION
Improvement of the detection of node_modules dir - adds bottom-up traversing to find it in parent dirs.

This should resolve some issues experienced with monorepos (e.g. with nx).

Example of an issue this can fix: https://github.com/cloudflare/wrangler/issues/820#issuecomment-762716331

To resolve most of the monorepo-related issues, we would need to refactor src/wranglerjs/mod.rs a bit more to establish the common root of node project (package.json and node_module location) and share it across a few other functions - still, that's a bit more work. I can do this some other time if you are keen on that.