### PR TITLE
fix installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,23 @@ You have many options to install wrangler!
 
 ### Install with `npm`
 
-We strongly recommend you install `npm` with a Node version manager like [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating), which will allow `wrangler` to install configuration data in a global `node_modules` directory in your user's home directory, without requiring that you run as `root`. 
+We strongly recommend you install `npm` with a Node version manager like [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating), which puts the global `node_modules` in your home directory to eliminate permissions issues with `npm install -g`. Distribution-packaged `npm` installs often use `/usr/lib/node_modules` (which is root) for globally installed `npm` packages, and running `npm install -g` as `root` prevents `wrangler` from installing properly.
 
-Once you've installed `nvm`, run:
+
+Once you've installed `nvm` and configured your system to use the `nvm` managed node install, run:
 
 ```bash
 npm i @cloudflare/wrangler -g
 ```
+
 If you are running an ARM based system (eg Raspberry Pi, Pinebook) you'll need to use the `cargo` installation method listed below to build wrangler from source.
+
+#### Specify binary location
+
+In case you need `wrangler`'s npm installer to place the binary in a non-default location (such as when using `wrangler` in CI), you can use the following configuration options to specify an install location:
+
+- Environment variable: `WRANGLER_INSTALL_PATH`
+- NPM configuration: `wrangler_install_path`
 
 #### Specify binary site URL
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -12,7 +12,7 @@ This is a list of the things that need to happen during a release.
 1. Go through the commit history since the last release. Ensure that all PRs
    that have landed are marked with the milestone. You can use this to
    show all the PRs that are merged on or after YYY-MM-DD:
-   `https://github.com/issues?utf8=%E2%9C%93&q=repo%3Acloudflare%2Fwrangler+merged%3A%3E%3DYYYY-MM-DD`
+   `https://github.com/issues?q=repo%3Acloudflare%2Fwrangler+base%3Amaster+merged%3A%3E%3DYYYY-MM-DD`
 1. Go through the closed PRs in the milestone. Each should have a changelog
    label indicating if the change is docs, fix, feature, or maintenance. If
    there is a missing label, please add one.
@@ -31,7 +31,7 @@ This is a list of the things that need to happen during a release.
 
 1. Copy `README.md` to `npm/README.md`
 1. Bump the version number in `npm/package.json`
-1. `cd npm && npm install` _Note: This step will appear to fail, however its utility is re-building npm-shrinkwrap.json_
+1. `cd npm && npm install` _Note: This step will appear to fail due to the new version not existing yet, however its utility is re-building npm-shrinkwrap.json_
 
 ### Start a release PR
 

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -32,10 +32,10 @@ const getBinary = () => {
   const version = require("./package.json").version;
   const url = getBinaryURL(version, platform);
 
-  const useCwd = !!process.env.WRANGLER_USE_CWD;
-  const customPath = process.env.WRANGLER_INSTALL_PATH;
-  const altPath = useCwd ? process.cwd() : !!customPath ? customPath : false;
-  const installDirectory = join(altPath || os.homedir(), ".wrangler");
+  const customPath =
+    process.env.WRANGLER_INSTALL_PATH ||
+    process.env.npm_config_wrangler_install_path;
+  const installDirectory = join(customPath || __dirname, "wrangler");
   return new Binary(url, { name: "wrangler", installDirectory });
 };
 

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -20,9 +20,10 @@ const getPlatform = () => {
 };
 
 const getBinaryURL = (version, platform) => {
-  const site = process.env.WRANGLER_BINARY_HOST ||
-      process.env.npm_config_wrangler_binary_host ||
-      'https://workers.cloudflare.com/get-npm-wrangler-binary';
+  const site =
+    process.env.WRANGLER_BINARY_HOST ||
+    process.env.npm_config_wrangler_binary_host ||
+    "https://workers.cloudflare.com/get-npm-wrangler-binary";
   return `${site}/${version}/${platform}`;
 };
 
@@ -30,7 +31,11 @@ const getBinary = () => {
   const platform = getPlatform();
   const version = require("./package.json").version;
   const url = getBinaryURL(version, platform);
-  const installDirectory = join(os.homedir(), ".wrangler");
+
+  const useCwd = !!process.env.WRANGLER_USE_CWD;
+  const customPath = process.env.WRANGLER_INSTALL_PATH;
+  const altPath = useCwd ? process.cwd() : !!customPath ? customPath : false;
+  const installDirectory = join(altPath || os.homedir(), ".wrangler");
   return new Binary(url, { name: "wrangler", installDirectory });
 };
 
@@ -47,10 +52,10 @@ const install = () => {
 const uninstall = () => {
   const binary = getBinary();
   binary.uninstall();
-}
+};
 
 module.exports = {
   install,
   run,
-  uninstall
+  uninstall,
 };

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,4 +1,4 @@
-const { Binary } = require("binary-install");
+const { Binary } = require("@cloudflare/binary-install");
 const os = require("os");
 const { join } = require("path");
 

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@cloudflare/binary-install": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/binary-install/-/binary-install-0.2.0.tgz",
+      "integrity": "sha512-54n9ILgln+qUJc0BtbetEIEi1GrIL88p7ZDJy+BV8EsUqA7pMCMHAUOHjDq+YrIoqJHGJktlQJxBYB+4Umf3ww==",
+      "requires": {
+        "axios": "^0.21.1",
+        "rimraf": "^3.0.2",
+        "tar": "^6.0.2"
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -16,16 +26,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "binary-install": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
-      "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
-      "requires": {
-        "axios": "^0.21.1",
-        "rimraf": "^3.0.2",
-        "tar": "^6.1.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/npm/package.json
+++ b/npm/package.json
@@ -42,6 +42,6 @@
     "cli"
   ],
   "dependencies": {
-    "binary-install": "0.1.1"
+    "@cloudflare/binary-install": "0.2.0"
   }
 }


### PR DESCRIPTION
binary-install@0.1.1 broke semver, this PR changes our installer to use a cloudflare-owned version of binary-install with updated dependencies to resolve the previous vulnerability warnings from the old version of axios that was being used.

Question: should we re-publish wrangler@1.13.0 with the fixed installer, or just proceed to 1.14.0?

closes #1772 
closes #1286
closes #1234
closes #1758 