### PR TITLE
Add `wasm_modules` config field for bundling arbitrary WebAssembly modules.

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -127,6 +127,7 @@ mod tests {
             text_blobs: None,
             usage_model: None,
             build: None,
+            wasm_modules: None,
         };
         assert!(kv::get_namespace_id(&target_with_dup_kv_bindings, "").is_err());
     }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -53,6 +53,7 @@ pub struct Manifest {
     pub env: Option<HashMap<String, Environment>>,
     pub vars: Option<HashMap<String, String>>,
     pub text_blobs: Option<HashMap<String, PathBuf>>,
+    pub wasm_modules: Option<HashMap<String, PathBuf>>,
     pub triggers: Option<Triggers>,
     #[serde(default, with = "string_empty_as_none")]
     pub usage_model: Option<UsageModel>,
@@ -354,6 +355,7 @@ impl Manifest {
             vars: self.vars.clone(), // Not inherited
             text_blobs: self.text_blobs.clone(), // Inherited
             usage_model: self.usage_model, // Top level
+            wasm_modules: self.wasm_modules.clone(),
         };
 
         let environment = self.get_environment(environment_name)?;

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -21,6 +21,7 @@ pub struct Target {
     pub vars: Option<HashMap<String, String>>,
     pub text_blobs: Option<HashMap<String, PathBuf>>,
     pub usage_model: Option<UsageModel>,
+    pub wasm_modules: Option<HashMap<String, PathBuf>>,
 }
 
 impl Target {

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -322,6 +322,7 @@ mod tests {
             vars: None,
             text_blobs: None,
             usage_model: None,
+            wasm_modules: None,
         }
     }
 

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -42,6 +42,12 @@ pub fn build(
         }
     }
 
+    if let Some(modules) = &target.wasm_modules {
+        for (key, module_path) in modules.iter() {
+            wasm_modules.push(WasmModule::new(module_path.clone(), key.clone())?);
+        }
+    }
+
     if let Some(vars) = &target.vars {
         for (key, value) in vars.iter() {
             plain_texts.push(PlainText::new(key.clone(), value.clone())?)


### PR DESCRIPTION
Currently it seems that wrangler only supports WebAssembly modules included from a `rust` or `webpack` project.

This pull request enables the inclusion of arbitrary WebAssembly modules through a `wasm_modules` config field.