### PR TITLE
v1.15.0-custom-builds-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+checksum = "5a872858e9cb9e3b96c80dd78774ad9e32e44d3b05dc31e142b858d14aebc82c"
 dependencies = [
  "curl-sys",
  "libc",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.40+curl-7.75.0"
+version = "0.4.41+curl-7.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
+checksum = "0ec466abd277c7cab2905948f3e94d10bc4963f1f5d47921c1cc4ffd2028fe65"
 dependencies = [
  "cc",
  "libc",
@@ -1258,7 +1258,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.14.0",
+ "console 0.14.1",
  "lazy_static",
  "number_prefix 0.3.0",
  "regex",
@@ -1325,9 +1325,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "libflate"
@@ -1685,15 +1685,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -2021,14 +2021,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -2042,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -2407,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
 
 [[package]]
 name = "slab"
@@ -2498,7 +2497,7 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "slog-term",
- "trackable",
+ "trackable 0.2.24",
 ]
 
 [[package]]
@@ -2538,9 +2537,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2885,18 +2884,28 @@ dependencies = [
 
 [[package]]
 name = "trackable"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11475c3c53b075360eac9794965822cb053996046545f91cf61d90e00b72efa5"
+checksum = "b98abb9e7300b9ac902cc04920945a874c1973e08c310627cc4458c04b70dd32"
+dependencies = [
+ "trackable 1.1.0",
+ "trackable_derive",
+]
+
+[[package]]
+name = "trackable"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffbe24a17d6b233c1d47e2d336b94a295a347b308a9a6d431a65b4eac57e97d"
 dependencies = [
  "trackable_derive",
 ]
 
 [[package]]
 name = "trackable_derive"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcf0b9b2caa5f4804ef77aeee1b929629853d806117c48258f402b69737e65c"
+checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
  "quote",
  "syn",
@@ -2947,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"
@@ -3058,9 +3067,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"
@@ -3079,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -3112,9 +3121,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.124",
@@ -3124,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3139,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3151,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3161,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3174,15 +3183,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3262,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.15.0-custom-builds-rc.0"
+version = "1.15.0-custom-builds-rc.1"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.15.0-custom-builds-rc.0"
+version = "1.15.0-custom-builds-rc.1"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>", "Nat Davidson <davidson@cloudflare.com>", "Steve Manuel <nilslice@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.0-custom-builds-rc.0",
+  "version": "1.15.0-custom-builds-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/wrangler",
-      "version": "1.15.0-custom-builds-rc.0",
+      "version": "1.15.0-custom-builds-rc.1",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.0-custom-builds-rc.0",
+  "version": "1.15.0-custom-builds-rc.1",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
Release notes below:



## Installation

### npm *(recommended)*
```bash
npm install -g @cloudflare/wrangler@beta
```

### from source
```bash
git clone https://github.com/cloudflare/wrangler.git
cd wrangler
git checkout custom-builds-rc
cargo install --path . --debug
```


## Overview
Howdy y'all, we just published candidate release 1 for custom builds! This version includes support for managing Durable Objects from within a wrangler project, as well as all of the features in rc.0

## Durable Objects

Wrangler now supports Durable Objects! We've introduced a new configuration section `[durable_objects]` that allows you to configure which Durable Objects your project can call into using bindings.

#### Because Durable Objects are written using modules, you must use [custom builds](#custom-builds) for Durable Objects projects. [Templates are provided below](#durable-objects-templates).



### Accessing Durable Objects

To access Durable Objects, you must configure a binding in `wrangler.toml` with the class name and script name
whose objects you wish to access using the binding. The script name can be omitted when creating a binding
for a class in the same script.

```toml
[durable_objects]
classes = [
  { binding = "COUNTER", class_name = "Counter" }, # Binding to the Counter class in the same script
  { binding = "CHAT_ROOM", class_name = "ChatRoom", script_name = "chatroom" } # Binding to the ChatRoom class in a different script
]
```
The `[durable_objects]` section has 1 subsection:

- `classes` - An array of tables, each table can contain the below fields
  - `binding` - Required, The binding name to use within your worker
  - `class_name` - Required, The class name you wish to bind to.
  - `script_name` - Optional, Defaults to the current project's script.

### Preparing Durable Objects Classes

When you export a new Durable Objects Class from your script, you must tell the Workers platform about it
before you can create and access Durable Objects associated with that class and script. You can read more about exporting
a new class [in the docs](https://developers.cloudflare.com/workers/learning/using-durable-objects).

This process is called a "migration", and is currently performed via extra options on `wrangler publish`.

To allow creation of Durable Objects associated with an exported class, you'd use `--new-class`:
```
wrangler publish --new-class Counter
```

If you want to delete the Durable Objects associated with an exported class, you'd use `--delete-class`:
### WARNING: This will delete all Durable Objects (and their data) associated with the deleted Durable Objects Class!

```
wrangler publish --delete-class Counter
```

These are basic examples -- you can use multiple of these options in a single `wrangler publish` call, one Durable Objects Class per option.

The following example adds 2 new classes (Counter and ChatRoom) and deletes the OldDeprecatedCode class

```
wrangler publish --new-class Counter --new-class ChatRoom --delete-class OldDeprecatedCode
```

A future RC will include migration directives for renaming a class, and transferring a class from one
Worker script to another, as well as support for writing these migrations in wrangler.toml.

### Durable Objects Templates

We've made 2 templates so you can try out Durable Objects in wrangler:

One uses [Rollup to bundle](https://github.com/cloudflare/durable-objects-rollup-esm) a Worker written using ES Modules, while the other uses [Webpack to bundle](https://github.com/cloudflare/durable-objects-webpack-commonjs) a worker written as CommonJS modules.

```bash
wrangler generate <worker-name> https://github.com/cloudflare/durable-objects-rollup-esm
```

```bash
wrangler generate <worker-name> https://github.com/cloudflare/durable-objects-webpack-commonjs
```


## Custom Builds

`wrangler.toml`
```toml
type = "javascript"
# The [build] section is only supported for type = "javascript"
# type = "webpack" and type = "rust" implement their own build
# process that is not configurable.

[build]
upload_format = "service-worker"
command = "npm install && npm run build"
cwd = "."
watch_dir = "src"
upload_dir = "dist"
upload_include = []
upload_exclude = []

```

### Options

#### Required
- `upload_format` - `"service-worker"` is the existing format for Workers scripts. `"modules"` is new, and is required to be used for all projects that export Durable Objects Classes. `"modules"` will only work if you are in the Durable Objects beta.

    The `"main"` key in `package.json` should be the location of the compiled bundle for `upload_format = "service-worker"`.
    The `"module"` key in `package.json` should be the location of the compiled bundle for `upload_format = "modules"`.

#### Optional
- `command` - the build command to use before publishing. (you can use shell operators like `&&`)
- `cwd` - the working directory for `command`, defaults to the project root directory.
- `watch_dir` - wrangler will watch this directory for changes when using wrangler dev, defaults to `src`.

#### Optional - Currently used only for `upload_format = "modules"`
- `upload_dir` -  the directory where your build outputs its artifacts, defaults to `dist`.
- `upload_include` - a list of [glob patterns](https://git-scm.com/docs/gitignore#_pattern_format) for files in `upload_dir` you wish to include.
- `upload_exclude` - a list of glob patterns for files in `upload_dir` you wish to exclude.

## Custom Builds Template

We've made a [template](https://github.com/cloudflare/service-worker-custom-build) so you can try out custom builds:

```bash
wrangler generate <worker-name> https://github.com/cloudflare/service-worker-custom-build
```

## What this means

Specific support for your desired bundler/build tooling can now be implemented separately, instead of requiring changes to wrangler itself. You are no longer limited by wrangler's opinionated build process with `webpack`, and you can customize your build as you wish. We'll provide templates that give you a good starting point for how to setup your build.

When using custom builds, wrangler won't run `npm install` automatically, since we no longer need to install `wranglerjs`. This means wrangler will now play nicer as part of larger projects, in monorepos, and when you want to use `yarn`.

## Modules

As part of the Durable Objects beta, you can upload scripts as [ES modules](https://nodejs.org/api/esm.html#esm_introduction), where instead of registering your `fetch` and `scheduled` handlers using `addEventListener()`, you can upload a set of modules and export your handlers from the root module instead. The root module is specified using the `module` key in `package.json`.

We support the following module types:
- ES Modules with `.mjs` extension (e.g. `import {} from "./lib.mjs"`)
- CommonJS modules with `.js` extension (e.g. `require("./lib.js")`)
- `WebAssembly` modules with `.wasm` extension, importing them gives compiled WASM. (replaces WASM bindings)
- `String` modules with `.txt` extension, importing them gives a string with the contents. (replaces text "blob" bindings)
- `ArrayBuffer` modules with `.bin` extension. (the buffer contains the content of the file)

We have two templates to demonstrate the new modules syntax:
```bash
wrangler generate <worker-name> https://github.com/cloudflare/modules-webpack-commonjs
wrangler generate <worker-name> https://github.com/cloudflare/modules-rollup-esm
```

Modules can be imported using their relative path (without the `./`) from `upload_dir`.

Currently, only ES modules can be used as the root module. You can still use CommonJS when necessary,
you just have to create a shim ES module that imports your CommonJS module, and re-exports it.

Unlike the `"service-worker"` format, bindings for module workers are exposed as a parameter to handler functions instead of being exposed as global variables.

## `wrangler generate` improvements

`wrangler generate` now uses a format-preserving parser (`toml_edit` for the curious) for making changes to the template-provided wrangler.toml. This means you can include comments and special formatting in your templates, and wrangler will preserve them unchanged.