### PR TITLE
Set panic to abort in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ strict = ['openssl/vendored']
 sys-openssl = ['openssl']
 # Keeping feature for users already using this feature flag
 vendored-openssl = ['openssl/vendored']
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
This should fix cases where we spawn threads that panic and get us in an invalid state that requires us to get killed anyway.