### PR TITLE
1.15.0-custom-builds-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e098e9c493fdf92832223594d9a164f96bdf17ba81a42aff86f85c76768726a"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.15.0"
+version = "1.15.0-custom-builds-rc.0"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.15.0"
+version = "1.15.0-custom-builds-rc.0"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>", "Nat Davidson <davidson@cloudflare.com>", "Steve Manuel <nilslice@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.0",
+  "version": "1.15.0-custom-builds-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/wrangler",
-      "version": "1.15.0",
+      "version": "1.15.0-custom-builds-rc.0",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.0",
+  "version": "1.15.0-custom-builds-rc.0",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
This PR sets up the custom builds release candidate. In this case, the version number represents the base release for the RC -- there's a chance this RC will stick around for longer than 1.15.0, and I think this convention makes reasonable sense

Documentation, to be put in the release page's notes section: (installation instructions will not work at the moment)

## Installation

### npm *(recommended)*
```bash
npm install -g @cloudflare/wrangler@1.15.0-custom-builds-rc.0
```

### from source
```bash
git clone https://github.com/cloudflare/wrangler.git
cd wrangler
git checkout custom-builds-rc
cargo install --path . --debug
```


## Overview
Howdy y'all, we just published candidate release v1 for custom builds! What are custom builds? It's a new `[build]` section in your configuration that allows you to specify a custom build step. Now you can use any JavaScript bundler you want!

`wrangler.toml`
```toml
[build]
upload_format = "service-worker"
command = "npm install && npm run build"
cwd = "."
watch_dir = "src"
upload_dir = "dist"
upload_include = []
upload_exclude = []

```

### Options

#### Required
- `upload_format` - the upload format of your worker, which should be set to `service-worker`. Unless, you are in the Durable Objects beta, where you should set this to `modules`.

#### Optional
- `command` - the build command to use before publishing. (you can use shell operators like `&&`)
- `cwd` - the working directory for `command`, defaults to the project root directory.
- `upload_dir` -  the directory where your build outputs its artifacts, defaults to `dist`.
- `upload_include` - a list of [glob patterns](https://www.malikbrowne.com/blog/a-beginners-guide-glob-patterns) for files in `upload_dir` you wish to include.
- `upload_exclude` - a list of glob patterns for files in `upload_dir` you wish to exclude.
- `watch_dir` - wrangler will watch this directory for changes when using wrangler dev, defaults to `src`.

## Template

We've made a [template](https://github.com/cloudflare/service-worker-custom-build) so you can try out custom builds:

```bash
wrangler generate https://github.com/cloudflare/service-worker-custom-build
```

## What this means

Specific support for your desired bundler/build tooling can now be implemented separately, instead of requiring changes to wrangler itself. You are no longer limited by wrangler's opinionated build process with `webpack`, and you can customize your build as you wish. We'll provide templates that give you a good starting point for how to setup your build.

When using custom builds, wrangler won't run `npm install` automatically, since we no longer need to install `wranglerjs`. This means wrangler will now play nicer as part of larger projects, in monorepos, and when you want to use `yarn`.

## Modules

### :warning: Modules are only available for those in the Durable Objects beta. If you are not in the beta and attempt any of the examples below, you will receive an error.

As part of the Durable Objects beta, you can uploading scripts as [ES modules](https://nodejs.org/api/esm.html#esm_introduction), where instead of registering your `fetch` and `scheduled` handlers using `addEventListener()`, you can upload a set of modules and export your handlers from the root module instead. The root module is specified using the `module` key in `package.json`.

We support the following module types:
- ES Modules with `.mjs` extension (e.g. `import {} from "./lib.mjs"`)
- CommonJS modules with `.js` extension (e.g. `require("./lib.js")`)
- `WebAssembly` modules with `.wasm` extension, importing them gives compiled WASM. (replaces WASM bindings)
- `String` modules with `.txt` extension, importing them gives a string with the contents. (replaces text "blob" bindings)
- `ArrayBuffer` modules with any other extension. (the buffer contains the content of the file)

We have two templates to demonstrate the new modules syntax:
```bash
wrangler generate https://github.com/cloudflare/modules-webpack-commonjs
wrangler generate https://github.com/cloudflare/modules-rollup-esm
```

Modules can be imported using their relative path (without the `./`) from `upload_dir`.

Currently, only ES modules can be used as the root module. You can still use CommonJS when necessary,
you just have to create a shim ES module that imports your CommonJS module, and re-exports it.

Unlike the `"service-worker"` format, bindings for module workers are exposed as a parameter to handler functions instead of being exposed as global variables.

## `wrangler generate`

`wrangler generate` now uses a format-preserving parser (`toml_edit` for the curious) for making changes to the template-provided wrangler.toml. This means you can include comments and special formatting in your templates, and wrangler will preserve them unchanged.