### PR TITLE
#1386: Support a configurable timeout

### DIFF
--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -1,18 +1,16 @@
-use std::time::Duration;
-
 use cloudflare::framework::async_api;
 use cloudflare::framework::auth::Credentials;
 use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::{Environment, HttpApiClient, HttpApiClientConfig};
 use http::StatusCode;
 
-use crate::http::{feature::headers, Feature, DEFAULT_HTTP_TIMEOUT_SECONDS};
+use crate::http::{feature::headers, Feature};
 use crate::settings::global_user::GlobalUser;
 use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
 pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
     let config = HttpApiClientConfig {
-        http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
+        http_timeout: user.get_http_config().get_http_timeout(),
         default_headers: headers(None),
     };
 
@@ -28,7 +26,7 @@ pub fn featured_cf_v4_client(
     feature: Feature,
 ) -> Result<HttpApiClient, failure::Error> {
     let config = HttpApiClientConfig {
-        http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
+        http_timeout: user.get_http_config().get_http_timeout(),
         default_headers: headers(Some(feature)),
     };
 

--- a/src/http/legacy.rs
+++ b/src/http/legacy.rs
@@ -42,13 +42,13 @@ fn builder() -> ClientBuilder {
 
 fn add_auth_headers(headers: &mut HeaderMap, user: &GlobalUser) {
     match user {
-        GlobalUser::TokenAuth { api_token } => {
+        GlobalUser::TokenAuth { api_token, .. } => {
             headers.insert(
                 "Authorization",
                 HeaderValue::from_str(&format!("Bearer {}", &api_token)).unwrap(),
             );
         }
-        GlobalUser::GlobalKeyAuth { email, api_key } => {
+        GlobalUser::GlobalKeyAuth { email, api_key, .. } => {
             headers.insert("X-Auth-Email", HeaderValue::from_str(&email).unwrap());
             headers.insert("X-Auth-Key", HeaderValue::from_str(&api_key).unwrap());
         }

--- a/src/http/legacy.rs
+++ b/src/http/legacy.rs
@@ -1,14 +1,16 @@
 use reqwest::blocking::{Client, ClientBuilder};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::redirect::Policy;
-use std::time::Duration;
 
-use crate::http::{feature::headers, Feature, DEFAULT_HTTP_TIMEOUT_SECONDS};
 use crate::settings::global_user::GlobalUser;
+use crate::{
+    http::{feature::headers, Feature},
+    settings::http_config::HttpConfig,
+};
 
 // TODO: remove this and replace it entirely with cloudflare-rs
-pub fn client() -> Client {
-    builder()
+pub fn client(http_config: Option<&HttpConfig>) -> Client {
+    builder(http_config.unwrap_or(&Default::default()))
         .default_headers(headers(None))
         .build()
         .expect("could not create http client")
@@ -26,18 +28,18 @@ fn get_client(user: &GlobalUser, feature: Option<Feature>) -> Client {
     let mut headers = headers(feature);
     add_auth_headers(&mut headers, user);
 
-    builder()
+    builder(user.get_http_config())
         .default_headers(headers)
         .redirect(Policy::none())
         .build()
         .expect("could not create authenticated http client")
 }
 
-fn builder() -> ClientBuilder {
+fn builder(http_config: &HttpConfig) -> ClientBuilder {
     let builder = reqwest::blocking::Client::builder();
     builder
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS))
+        .connect_timeout(http_config.get_connect_timeout())
+        .timeout(http_config.get_http_timeout())
 }
 
 fn add_auth_headers(headers: &mut HeaderMap, user: &GlobalUser) {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,7 +2,9 @@ pub(self) mod cf;
 pub(crate) mod feature;
 pub(self) mod legacy;
 
+pub const DEFAULT_CONNECT_TIMEOUT_SECONDS: u64 = 10;
 pub const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 60;
+pub const DEFAULT_BULK_TIMEOUT_SECONDS: u64 = 5 * 60;
 pub use cf::{cf_v4_api_client_async, cf_v4_client, featured_cf_v4_client, format_error};
 pub use feature::Feature;
 pub use legacy::{client, featured_legacy_auth_client, legacy_auth_client};

--- a/src/kv/bulk.rs
+++ b/src/kv/bulk.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use indicatif::ProgressBar;
 
 use cloudflare::endpoints::workerskv::delete_bulk::DeleteBulk;
@@ -24,7 +22,7 @@ const UPLOAD_MAX_SIZE: usize = 50 * 1024 * 1024;
 // can be lengthy if payloads are large.
 fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
     let config = HttpApiClientConfig {
-        http_timeout: Duration::from_secs(5 * 60),
+        http_timeout: user.get_http_config().get_bulk_timeout(),
         default_headers: headers(None),
     };
 

--- a/src/login/mod.rs
+++ b/src/login/mod.rs
@@ -46,6 +46,7 @@ pub fn run() -> Result<(), failure::Error> {
 
     let user = GlobalUser::TokenAuth {
         api_token: token.to_string(),
+        http_config: Default::default(),
     };
     global_config(&user, true)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -666,13 +666,20 @@ fn run() -> Result<(), failure::Error> {
             // API Tokens are the default
             StdOut::billboard(&format!("To find your API Token, go to {}\nand create it using the \"Edit Cloudflare Workers\" template.\n\nConsider using {} which only requires your Cloudflare username and password.\n\nIf you are trying to use your Global API Key instead of an API Token\n{}, run {}.", api_token_url, wrangler_login_msg, not_recommended_msg, recommended_cmd_msg));
             let api_token: String = interactive::get_user_input("Enter API Token: ");
-            GlobalUser::TokenAuth { api_token }
+            GlobalUser::TokenAuth {
+                api_token,
+                http_config: Default::default(),
+            }
         } else {
             StdOut::billboard(&format!("We don't recommend using your Global API Key!\nPlease consider using an API Token instead.\n\n{}", token_support_url));
             let email: String = interactive::get_user_input("Enter Email: ");
             let api_key: String = interactive::get_user_input("Enter Global API Key: ");
 
-            GlobalUser::GlobalKeyAuth { email, api_key }
+            GlobalUser::GlobalKeyAuth {
+                email,
+                api_key,
+                http_config: Default::default(),
+            }
         };
 
         let verify = !matches.is_present("no-verify");

--- a/src/settings/environment.rs
+++ b/src/settings/environment.rs
@@ -80,7 +80,11 @@ impl MockEnvironment {
 impl QueryEnvironment for MockEnvironment {
     #[allow(unused_variables)]
     fn get_var(&self, var: &'static str) -> Result<String, std::env::VarError> {
-        Ok("Some Mocked Result".to_string()) // Returns a mocked response
+        if self.vars.iter().any(|&(key, _)| key == var) {
+            Ok("Some Mocked Result".to_string()) // Returns a mocked response
+        } else {
+            Err(std::env::VarError::NotPresent)
+        }
     }
 
     fn empty(&self) -> Result<bool, failure::Error> {

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -53,6 +53,13 @@ impl GlobalUser {
         GlobalUser::build(environment, config_path)
     }
 
+    pub fn get_http_config(&self) -> &HttpConfig {
+        match &self {
+            GlobalUser::TokenAuth { http_config, .. } => http_config,
+            GlobalUser::GlobalKeyAuth { http_config, .. } => http_config,
+        }
+    }
+
     fn build<T: 'static + QueryEnvironment>(
         environment: T,
         config_path: PathBuf,

--- a/src/settings/http_config.rs
+++ b/src/settings/http_config.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use std::{str::FromStr, time::Duration};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct HttpConfig {
+    connect_timeout: Option<u64>,
+    http_timeout: Option<u64>,
+    bulk_timeout: Option<u64>,
+}
+
+impl HttpConfig {
+    pub fn get_connect_timeout(&self) -> Duration {
+        Duration::from_secs(
+            self.connect_timeout
+                .unwrap_or(crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS),
+        )
+    }
+
+    pub fn get_http_timeout(&self) -> Duration {
+        Duration::from_secs(
+            self.http_timeout
+                .unwrap_or(crate::http::DEFAULT_HTTP_TIMEOUT_SECONDS),
+        )
+    }
+
+    pub fn get_bulk_timeout(&self) -> Duration {
+        Duration::from_secs(
+            self.bulk_timeout
+                .unwrap_or(crate::http::DEFAULT_BULK_TIMEOUT_SECONDS),
+        )
+    }
+}
+
+impl FromStr for HttpConfig {
+    type Err = toml::de::Error;
+
+    fn from_str(serialized_toml: &str) -> Result<Self, Self::Err> {
+        toml::from_str(serialized_toml)
+    }
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        HttpConfig {
+            connect_timeout: None,
+            http_timeout: None,
+            bulk_timeout: None,
+        }
+    }
+}
+
+#[test]
+fn it_reads_timeout_when_specified_otherwise_reads_default_values() {
+    // make sure that the values in our test aren't the default values,
+    // wouln't want this test to break if the defaults happen to be the same
+    // as the test
+    assert_ne!(3, crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS);
+    assert_ne!(8, crate::http::DEFAULT_HTTP_TIMEOUT_SECONDS);
+    assert_ne!(16, crate::http::DEFAULT_BULK_TIMEOUT_SECONDS);
+
+    // assert that reading a config yields the timeouts specified
+    let http_config = HttpConfig::from_str(
+        r#"
+connect_timeout = 3
+http_timeout = 8
+bulk_timeout = 16
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(Duration::from_secs(3), http_config.get_connect_timeout());
+    assert_eq!(Duration::from_secs(8), http_config.get_http_timeout());
+    assert_eq!(Duration::from_secs(16), http_config.get_bulk_timeout());
+
+    // assert that a lack of a config uses the defaults
+    let manifest = HttpConfig::from_str("").unwrap();
+
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS),
+        manifest.get_connect_timeout()
+    );
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_HTTP_TIMEOUT_SECONDS),
+        manifest.get_http_timeout()
+    );
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_BULK_TIMEOUT_SECONDS),
+        manifest.get_bulk_timeout()
+    );
+}

--- a/src/settings/http_config.rs
+++ b/src/settings/http_config.rs
@@ -1,11 +1,17 @@
-use serde::{Deserialize, Serialize};
-use std::{str::FromStr, time::Duration};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::convert::TryFrom;
+use std::{fmt, str::FromStr};
+use std::{marker::PhantomData, time::Duration};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct HttpConfig {
-    connect_timeout: Option<u64>,
-    http_timeout: Option<u64>,
-    bulk_timeout: Option<u64>,
+    #[serde(default, deserialize_with = "string_or_number")]
+    pub connect_timeout: Option<u64>,
+    #[serde(default, deserialize_with = "string_or_number")]
+    pub http_timeout: Option<u64>,
+    #[serde(default, deserialize_with = "string_or_number")]
+    pub bulk_timeout: Option<u64>,
 }
 
 impl HttpConfig {
@@ -49,6 +55,70 @@ impl Default for HttpConfig {
     }
 }
 
+/// When reading from the environment, all values are strings. Thus,
+/// deserialization fails when reading from the environment. To combat this,
+/// this deserialization method is used in order to support deserializing valid
+/// number strings and numbers into the correct value.
+///
+/// https://serde.rs/string-or-struct.html
+fn string_or_number<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrNumber(PhantomData<fn() -> Option<u64>>);
+
+    impl<'de> Visitor<'de> for StringOrNumber {
+        type Value = Option<u64>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("`str`, `u64`, or `none`")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            value.parse::<u64>().map(|n| Some(n)).map_err(|_| {
+                serde::de::Error::invalid_type(serde::de::Unexpected::Str(value), &self)
+            })
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match u64::try_from(v) {
+                Ok(v) => Ok(Some(v)),
+                Err(_) => Err(serde::de::Error::invalid_type(
+                    serde::de::Unexpected::Signed(v),
+                    &self,
+                )),
+            }
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(v.into())
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrNumber(PhantomData))
+}
+
 #[test]
 fn it_reads_timeout_when_specified_otherwise_reads_default_values() {
     // make sure that the values in our test aren't the default values,
@@ -87,4 +157,81 @@ bulk_timeout = 16
         Duration::from_secs(crate::http::DEFAULT_BULK_TIMEOUT_SECONDS),
         manifest.get_bulk_timeout()
     );
+}
+
+/// Ensures we can deserialize strings into numbers as well. This is to support
+/// passing in these values as environment variables.
+#[test]
+fn it_can_deserialize_strings() {
+    // make sure that the values in our test aren't the default values,
+    // wouln't want this test to break if the defaults happen to be the same
+    // as the test
+    assert_ne!(3, crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS);
+    assert_ne!(8, crate::http::DEFAULT_HTTP_TIMEOUT_SECONDS);
+    assert_ne!(16, crate::http::DEFAULT_BULK_TIMEOUT_SECONDS);
+
+    // assert that reading a config yields the timeouts specified
+    let http_config = HttpConfig::from_str(
+        r#"
+connect_timeout = "3"
+http_timeout = "8"
+bulk_timeout = "16"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(Duration::from_secs(3), http_config.get_connect_timeout());
+    assert_eq!(Duration::from_secs(8), http_config.get_http_timeout());
+    assert_eq!(Duration::from_secs(16), http_config.get_bulk_timeout());
+}
+
+#[test]
+fn it_uses_defaults_when_nothing() {
+    // assert that a lack of a config uses the defaults
+    let manifest = HttpConfig::from_str("").unwrap();
+
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS),
+        manifest.get_connect_timeout()
+    );
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_HTTP_TIMEOUT_SECONDS),
+        manifest.get_http_timeout()
+    );
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_BULK_TIMEOUT_SECONDS),
+        manifest.get_bulk_timeout()
+    );
+}
+
+#[test]
+fn it_ignores_skipped_values() {
+    // assert that a lack of a config uses the defaults
+    let manifest = HttpConfig::from_str(
+        r#"
+http_timeout = 69
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_CONNECT_TIMEOUT_SECONDS),
+        manifest.get_connect_timeout()
+    );
+    assert_eq!(Duration::from_secs(69), manifest.get_http_timeout());
+    assert_eq!(
+        Duration::from_secs(crate::http::DEFAULT_BULK_TIMEOUT_SECONDS),
+        manifest.get_bulk_timeout()
+    );
+}
+
+#[test]
+fn it_fails_for_negative_values() {
+    let manifest = HttpConfig::from_str(
+        r#"
+http_timeout = -1
+"#,
+    );
+
+    assert!(manifest.is_err());
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -2,6 +2,7 @@ pub mod binding;
 mod environment;
 mod global_config;
 pub mod global_user;
+pub mod http_config;
 pub mod metadata;
 pub mod toml;
 


### PR DESCRIPTION
This PR supplies a robust solution to #1386. It offers three new configurable variables, `http_timeout`, `connect_timeout`, and `bulk_timeout` which are used in the places where timeout durations were previously hardcoded.

Unit tests were added to confirm that the features added work. For a final manual sanity check, I ran `wrangler publish` on a 2.4MiB JS file (on my 0.5Mbps upload internet), one without setting the related environment variables and one with. When the timeout variables weren't set, my internet upload was getting maxed out, and when setting the timeout to `0` the upload instantly failed. huzzah :DDD :tada:

```
$ CF_HTTP_TIMEOUT=0 CF_CONNECT_TIMEOUT=0 CF_BULK_TIMEOUT=0 wrangler publish
 JavaScript project found. Skipping unnecessary build!
Error: error sending request for url (https://api.cloudflare.com/client/v4/accounts/x/workers/scripts/worker): operation timed out
```

Relevant documentation should be added to notify users that they can set these environment variables if they need to increase the timeout.