### PR TITLE
1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 1.16.0
+
+- ### Features
+
+  - **Custom Builds and Modules - [xortive], [caass], [pull/1855]**
+
+    Custom Builds and Modules has finally landed in a main release!
+    There's too many new features to write about in a changelog, so here's a
+    [link to the docs](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build).
+
+    [xortive]: https://github.com/xortive
+    [caass]: https://github.com/caass
+    [pull/1855]: https://github.com/cloudflare/wrangler/pull/1855
+
+  - **add `--format` option, including default `json` and new `pretty` - [caass], [pull/1851]**
+
+    You can now pass `--format pretty` to `wrangler tail` to get pretty printed logs!
+    `--format json` is also available, and gives you the existing JSON-formatted logs.
+
+    [caass]: https://github.com/caass
+    [pull/1851]: https://github.com/cloudflare/wrangler/pull/1851
+
+- ### Fixes
+
+  - **Revert "Print line and column numbers for exception thrown (#1645)" - [Electroid], [pull/1835]**
+
+    This reverts commit 74a89f7c383bc22758cbe55096ce3016c5c319d7.
+
+    Closes #1826
+
+    This commit is causing `wrangler dev` to not show uncaught exceptions. Reverting `chrome-devtools-rs` was also necessary.
+
+    We have a fix in progress to fix the underlying issue and re-introduce line and column numbers.
+
+    [electroid]: https://github.com/Electroid
+    [pull/1835]: https://github.com/cloudflare/wrangler/pull/1835
+
+  - **Don't generate `usage_model = ""` by default - [xortive], [issues/1850]**
+
+    Generating `usage_model = ""` by default was violating the toml spec, which broke
+    `wrangler init --site` as `usage_model` came after `[site]`.
+
+    [xortive]: https://github.com/xortive
+    [issues/1850]: https://github.com/cloudflare/wrangler/pull/1850
+
 ## 1.15.1
 
 - ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "589652ce7ccb335d1e7ecb3be145425702b290dbcb7029bbeaae263fc1d87b48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -841,7 +841,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "winapi 0.3.9",
 ]
 
@@ -1592,9 +1592,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
-version = "4.0.15"
+version = "4.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+checksum = "2599080e87c9bd051ddb11b10074f4da7b1223298df65d4c2ec5bcf309af1533"
 dependencies = [
  "bitflags",
  "filetime",
@@ -1990,9 +1990,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -2015,7 +2015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
 ]
 
 [[package]]
@@ -2594,7 +2594,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.15.1"
+version = "1.16.0"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>", "Avery Harnish <averyharnish@gmail.com>", "Ashley Lewis <ashleymichal@gmail.com>", "Ashley Williams <ashley666ashley@gmail.com>", "Nat Davidson <davidson@cloudflare.com>", "Steve Manuel <nilslice@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/wrangler",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
closes #1850 

## 1.16.0

- ### Features

  - **Custom Builds and Modules - [xortive], [caass], [pull/1855]**

    Custom Builds and Modules has finally landed in a main release!
    There's too many new features to write about in a changelog, so here's a
    [link to the docs](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build).

    [xortive]: https://github.com/xortive
    [caass]: https://github.com/caass
    [pull/1855]: https://github.com/cloudflare/wrangler/pull/1855

  - **add `--format` option, including default `json` and new `pretty` - [caass], [pull/1851]**

    It may make sense to have this just be a --pretty flag, but if we decide we want to add more formats in the future (like forwarding raw devtools protocol stuff) then it's better to have the --format flag. Plus, we can introduce a warning li
    ... truncated

    [caass]: https://github.com/caass
    [pull/1851]: https://github.com/cloudflare/wrangler/pull/1851