### PR TITLE
Revert default installer location change and release 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.14.1
+
+- ### Fixes
+
+  - **revert default install location change - [xortive], [pull/1798]**
+
+    In 1.14.0, we changed the default install location from `~/.wrangler` to `node_modules`,
+    to allow `npx wrangler` to use the pinned version in a project's dependencies. It seems that
+    this is causing issues, so we're rolling it back in favor of having folks who want this behavior,
+    to specify a the install location in the `config` section of package.json. We'll document this soon.
+
+    [xortive]: https://github.com/xortive
+    [pull/1798]: https://github.com/cloudflare/wrangler/pull/1798
+
 ## 1.14.0
 
 - ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "d3340571769500ddef1e94b45055fabed6b08a881269b7570c830b8f32ef84ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2507,9 +2507,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.14.0"
+version = "1.14.1"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>", "Nat Davidson <davidson@cloudflare.com>", "Steve Manuel <nilslice@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -43,14 +43,21 @@ Most of your comments will be about the changelog. Once the PR is finalized and 
 
 1. If you made changes, squash or fixup all changes into a single commit.
 1. Run `git push` and wait for CI to pass.
+## Merge
+
+1. Hit the big green Merge button on the release PR.
+1. `git checkout master` and `git pull --rebase origin master`
 
 ### Tag and build release
 
 This part of the release process is handled by GitHub Actions, and our binaries are distributed as GitHub Releases. When you push a version tag, it kicks off an action that creates a new GitHub release for that tag, builds release binaries and attaches them to the release.
 
-1. Once ready to merge, tag the commit by running either `git tag -a v#.#.# -m #.#.#` (release), or `git tag -a v#.#.#-rc.# -m #.#.#` (release candidate)
+1. After pulling `master` in the step above, tag the commit by running either `git tag -a v#.#.# -m #.#.#` (release), or `git tag -a v#.#.#-rc.# -m #.#.#` (release candidate)
 1. Run `git push --tags`.
 1. Wait for CI to pass.
+1. If CI fails, delete the tag locally and remotely
+1. Fix whatever caused the CI failure
+1. Re-tag the healthy commit, and wait for CI to pass again.
 
 ### Edit the release
 
@@ -73,11 +80,6 @@ After CI builds the release binaries and they appear on the [releases page](http
    ```
 
    The new release candidate should then include updated testing instructions with a small changelog at the top to get folks who installed the old release candidate up to speed.
-
-## Publish
-
-1. Hit the big green Merge button on the release PR.
-1. `git checkout master` and `git pull --rebase origin master`
 
 ### Publish to crates.io (full release only)
 

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -38,7 +38,7 @@ const getBinary = () => {
   const customPath =
     process.env.WRANGLER_INSTALL_PATH ||
     process.env.npm_config_wrangler_install_path;
-  const installDirectory = join(customPath || __dirname, "wrangler");
+  const installDirectory = join(customPath || os.homedir(), ".wrangler");
   return new Binary(url, { name: "wrangler", installDirectory });
 };
 

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/wrangler",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
I had tested this using `npm pack`, but it seems that when installing using the actual npm package, this change is causing issues for folks on npm@7. Let's revert to the known-good homedir install location until we figure out what's going on.

I also included some edits to the release  checklist that involve tagging the release after the release PR is merged. This makes fix and release PRs like this one work better, and it fixes some parts of github's CI that expect release tags to be tagged on the default branch

closes #1796 