### PR TITLE
ci: add build config for aarch64-apple-darwin target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
-on:
-  push:
-    tags:
-      - "v*" # Run when tag matches v*, i.e. v1.0, v20.15.10
+on: push
+  # push:
+    # tags:
+    #   - "v*" # Run when tag matches v*, i.e. v1.0, v20.15.10
 
 name: Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   MACOS_TARGET: x86_64-apple-darwin
   MACOS_AARCH64_TARGET: aarch64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-musl
+  SELECT_XCODE: /Applications/Xcode_12.2.app
 
   # Space separated paths to include in the archive.
   RELEASE_ADDS: README.md
@@ -76,6 +77,7 @@ jobs:
       - name: Build (MacOS Apple Silicon)
         if: matrix.build == 'macos'
         run: |
+          sudo xcode-select -s "${SELECT_XCODE}"
           rustup target add ${{ env.MACOS_AARCH64_TARGET }}
           cargo build --release --target ${{ env.MACOS_AARCH64_TARGET }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   GITHUB_REF: "${{ github.ref }}"
   WINDOWS_TARGET: x86_64-pc-windows-msvc
   MACOS_TARGET: x86_64-apple-darwin
+  MACOS_AARCH64_TARGET: aarch64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-musl
 
   # Space separated paths to include in the archive.
@@ -72,6 +73,12 @@ jobs:
         if: matrix.build == 'macos'
         run: cargo build --release
 
+      - name: Build (MacOS Apple Silicon)
+        if: matrix.build == 'macos'
+        run: |
+          rustup target add ${{ env.MACOS_AARCH64_TARGET }}
+          cargo build --release --target ${{ env.MACOS_AARCH64_TARGET }}
+
       - name: Build (Windows)
         if: matrix.build == 'windows'
         run: cargo build --release
@@ -104,6 +111,13 @@ jobs:
           mv ./target/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
           mv ${{ env.RELEASE_ADDS }} ./dist
           7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+
+      - name: Create tarball (MacOS Apple Silicon)
+        if: matrix.build == 'macos'
+        run: |
+          mv ./target/${{ env.MACOS_AARCH64_TARGET }}/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
+          mv ${{ env.RELEASE_ADDS }} ./dist
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_AARCH64_TARGET }}.tar.gz
 
       - name: Create tarball (wranglerjs)
         if: matrix.build == 'wranglerjs'
@@ -195,3 +209,13 @@ jobs:
           asset_path: ./macos/wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
           asset_content_type: application/gzip
           asset_name: wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+
+      - name: Release MacOS (Apple Silicon) tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./macos/wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_AARCH64_TARGET }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_AARCH64_TARGET }}.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wrangler"
 version = "1.14.1"
-authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>", "Nat Davidson <davidson@cloudflare.com>", "Steve Manuel <nilslice@gmail.com>"]
+authors = ["The Wrangler Team <wrangler@cloudflare.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Command-line interface for all things Cloudflare Workers"


### PR DESCRIPTION
Updates github action to support build & release of the `aarch64-apple-darwin` target needed for M1 devices.