### PR TITLE
Remove package.json requirement for JS workers

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -120,6 +120,7 @@ mod tests {
                 },
             ],
             name: "test-target".to_string(),
+            main: "".to_string(),
             target_type: TargetType::Webpack,
             webpack_config: None,
             site: None,

--- a/src/fixtures/wrangler_toml.rs
+++ b/src/fixtures/wrangler_toml.rs
@@ -93,6 +93,7 @@ pub struct WranglerToml {
     pub name: Option<&'static str>,
     #[serde(rename = "type")]
     pub target_type: Option<&'static str>,
+    pub main: Option<&'static str>,
     pub account_id: Option<&'static str>,
     pub workers_dev: Option<bool>,
     pub route: Option<&'static str>,
@@ -233,11 +234,12 @@ impl WranglerToml {
         }
     }
 
-    pub fn javascript(name: &'static str) -> WranglerToml {
+    pub fn javascript(name: &'static str, main: &'static str) -> WranglerToml {
         WranglerToml {
             name: Some(name),
             workers_dev: Some(true),
             target_type: Some("javascript"),
+            main: Some(main),
             ..Default::default()
         }
     }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -32,6 +32,8 @@ pub struct Manifest {
     #[serde(rename = "type")]
     pub target_type: TargetType,
     #[serde(default)]
+    pub main: String,
+    #[serde(default)]
     pub account_id: String,
     pub workers_dev: Option<bool>,
     #[serde(default, with = "string_empty_as_none")]
@@ -288,6 +290,7 @@ impl Manifest {
         */
         let mut target = Target {
             target_type,                                 // Top level
+            main: self.main.clone(),                     // Top level
             account_id: self.account_id.clone(),         // Inherited
             webpack_config: self.webpack_config.clone(), // Inherited
             // importantly, the top level name will be modified

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -12,6 +12,7 @@ pub struct Target {
     pub account_id: String,
     pub kv_namespaces: Vec<KvNamespace>,
     pub name: String,
+    pub main: String,
     pub target_type: TargetType,
     pub webpack_config: Option<String>,
     pub site: Option<Site>,

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -315,6 +315,7 @@ mod tests {
             account_id: "".to_string(),
             kv_namespaces: Vec::new(),
             name: "".to_string(),
+            main: "".to_string(),
             target_type: TargetType::JavaScript,
             webpack_config: None,
             site: Some(site),

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -20,7 +20,7 @@ use text_blob::TextBlob;
 use wasm_module::WasmModule;
 
 // TODO: https://github.com/cloudflare/wrangler/issues/1083
-use super::{krate, Package};
+use super::krate;
 
 pub fn build(
     target: &Target,
@@ -72,10 +72,14 @@ pub fn build(
         }
         TargetType::JavaScript => {
             log::info!("JavaScript project detected. Publishing...");
-            let build_dir = target.build_dir()?;
-            let package = Package::new(&build_dir)?;
+            let mut script_path = target.build_dir()?;
 
-            let script_path = package.main(&build_dir)?;
+            // always expects main worker file at index.js
+            script_path.push("index.js");
+
+            if !std::path::Path::new(&script_path).exists() {
+                failure::bail!("Please rename your main JavaScript file to index.js")
+            }
 
             let assets = ProjectAssets::new(
                 script_path,

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -74,7 +74,7 @@ pub fn build(
             log::info!("JavaScript project detected. Publishing...");
             let mut script_path = target.build_dir()?;
 
-            if target.main != "" {
+            if !target.main.is_empty() {
                 // use main key from wrangler.toml
                 script_path.push(&target.main);
 

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -27,7 +27,35 @@ fn it_can_preview_js_project() {
     "#,
     );
 
-    let wrangler_toml = WranglerToml::javascript("test-preview-javascript");
+    let wrangler_toml = WranglerToml::javascript("test-preview-javascript", "index.js");
+    fixture.create_wrangler_toml(wrangler_toml);
+
+    preview_succeeds(&fixture);
+}
+
+#[test]
+fn it_can_preview_js_project_with_package_json() {
+    let fixture = Fixture::new();
+    fixture.create_file(
+        "index.js",
+        r#"
+        addEventListener('fetch', event => {
+            event.respondWith(handleRequest(event.request))
+        })
+
+        /**
+        * Fetch and log a request
+        * @param {Request} request
+        */
+        async function handleRequest(request) {
+            return new Response('Hello worker!', { status: 200 })
+        }
+    "#,
+    );
+
+    fixture.create_default_package_json();
+
+    let wrangler_toml = WranglerToml::javascript("test-preview-javascript", "");
     fixture.create_wrangler_toml(wrangler_toml);
 
     preview_succeeds(&fixture);
@@ -186,9 +214,8 @@ fn it_can_preview_using_url_flag() {
         }
     "#,
     );
-    fixture.create_default_package_json();
 
-    let wrangler_toml = WranglerToml::javascript("test-preview-javascript");
+    let wrangler_toml = WranglerToml::javascript("test-preview-javascript", "index.js");
     fixture.create_wrangler_toml(wrangler_toml);
 
     // URLs should match as expected
@@ -213,11 +240,10 @@ fn it_previews_with_config_text() {
         }
     "#,
     );
-    fixture.create_default_package_json();
 
     let test_value: &'static str = "sdhftiuyrtdhfjgpoopuyrdfjgkyitudrhf";
 
-    let mut wrangler_toml = WranglerToml::javascript("test-preview-with-config");
+    let mut wrangler_toml = WranglerToml::javascript("test-preview-with-config", "index.js");
     let mut config: HashMap<&'static str, &'static str> = HashMap::new();
     config.insert("CONFIG_TEST", test_value);
     wrangler_toml.vars = Some(config);
@@ -241,12 +267,11 @@ fn it_previews_with_text_blob() {
         }
     "#,
     );
-    fixture.create_default_package_json();
 
     let test_value: &'static str = "sdhftiuyrtdhfjgpoopuyrdfjgkyitudrhf";
     fixture.create_file("blob.txt", test_value);
 
-    let mut wrangler_toml = WranglerToml::javascript("test-preview-with-config");
+    let mut wrangler_toml = WranglerToml::javascript("test-preview-with-config", "index.js");
     let mut blobs: HashMap<&'static str, &'static str> = HashMap::new();
     blobs.insert("BLOB", "blob.txt");
     wrangler_toml.text_blobs = Some(blobs);

--- a/tests/preview.rs
+++ b/tests/preview.rs
@@ -26,7 +26,6 @@ fn it_can_preview_js_project() {
         }
     "#,
     );
-    fixture.create_default_package_json();
 
     let wrangler_toml = WranglerToml::javascript("test-preview-javascript");
     fixture.create_wrangler_toml(wrangler_toml);


### PR DESCRIPTION
Fixes issue #1715 
For now it uses index.js as the default entry point. Maybe there should be an option to change that.