### PR TITLE
add `--format` option, including default `json` and new `pretty`

### DIFF
--- a/src/commands/tail.rs
+++ b/src/commands/tail.rs
@@ -10,6 +10,7 @@ const DEFAULT_METRICS_PORT: u16 = 8081;
 pub fn start(
     target: &Target,
     user: &GlobalUser,
+    format: String,
     tunnel_port: Option<u16>,
     metrics_port: Option<u16>,
     verbose: bool,
@@ -20,6 +21,7 @@ pub fn start(
     Tail::run(
         target.clone(),
         user.clone(),
+        format,
         tunnel_port,
         metrics_port,
         verbose,

--- a/src/main.rs
+++ b/src/main.rs
@@ -622,6 +622,15 @@ fn run() -> Result<(), failure::Error> {
                 .about(&*format!("{} Aggregate logs from production worker", emoji::TAIL))
                 .arg(wrangler_file.clone())
                 .arg(
+                    Arg::with_name("format")
+                        .help("specify an output format")
+                        .short("f")
+                        .long("format")
+                        .takes_value(true)
+                        .default_value("json")
+                        .possible_values(&["json", "pretty"])
+                )
+                .arg(
                     Arg::with_name("env")
                         .help("environment to tail logs from")
                         .short("e")
@@ -1122,6 +1131,7 @@ fn run() -> Result<(), failure::Error> {
                 .unwrap_or(commands::DEFAULT_CONFIG_PATH),
         );
         let manifest = settings::toml::Manifest::new(config_path)?;
+        let format = matches.value_of("format").unwrap().to_owned();
         let env = matches.value_of("env");
         let target = manifest.get_target(env, is_preview)?;
         let user = settings::global_user::GlobalUser::new()?;
@@ -1135,7 +1145,7 @@ fn run() -> Result<(), failure::Error> {
 
         let verbose = matches.is_present("verbose");
 
-        commands::tail::start(&target, &user, tunnel_port, metrics_port, verbose)?;
+        commands::tail::start(&target, &user, format, tunnel_port, metrics_port, verbose)?;
     } else if matches.subcommand_matches("login").is_some() {
         commands::login::run()?;
     }

--- a/src/tail/log_server.rs
+++ b/src/tail/log_server.rs
@@ -1,7 +1,10 @@
+use crate::terminal::{emoji, styles};
 use hyper::server::conn::AddrIncoming;
 use hyper::server::Builder;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
 use tokio::sync::oneshot::Receiver;
 
 pub struct LogServer {
@@ -24,26 +27,55 @@ impl LogServer {
         }
     }
 
-    pub async fn run(self) -> Result<(), failure::Error> {
-        let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(print_logs)) });
+    pub async fn run(self, format: String) -> Result<(), failure::Error> {
+        // this is so bad
+        // but i also am so bad at types
+        // TODO: make this less terrible
+        match format.as_str() {
+            "json" => {
+                let service = make_service_fn(|_| async {
+                    Ok::<_, hyper::Error>(service_fn(print_logs_json))
+                });
 
-        let server = self.server.serve(service);
+                let server = self.server.serve(service);
 
-        // The shutdown receiver listens for a one shot message from our sigint handler as a signal
-        // to gracefully shut down the hyper server.
-        let shutdown_rx = self.shutdown_rx;
+                // The shutdown receiver listens for a one shot message from our sigint handler as a signal
+                // to gracefully shut down the hyper server.
+                let shutdown_rx = self.shutdown_rx;
 
-        let graceful = server.with_graceful_shutdown(async {
-            shutdown_rx.await.ok();
-        });
+                let graceful = server.with_graceful_shutdown(async {
+                    shutdown_rx.await.ok();
+                });
 
-        graceful.await?;
+                graceful.await?;
 
-        Ok(())
+                Ok(())
+            }
+            "pretty" => {
+                let service = make_service_fn(|_| async {
+                    Ok::<_, hyper::Error>(service_fn(print_logs_pretty))
+                });
+
+                let server = self.server.serve(service);
+
+                // The shutdown receiver listens for a one shot message from our sigint handler as a signal
+                // to gracefully shut down the hyper server.
+                let shutdown_rx = self.shutdown_rx;
+
+                let graceful = server.with_graceful_shutdown(async {
+                    shutdown_rx.await.ok();
+                });
+
+                graceful.await?;
+
+                Ok(())
+            }
+            _ => unreachable!(),
+        }
     }
 }
 
-async fn print_logs(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+async fn print_logs_json(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => {
             let whole_body = hyper::body::to_bytes(req.into_body()).await?;
@@ -60,4 +92,108 @@ async fn print_logs(req: Request<Body>) -> Result<Response<Body>, hyper::Error> 
             Ok(bad_request)
         }
     }
+}
+
+async fn print_logs_pretty(req: Request<Body>) -> Result<Response<Body>, failure::Error> {
+    match (req.method(), req.uri().path()) {
+        (&Method::POST, "/") => {
+            let whole_body = hyper::body::to_bytes(req.into_body()).await?;
+
+            let parsed = serde_json::from_slice::<LogResponse>(&whole_body).map_err(|e| {
+                println!("{}", styles::warning("Error parsing response body!"));
+                println!(
+                    "This is not a problem with your worker, it's a problem with Wrangler.\nPlease file an issue on our GitHub page, with a minimal reproducible example of\nthe script that caused this error and a description of what happened."
+                );
+                e
+            })?;
+
+            let secs = (parsed.event_timestamp / 1000).try_into().unwrap();
+
+            let timestamp = chrono::NaiveDateTime::from_timestamp(secs, 0);
+
+            println!(
+                "{}{} {} --> {} @ {} UTC",
+                emoji::EYES,
+                parsed.event.request.method,
+                styles::url(parsed.event.request.url),
+                parsed.outcome.to_uppercase(),
+                timestamp.time()
+            );
+
+            if !parsed.exceptions.is_empty() {
+                println!("  Exceptions:");
+                parsed.exceptions.iter().for_each(|exception| {
+                    println!(
+                        "\t{} {}",
+                        emoji::X,
+                        styles::warning(format!("{}: {}", exception.name, exception.message))
+                    );
+                });
+            }
+
+            if !parsed.logs.is_empty() {
+                println!("  Logs:");
+                parsed.logs.iter().for_each(|log| {
+                    let messages = log.message.join(" ");
+
+                    let output = match log.level.as_str() {
+                        "assert" | "error" => format!("{} {}", emoji::X, styles::warning(messages)),
+                        "warn" => format!("{} {}", emoji::WARN, styles::highlight(messages)),
+                        "trace" | "debug" => {
+                            format!("{}{}", emoji::MICROSCOPE, styles::cyan(messages))
+                        }
+                        _ => format!("{} {}", emoji::FILES, styles::bold(messages)),
+                    };
+
+                    println!("\t{}", output);
+                });
+            }
+
+            Ok(Response::new(Body::from("Success")))
+        }
+        _ => {
+            let mut bad_request = Response::default();
+            *bad_request.status_mut() = StatusCode::BAD_REQUEST;
+            Ok(bad_request)
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LogResponse {
+    outcome: String,
+    script_name: Option<String>,
+    // todo: wtf gets served here
+    exceptions: Vec<LogException>,
+    logs: Vec<LogMessage>,
+    event_timestamp: usize,
+    event: RequestEvent,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LogException {
+    name: String,
+    message: String,
+    timestamp: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LogMessage {
+    message: Vec<String>,
+    level: String,
+    timestamp: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RequestEvent {
+    request: RequestEventData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RequestEventData {
+    url: String,
+    method: String,
+    // headers: bruh,
+    // cf: RequestEventCfData, // lol
 }

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -58,7 +58,7 @@ impl Tail {
             let listener = tokio::spawn(shutdown_handler.run(rx));
 
             // Spin up a local http server to receive logs
-            let log_server = tokio::spawn(LogServer::new(tunnel_port, log_rx).run(format));
+            let log_server = tokio::spawn(LogServer::new(tunnel_port, log_rx, format).run());
 
             // Spin up a new cloudflared tunnel to connect trace worker to local server
             let tunnel_process = Tunnel::new(tunnel_port, metrics_port, verbose)?;

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -34,6 +34,7 @@ impl Tail {
     pub fn run(
         target: Target,
         user: GlobalUser,
+        format: String,
         tunnel_port: u16,
         metrics_port: u16,
         verbose: bool,
@@ -57,7 +58,7 @@ impl Tail {
             let listener = tokio::spawn(shutdown_handler.run(rx));
 
             // Spin up a local http server to receive logs
-            let log_server = tokio::spawn(LogServer::new(tunnel_port, log_rx).run());
+            let log_server = tokio::spawn(LogServer::new(tunnel_port, log_rx).run(format));
 
             // Spin up a new cloudflared tunnel to connect trace worker to local server
             let tunnel_process = Tunnel::new(tunnel_port, metrics_port, verbose)?;

--- a/src/terminal/emoji.rs
+++ b/src/terminal/emoji.rs
@@ -37,3 +37,4 @@ pub static WARN: Emoji = Emoji("⚠️ ", "");
 pub static WAVING: Emoji = Emoji("👋 ", "");
 pub static WORKER: Emoji = Emoji("👷 ", "");
 pub static UNLOCKED: Emoji = Emoji("🔓", "");
+pub static X: Emoji = Emoji("❌ ", "");

--- a/src/terminal/styles.rs
+++ b/src/terminal/styles.rs
@@ -11,3 +11,11 @@ pub fn warning<D>(msg: D) -> StyledObject<D> {
 pub fn highlight<D>(msg: D) -> StyledObject<D> {
     style(msg).yellow().bold()
 }
+
+pub fn cyan<D>(msg: D) -> StyledObject<D> {
+    style(msg).cyan().bold()
+}
+
+pub fn bold<D>(msg: D) -> StyledObject<D> {
+    style(msg).bold()
+}


### PR DESCRIPTION
It may make sense to have this just be a --pretty flag, but if we decide we want to add more formats in the future (like forwarding raw devtools protocol stuff) then it's better to have the --format flag. Plus, we can introduce a warning like "the default is set to json but make sure to be explicit in case we change it"

Example of using `--format pretty` here:


https://user-images.githubusercontent.com/25358963/114754564-b53e2900-9d26-11eb-8ff8-763ffe95cd63.mp4

