### PR TITLE
Revert "Print line and column numbers for exception thrown (#1645)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrome-devtools-rs"
-version = "0.0.0-alpha.2"
+version = "0.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a79dc4759f70819397d2e4281c8bc2991f9207d6abcbdb9f2279a512bf78e4"
+checksum = "17d1ada6e226ee1c5a69bfe5b16a494f036151d16461904afd22edeccb93061b"
 dependencies = [
  "console 0.11.3",
  "log 0.4.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ atty = "0.2.14"
 base64 = "0.13.0"
 billboard = "0.1.0"
 binary-install = "0.0.3-alpha.1"
-chrome-devtools-rs = "0.0.0-alpha.2"
+chrome-devtools-rs = { version = "0.0.0-alpha.1", features = ["color"] }
 chrono = "0.4.19"
 clap = "2.33.3"
 cloudflare = "0.6.6"


### PR DESCRIPTION
This reverts commit 74a89f7c383bc22758cbe55096ce3016c5c319d7.

Closes #1826

This commit is causing `wrangler dev` to not show uncaught exceptions. Reverting `chrome-devtools-rs` was also necessary.