### PR TITLE
Stop assuming KV values are UTF8 text

### DIFF
--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -9,6 +9,7 @@ use crate::commands::kv;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
+use std::io::{self, Write};
 
 pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
     kv::validate_target(target)?;
@@ -25,10 +26,12 @@ pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<()
 
     let response_status = res.status();
     if response_status.is_success() {
-        let body_text = res.text()?;
+        let body = res.bytes()?;
         // We don't use message::success because we don't want to include the emoji/formatting
-        // in case someone is piping this to stdin
-        print!("{}", &body_text);
+        // in case someone is piping this to stdin.
+        // This will probably fail for non-UTF8 on Windows, but should at least work for people
+        // getting binary data from KV on Unix-y systems.
+        io::stdout().write_all(&*body)?;
     } else {
         // This is logic pulled from cloudflare-rs for pretty error formatting right now;
         // it will be redundant when we switch to using cloudflare-rs for all API requests.


### PR DESCRIPTION
Implementation of kv:key get is calling text() on the result of the api call, so it's replacing non-utf8 values with ef bf bd, the unicode REPLACEMENT CHAR.  KV values can be arbitrary bytes, we shouldn't assume they're UTF8 text, so this patch just writes bytes to stdout.  Probably won't work on Windows, but I don't know of a better option, and this at least isn't worse than we are today.

Testing on 1k of random data:
```
bash-3.2$ hexdump -C /tmp/1k_via_curl | head -n1
00000000  ed ff 79 19 cb 06 6e cf  d6 92 72 d6 89 8b 4f ac  |..y...n...r...O.|

bash-3.2$ hexdump -C /tmp/1k_via_wrangler | head -n1
00000000  ef bf bd ef bf bd 79 19  ef bf bd 06 6e ef bf bd  |......y.....n...|

bash-3.2$ hexdump -C /tmp/1k_via_patched_wrangler | head -n1
00000000  ed ff 79 19 cb 06 6e cf  d6 92 72 d6 89 8b 4f ac  |..y...n...r...O.|
```

Still works on UTF-8 text:

```
bash-3.2$ ~/cf-repos/wrangler/target/debug/wrangler kv:key put foo '(╯°□°)╯︵ ┻━┻' --binding KV
✨  Success
bash-3.2$ ~/cf-repos/wrangler/target/debug/wrangler kv:key get foo --binding KV
(╯°□°)╯︵ ┻━┻
```
