### PR TITLE
fix: use x86_64 arch for pre-built downloads on M1 devices

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -12,11 +12,9 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
-  if (type === "Darwin" && arch === "x64") {
+  if (type === "Darwin" && (arch === "x64" || arch == "arm64")) {
+    // for users of M1 / Apple Silicon devices, use an x86 binary automatically run by Rosetta 2.
     return "x86_64-apple-darwin";
-  }
-  if (type === "Darwin" && arch === "arm64") {
-    return "aarch64-apple-darwin";
   }
 
   throw new Error(`Unsupported platform: ${type} ${arch}`);

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -147,12 +147,10 @@ fn prebuilt_url(tool_name: &str, owner: &str, version: &str) -> Option<String> {
     } else {
         let target = if target::LINUX && target::x86_64 {
             "x86_64-unknown-linux-musl"
-        } else if target::MACOS && target::x86_64 {
+        } else if target::MACOS && (target::x86_64 || target::aarch64) {
             "x86_64-apple-darwin"
         } else if target::WINDOWS && target::x86_64 {
             "x86_64-pc-windows-msvc"
-        } else if target::MACOS && target::aarch64 {
-            "aarch64-apple-darwin"
         } else {
             return None;
         };


### PR DESCRIPTION
This PR forces the use of a pre-built x86_64 binary on a aarch64/arm64 Apple system. For M1 devices specifically, it will fix `wrangler generate`, and `wrangler build` for `type = "rust"` wrangler projects.

There is another semi-related PR that will fix some additional rust/wasm issues in our template repo here: https://github.com/cloudflare/rustwasm-worker-template/pull/21, which would be nice to have merged along with this. 