### PR TITLE
Revert #1748, update changelog-generator package.json, and release 1.15.0

### DIFF
--- a/changelog-generator/package-lock.json
+++ b/changelog-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "changelog-interactive",
+  "name": "changelog-generator",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^18.3.2",
         "commander": "^7.1.0",

--- a/changelog-generator/package.json
+++ b/changelog-generator/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "changelog-interactive",
+  "name": "changelog-generator",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "wrangler@cloudflare.com",
+  "license": "MIT OR Apache-2.0",
   "dependencies": {
     "@octokit/rest": "^18.3.2",
     "commander": "^7.1.0",


### PR DESCRIPTION
#1748 turned out to interact poorly with workers-sites projects. We first noticed this when 1.14.1 broke CI for the cloudflare-docs repo.

We're going to revert this change. Folks already depending on it should use #1677 once it makes it into a release candidate.