### PR TITLE
docs: correct default type for generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ wrangler publish
 
   - `name`: defaults to `worker`
   - `template`: defaults to the [`https://github.com/cloudflare/worker-template`](https://github.com/cloudflare/worker-template)
-  - `type`: defaults to ["webpack"](https://developers.cloudflare.com/workers/tooling/wrangler/webpack)
+  - `type`: defaults to `javascript` based on the ["worker-template"](https://github.com/cloudflare/worker-template/blob/master/wrangler.toml)
 
 ### 📥 `init`
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -75,7 +75,7 @@ $ wrangler publish
 
   - `name`: defaults to `worker`
   - `template`: defaults to the [`https://github.com/cloudflare/worker-template`](https://github.com/cloudflare/worker-template)
-  - `type`: defaults to ["webpack"](https://developers.cloudflare.com/workers/tooling/wrangler/webpack)
+  - `type`: defaults to `javascript` based on the ["worker-template"](https://github.com/cloudflare/worker-template/blob/master/wrangler.toml)
 
 ### 📥 `init`
 


### PR DESCRIPTION
The README indicates that the default `type` for the `wrangler generate` command will be `webpack`.

However, this is not correct. As the `template` defaults to the `worker-template`, the default is effectively `javascript`.