### PR TITLE
Allow non-Webpack Workers Sites

### DIFF
--- a/src/settings/toml/builder.rs
+++ b/src/settings/toml/builder.rs
@@ -12,7 +12,7 @@ const WATCH_DIR: &str = "src";
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Builder {
-    command: Option<String>,
+    pub command: Option<String>,
     #[serde(default = "project_root")]
     pub cwd: PathBuf,
     #[serde(default = "upload_dir")]

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -321,18 +321,16 @@ impl Manifest {
                     ))
                 }
                 TargetType::JavaScript => {
+                    let error_message = format!(
+                        "{} Workers Sites requires using a bundler, and your configuration indicates that you aren't using one. You can fix this by:\n* setting your project type to \"webpack\" to use our automatically configured webpack bundler.\n* setting your project type to \"javascript\", and configuring a build command in the `[build]` section if you wish to use your choice of bundler.",
+                        emoji::WARN
+                    );
                     if let Some(build) = &self.build {
                         if build.command.is_none() {
-                            failure::bail!(format!(
-                                "{} Workers Sites requires using a bundler, and your configuration indicates that you aren't using one. You can fix this by:\n* setting your project type to \"webpack\" to use our automatically configured webpack bundler.\n* setting your project type to \"javascript\", and configuring a build command in the `[build]` section if you wish to use your choice of bundler.",
-                                emoji::WARN
-                            ))
+                            failure::bail!(error_message)
                         }
                     } else {
-                        failure::bail!(format!(
-                            "{} Workers Sites requires using a bundler, and your configuration indicates that you aren't using one. You can fix this by:\n* setting your project type to \"webpack\" to use our automatically configured webpack bundler.\n* setting your project type to \"javascript\", and configuring a build command in the `[build]` section if you wish to use your choice of bundler.",
-                            emoji::WARN
-                        ))
+                        failure::bail!(error_message)
                     }
                 }
                 _ => {}

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -312,6 +312,33 @@ impl Manifest {
         environment_name: Option<&str>,
         preview: bool,
     ) -> Result<Target, failure::Error> {
+        if self.site.is_some() {
+            match self.target_type {
+                TargetType::Rust => {
+                    failure::bail!(format!(
+                        "{} Workers Sites does not support Rust type projects.",
+                        emoji::WARN
+                    ))
+                }
+                TargetType::JavaScript => {
+                    if let Some(build) = &self.build {
+                        if build.command.is_none() {
+                            failure::bail!(format!(
+                                "{} Workers Sites requires using a bundler, and your configuration indicates that you aren't using one. You can fix this by:\n* setting your project type to \"webpack\" to use our automatically configured webpack bundler.\n* setting your project type to \"javascript\", and configuring a build command in the `[build]` section if you wish to use your choice of bundler.",
+                                emoji::WARN
+                            ))
+                        }
+                    } else {
+                        failure::bail!(format!(
+                            "{} Workers Sites requires using a bundler, and your configuration indicates that you aren't using one. You can fix this by:\n* setting your project type to \"webpack\" to use our automatically configured webpack bundler.\n* setting your project type to \"javascript\", and configuring a build command in the `[build]` section if you wish to use your choice of bundler.",
+                            emoji::WARN
+                        ))
+                    }
+                }
+                _ => {}
+            }
+        }
+
         /*
         From https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys
         Top level: required to be configured at the top level of your wrangler.toml only; multiple environments on the same project must share this property

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -312,12 +312,6 @@ impl Manifest {
         environment_name: Option<&str>,
         preview: bool,
     ) -> Result<Target, failure::Error> {
-        // Site projects are always webpack for now; don't let toml override this.
-        let target_type = match self.site {
-            Some(_) => TargetType::Webpack,
-            None => self.target_type.clone(),
-        };
-
         /*
         From https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys
         Top level: required to be configured at the top level of your wrangler.toml only; multiple environments on the same project must share this property
@@ -327,7 +321,7 @@ impl Manifest {
         Not inherited: Must be defined for every environment individually.
         */
         let mut target = Target {
-            target_type,                                 // Top level
+            target_type: self.target_type.clone(),       // Top level
             account_id: self.account_id.clone(),         // Inherited
             webpack_config: self.webpack_config.clone(), // Inherited
             build: self.build.clone(),                   // Inherited

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -58,6 +58,14 @@ pub fn build(
         }
     }
 
+    if let Some(asset_manifest) = asset_manifest {
+        log::info!("adding __STATIC_CONTENT_MANIFEST");
+        let binding = "__STATIC_CONTENT_MANIFEST".to_string();
+        let asset_manifest_blob = get_asset_manifest_blob(asset_manifest)?;
+        let text_blob = TextBlob::new(asset_manifest_blob, binding)?;
+        text_blobs.push(text_blob);
+    }
+
     match target_type {
         TargetType::Rust => {
             log::info!("Rust project detected. Publishing...");
@@ -89,7 +97,7 @@ pub fn build(
                     log::info!("Plain JavaScript project detected. Publishing...");
                     let package_dir = target.package_dir()?;
                     let package = Package::new(&package_dir)?;
-                    let script_path = package.main(&package_dir)?;
+                    let script_path = package_dir.join(package.main(&package_dir)?);
 
                     let assets = ServiceWorkerAssets::new(
                         script_path,
@@ -183,14 +191,6 @@ pub fn build(
                 let binding = bundle.get_wasm_binding();
                 let wasm_module = WasmModule::new(path, binding)?;
                 wasm_modules.push(wasm_module);
-            }
-
-            if let Some(asset_manifest) = asset_manifest {
-                log::info!("adding __STATIC_CONTENT_MANIFEST");
-                let binding = "__STATIC_CONTENT_MANIFEST".to_string();
-                let asset_manifest_blob = get_asset_manifest_blob(asset_manifest)?;
-                let text_blob = TextBlob::new(asset_manifest_blob, binding)?;
-                text_blobs.push(text_blob);
             }
 
             let assets = ServiceWorkerAssets::new(


### PR DESCRIPTION
Right now, custom build commands don't work with Workers SItes. This should enable them.