### PR TITLE
failure --> anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,15 +772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exitfailure"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515"
-dependencies = [
- "failure",
-]
-
-[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,6 +3174,7 @@ dependencies = [
 name = "wrangler"
 version = "1.16.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "atty",
  "base64",
@@ -3197,8 +3189,6 @@ dependencies = [
  "dirs 3.0.2",
  "env_logger",
  "eventual",
- "exitfailure",
- "failure",
  "flate2",
  "fs2",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["wasm", "development-tools", "command-line-utilities", "web-progra
 build = "build.rs"
 
 [dependencies]
+anyhow = "1.0"
 atty = "0.2.14"
 base64 = "0.13.0"
 billboard = "0.1.0"
@@ -24,8 +25,6 @@ console = "0.13.0"
 dirs = "3.0.1"
 env_logger = "0.8.2"
 eventual = "0.1.7"
-exitfailure = "0.5.1"
-failure = "0.1.8"
 flate2 = "1.0.18"
 fs2 = "0.4.3"
 futures-util = "0.3"

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use anyhow::Result;
 use clap::ArgMatches;
 
 use super::DEFAULT_CONFIG_PATH;
@@ -7,7 +8,7 @@ use crate::build::build_target;
 use crate::settings::toml::Manifest;
 use crate::terminal::message::{Message, StdOut};
 
-pub fn build(matches: &ArgMatches) -> Result<(), failure::Error> {
+pub fn build(matches: &ArgMatches) -> Result<()> {
     log::info!("Getting project settings");
     let config_file = matches.value_of("config").unwrap_or(DEFAULT_CONFIG_PATH);
     let config_path = Path::new(config_file);

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -9,6 +9,7 @@ use crate::commands::dev::{socket, Protocol, ServerConfig};
 use crate::deploy::DeployTarget;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
+use anyhow::Result;
 
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -23,7 +24,7 @@ pub fn dev(
     local_protocol: Protocol,
     upstream_protocol: Protocol,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let session = Session::new(&target, &user, &deploy_target)?;
     let mut target = target;
 

--- a/src/commands/dev/edge/server/http.rs
+++ b/src/commands/dev/edge/server/http.rs
@@ -5,6 +5,7 @@ use crate::terminal::emoji;
 
 use std::sync::{Arc, Mutex};
 
+use anyhow::Result;
 use chrono::prelude::*;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client as HyperClient, Request, Server};
@@ -15,7 +16,7 @@ pub async fn http(
     preview_token: Arc<Mutex<String>>,
     host: String,
     upstream_protocol: Protocol,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     // set up https client to connect to the preview service
     let https = HttpsConnector::with_native_roots();
     let client = HyperClient::builder().build::<_, Body>(https);
@@ -30,7 +31,7 @@ pub async fn http(
         let server_config = server_config.to_owned();
 
         async move {
-            Ok::<_, failure::Error>(service_fn(move |req| {
+            Ok::<_, anyhow::Error>(service_fn(move |req| {
                 let client = client.to_owned();
                 let preview_token = preview_token.lock().unwrap().to_owned();
                 let host = host.to_owned();
@@ -65,7 +66,7 @@ pub async fn http(
                         version,
                         resp.status()
                     );
-                    Ok::<_, failure::Error>(resp)
+                    Ok::<_, anyhow::Error>(resp)
                 }
             }))
         }

--- a/src/commands/dev/edge/server/https.rs
+++ b/src/commands/dev/edge/server/https.rs
@@ -5,6 +5,7 @@ use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
 use std::sync::{Arc, Mutex};
 
+use anyhow::Result;
 use chrono::prelude::*;
 use futures_util::{stream::StreamExt, FutureExt};
 
@@ -17,7 +18,7 @@ pub async fn https(
     server_config: ServerConfig,
     preview_token: Arc<Mutex<String>>,
     host: String,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     tls::generate_cert()?;
 
     // set up https client to connect to the preview service
@@ -34,7 +35,7 @@ pub async fn https(
         let server_config = server_config.to_owned();
 
         async move {
-            Ok::<_, failure::Error>(service_fn(move |req| {
+            Ok::<_, anyhow::Error>(service_fn(move |req| {
                 let client = client.to_owned();
                 let preview_token = preview_token.lock().unwrap().to_owned();
                 let host = host.to_owned();
@@ -69,7 +70,7 @@ pub async fn https(
                         version,
                         resp.status()
                     );
-                    Ok::<_, failure::Error>(resp)
+                    Ok::<_, anyhow::Error>(resp)
                 }
             }))
         }

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -8,6 +8,7 @@ use crate::sites::{add_namespace, sync};
 use crate::terminal::message::{Message, StdOut};
 use crate::upload;
 
+use anyhow::{anyhow, Result};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -18,7 +19,7 @@ pub(super) fn upload(
     user: &GlobalUser,
     session_token: String,
     verbose: bool,
-) -> Result<String, failure::Error> {
+) -> Result<String> {
     let client = crate::http::legacy_auth_client(&user);
 
     let (to_delete, asset_manifest, site_namespace_id) = if let Some(site_config) =
@@ -78,13 +79,11 @@ impl Session {
         target: &Target,
         user: &GlobalUser,
         deploy_target: &DeployTarget,
-    ) -> Result<Session, failure::Error> {
+    ) -> Result<Session> {
         let exchange_url = get_exchange_url(deploy_target, user)?;
         let host = match exchange_url.host_str() {
             Some(host) => Ok(host.to_string()),
-            None => Err(failure::format_err!(
-                "Could not parse host from exchange url"
-            )),
+            None => Err(anyhow!("Could not parse host from exchange url")),
         }?;
 
         let host = match deploy_target {
@@ -152,10 +151,7 @@ fn get_upload_address(target: &mut Target) -> String {
     )
 }
 
-fn get_exchange_url(
-    deploy_target: &DeployTarget,
-    user: &GlobalUser,
-) -> Result<Url, failure::Error> {
+fn get_exchange_url(deploy_target: &DeployTarget, user: &GlobalUser) -> Result<Url> {
     let client = crate::http::legacy_auth_client(&user);
     let address = get_session_address(deploy_target);
     let url = Url::parse(&address)?;

--- a/src/commands/dev/edge/watch.rs
+++ b/src/commands/dev/edge/watch.rs
@@ -6,6 +6,8 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::watch::watch_and_build;
 
+use anyhow::Result;
+
 pub fn watch_for_changes(
     target: Target,
     deploy_target: &DeployTarget,
@@ -13,7 +15,7 @@ pub fn watch_for_changes(
     preview_token: Arc<Mutex<String>>,
     session_token: String,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
     watch_and_build(&target, Some(sender))?;
 

--- a/src/commands/dev/gcs/headers.rs
+++ b/src/commands/dev/gcs/headers.rs
@@ -12,6 +12,7 @@ const HEADER_PREFIX: &str = "cf-ew-raw-";
 /// must have the prefix stripped
 use std::str::FromStr;
 
+use anyhow::Result;
 use hyper::header::{HeaderMap, HeaderName};
 use hyper::http::request::Parts as RequestParts;
 use hyper::http::response::Parts as ResponseParts;
@@ -23,7 +24,7 @@ pub fn structure_request(parts: &mut RequestParts) {
 }
 
 /// modify a response from the preview service before returning it to the user
-pub fn destructure_response(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+pub fn destructure_response(parts: &mut ResponseParts) -> Result<()> {
     set_response_status(parts)?;
     strip_response_headers_prefix(parts)
 }
@@ -51,7 +52,7 @@ fn prepend_request_headers_prefix(parts: &mut RequestParts) {
 ///
 /// discard headers without that prefix
 /// strip the prefix from real Workers headers
-fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<()> {
     let mut headers = HeaderMap::new();
 
     for header in &parts.headers {
@@ -68,7 +69,7 @@ fn strip_response_headers_prefix(parts: &mut ResponseParts) -> Result<(), failur
 
 /// parse the response status from headers sent by the preview service
 /// and apply the parsed result to mutable ResponseParts
-fn set_response_status(parts: &mut ResponseParts) -> Result<(), failure::Error> {
+fn set_response_status(parts: &mut ResponseParts) -> Result<()> {
     let status = parts
         .headers
         .get("cf-ew-status")

--- a/src/commands/dev/gcs/mod.rs
+++ b/src/commands/dev/gcs/mod.rs
@@ -9,6 +9,7 @@ use watch::watch_for_changes;
 use crate::commands::dev::{socket, Protocol, ServerConfig};
 use crate::settings::toml::Target;
 
+use anyhow::Result;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use tokio::runtime::Runtime as TokioRuntime;
@@ -21,7 +22,7 @@ pub fn dev(
     server_config: ServerConfig,
     local_protocol: Protocol,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     println!("unauthenticated");
 
     // setup the session

--- a/src/commands/dev/gcs/server/http.rs
+++ b/src/commands/dev/gcs/server/http.rs
@@ -6,6 +6,7 @@ use crate::terminal::emoji;
 
 use std::sync::{Arc, Mutex};
 
+use anyhow::Result;
 use chrono::prelude::*;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client as HyperClient, Request, Response, Server};
@@ -13,10 +14,7 @@ use hyper_rustls::HttpsConnector;
 
 /// performs all logic that takes an incoming request
 /// and routes it to the Workers runtime preview service
-pub async fn http(
-    server_config: ServerConfig,
-    preview_id: Arc<Mutex<String>>,
-) -> Result<(), failure::Error> {
+pub async fn http(server_config: ServerConfig, preview_id: Arc<Mutex<String>>) -> Result<()> {
     // set up https client to connect to the preview service
     let https = HttpsConnector::with_native_roots();
     let client = HyperClient::builder().build::<_, Body>(https);
@@ -31,7 +29,7 @@ pub async fn http(
         let server_config = server_config.to_owned();
         let preview_id = preview_id.to_owned();
         async move {
-            Ok::<_, failure::Error>(service_fn(move |req| {
+            Ok::<_, anyhow::Error>(service_fn(move |req| {
                 let client = client.to_owned();
                 let server_config = server_config.to_owned();
                 let preview_id = preview_id.lock().unwrap().to_owned();
@@ -86,7 +84,7 @@ pub async fn http(
                         version,
                         resp.status()
                     );
-                    Ok::<_, failure::Error>(resp)
+                    Ok::<_, anyhow::Error>(resp)
                 }
             }))
         }

--- a/src/commands/dev/gcs/server/https.rs
+++ b/src/commands/dev/gcs/server/https.rs
@@ -7,6 +7,7 @@ use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
 use std::sync::{Arc, Mutex};
 
+use anyhow::Result;
 use chrono::prelude::*;
 use futures_util::{FutureExt, StreamExt};
 use hyper::service::{make_service_fn, service_fn};
@@ -16,10 +17,7 @@ use tokio::net::TcpListener;
 
 /// performs all logic that takes an incoming request
 /// and routes it to the Workers runtime preview service
-pub async fn https(
-    server_config: ServerConfig,
-    preview_id: Arc<Mutex<String>>,
-) -> Result<(), failure::Error> {
+pub async fn https(server_config: ServerConfig, preview_id: Arc<Mutex<String>>) -> Result<()> {
     tls::generate_cert()?;
 
     // set up https client to connect to the preview service
@@ -36,7 +34,7 @@ pub async fn https(
         let server_config = server_config.to_owned();
         let preview_id = preview_id.to_owned();
         async move {
-            Ok::<_, failure::Error>(service_fn(move |req| {
+            Ok::<_, anyhow::Error>(service_fn(move |req| {
                 let client = client.to_owned();
                 let server_config = server_config.to_owned();
                 let preview_id = preview_id.lock().unwrap().to_owned();
@@ -91,7 +89,7 @@ pub async fn https(
                         version,
                         resp.status()
                     );
-                    Ok::<_, failure::Error>(resp)
+                    Ok::<_, anyhow::Error>(resp)
                 }
             }))
         }

--- a/src/commands/dev/gcs/setup.rs
+++ b/src/commands/dev/gcs/setup.rs
@@ -3,11 +3,12 @@ use crate::preview::upload;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
+use anyhow::Result;
 use uuid::Uuid;
 
 /// generate a unique uuid that lasts the entirety of the
 /// `wrangler dev` session
-pub(super) fn get_session_id() -> Result<String, failure::Error> {
+pub(super) fn get_session_id() -> Result<String> {
     Ok(Uuid::new_v4().to_simple().to_string())
 }
 
@@ -22,7 +23,7 @@ pub fn get_preview_id(
     server_config: &ServerConfig,
     session_id: &str,
     verbose: bool,
-) -> Result<String, failure::Error> {
+) -> Result<String> {
     // setting sites_preview to `true` would print a message to the terminal
     // directing the user to open the browser to view the output
     // this message makes sense for `wrangler preview` but not `wrangler dev`

--- a/src/commands/dev/gcs/watch.rs
+++ b/src/commands/dev/gcs/watch.rs
@@ -6,13 +6,15 @@ use crate::commands::dev::server_config::ServerConfig;
 use crate::settings::toml::Target;
 use crate::watch::watch_and_build;
 
+use anyhow::Result;
+
 pub fn watch_for_changes(
     target: Target,
     server_config: &ServerConfig,
     preview_id: Arc<Mutex<String>>,
     session_id: &str,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
     watch_and_build(&target, Some(sender))?;
 

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -15,6 +15,8 @@ use crate::settings::toml::Target;
 use crate::terminal::message::{Message, StdOut};
 use crate::terminal::styles;
 
+use anyhow::Result;
+
 /// `wrangler dev` starts a server on a dev machine that routes incoming HTTP requests
 /// to a Cloudflare Workers runtime and returns HTTP responses
 pub fn dev(
@@ -25,7 +27,7 @@ pub fn dev(
     local_protocol: Protocol,
     upstream_protocol: Protocol,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     // before serving requests we must first build the Worker
     build_target(&target)?;
 
@@ -47,7 +49,7 @@ pub fn dev(
         if let Some(target) = valid_target {
             target.clone()
         } else {
-            failure::bail!("No valid deployment targets: `wrangler dev` can only be used to develop zoned and zoneless deployments")
+            anyhow::bail!("No valid deployment targets: `wrangler dev` can only be used to develop zoned and zoneless deployments")
         }
     };
 
@@ -56,12 +58,12 @@ pub fn dev(
     let upstream_str = styles::highlight("--upstream-protocol");
 
     if server_config.host.is_https() != upstream_protocol.is_https() {
-        failure::bail!(format!(
+        anyhow::bail!(format!(
             "Protocol mismatch: protocol in {} and protocol in {} must match",
             host_str, upstream_str
         ))
     } else if local_protocol.is_https() && upstream_protocol.is_http() {
-        failure::bail!("{} cannot be https if {} is http", local_str, upstream_str)
+        anyhow::bail!("{} cannot be https if {} is http", local_str, upstream_str)
     }
 
     if let Some(user) = user {

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -58,10 +58,11 @@ pub fn dev(
     let upstream_str = styles::highlight("--upstream-protocol");
 
     if server_config.host.is_https() != upstream_protocol.is_https() {
-        anyhow::bail!(format!(
+        anyhow::bail!(
             "Protocol mismatch: protocol in {} and protocol in {} must match",
-            host_str, upstream_str
-        ))
+            host_str,
+            upstream_str
+        )
     } else if local_protocol.is_https() && upstream_protocol.is_http() {
         anyhow::bail!("{} cannot be https if {} is http", local_str, upstream_str)
     }

--- a/src/commands/dev/server_config/host.rs
+++ b/src/commands/dev/server_config/host.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -10,7 +10,7 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new(host: &str, default: bool) -> Result<Self, failure::Error> {
+    pub fn new(host: &str, default: bool) -> Result<Self> {
         // try to create a url from host
         let url = match Url::parse(&host) {
             Ok(host) => Ok(host),
@@ -22,11 +22,11 @@ impl Host {
         // validate scheme
         let scheme = url.scheme();
         if scheme != "http" && scheme != "https" {
-            failure::bail!("Your host scheme must be either http or https")
+            anyhow::bail!("Your host scheme must be either http or https")
         }
 
         // validate host
-        let host = url.host_str().ok_or_else(|| format_err!("Invalid host, accepted formats are example.com, http://example.com, or https://example.com"))?;
+        let host = url.host_str().ok_or_else(|| anyhow!("Invalid host, accepted formats are example.com, http://example.com, or https://example.com"))?;
 
         // recreate url without any trailing path
         let url = Url::parse(&format!("{}://{}", scheme, host))?;

--- a/src/commands/dev/server_config/mod.rs
+++ b/src/commands/dev/server_config/mod.rs
@@ -5,6 +5,7 @@ pub use protocol::Protocol;
 
 use host::Host;
 
+use anyhow::Result;
 use std::net::{SocketAddr, TcpListener};
 
 #[derive(Debug, Clone)]
@@ -19,13 +20,13 @@ impl ServerConfig {
         ip: Option<&str>,
         port: Option<u16>,
         upstream_protocol: Protocol,
-    ) -> Result<Self, failure::Error> {
+    ) -> Result<Self> {
         let ip = ip.unwrap_or("127.0.0.1");
         let port = port.unwrap_or(8787);
         let addr = format!("{}:{}", ip, port);
         let listening_address = match TcpListener::bind(&addr) {
             Ok(socket) => socket.local_addr(),
-            Err(_) => failure::bail!("{} is unavailable, try binding to another address with the --port and --ip flags, or stop other `wrangler dev` processes.", &addr)
+            Err(_) => anyhow::bail!("{} is unavailable, try binding to another address with the --port and --ip flags, or stop other `wrangler dev` processes.", &addr)
         }?;
 
         let host = if let Some(host) = host {

--- a/src/commands/dev/server_config/protocol.rs
+++ b/src/commands/dev/server_config/protocol.rs
@@ -1,4 +1,5 @@
-pub use std::convert::TryFrom;
+use anyhow::{anyhow, Result};
+use std::convert::TryFrom;
 
 #[derive(Clone, Copy)]
 pub enum Protocol {
@@ -17,13 +18,13 @@ impl Protocol {
 }
 
 impl TryFrom<&str> for Protocol {
-    type Error = failure::Error;
+    type Error = anyhow::Error;
 
-    fn try_from(p: &str) -> Result<Protocol, failure::Error> {
+    fn try_from(p: &str) -> Result<Protocol> {
         match p {
             "http" => Ok(Protocol::Http),
             "https" => Ok(Protocol::Https),
-            _ => failure::bail!("Invalid protocol, must be http or https"),
+            _ => Err(anyhow!("Invalid protocol, must be http or https")),
         }
     }
 }

--- a/src/commands/dev/tls/certs.rs
+++ b/src/commands/dev/tls/certs.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::hash::MessageDigest;
@@ -14,7 +15,7 @@ use std::path::PathBuf;
 use crate::settings::get_wrangler_home_dir;
 use crate::terminal::message::{Message, StdOut};
 /// Create files for cert and private key
-fn create_output_files() -> Result<Option<(PathBuf, PathBuf)>, failure::Error> {
+fn create_output_files() -> Result<Option<(PathBuf, PathBuf)>> {
     let home = get_wrangler_home_dir()?.join("config");
     let cert = home.join("dev-cert.pem");
     let privkey = home.join("dev-privkey.rsa");
@@ -31,7 +32,7 @@ fn create_output_files() -> Result<Option<(PathBuf, PathBuf)>, failure::Error> {
 }
 
 /// Generate certificate authority to sign cert
-fn create_ca() -> Result<(X509, PKey<Private>), failure::Error> {
+fn create_ca() -> Result<(X509, PKey<Private>)> {
     let rsa = Rsa::generate(2048)?;
     let privkey = PKey::from_rsa(rsa)?;
 
@@ -77,7 +78,7 @@ fn create_ca() -> Result<(X509, PKey<Private>), failure::Error> {
     Ok((cert, privkey))
 }
 
-fn create_req(privkey: &PKey<Private>) -> Result<X509Req, failure::Error> {
+fn create_req(privkey: &PKey<Private>) -> Result<X509Req> {
     let mut req_builder = X509ReqBuilder::new()?;
     req_builder.set_pubkey(&privkey)?;
 
@@ -95,7 +96,7 @@ fn create_req(privkey: &PKey<Private>) -> Result<X509Req, failure::Error> {
 }
 
 /// Generate cert and private key
-pub fn generate_cert() -> Result<(), failure::Error> {
+pub fn generate_cert() -> Result<()> {
     let files = create_output_files()?;
     if files.is_none() {
         return Ok(());

--- a/src/commands/dev/tls/mod.rs
+++ b/src/commands/dev/tls/mod.rs
@@ -1,6 +1,7 @@
 mod certs;
 pub use certs::generate_cert;
 
+use anyhow::Result;
 use core::task::{Context, Poll};
 use fs::File;
 use futures_util::stream::Stream;
@@ -17,7 +18,7 @@ use tokio_rustls::{server::TlsStream, TlsAcceptor};
 use crate::settings::get_wrangler_home_dir;
 
 // Build TLS configuration
-pub(super) fn get_tls_acceptor() -> Result<TlsAcceptor, failure::Error> {
+pub(super) fn get_tls_acceptor() -> Result<TlsAcceptor> {
     let home = get_wrangler_home_dir()?.join("config");
     let cert = home.join("dev-cert.pem");
     let privkey = home.join("dev-privkey.rsa");

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::{env, fs};
 
+use anyhow::Result;
+
 use crate::commands::validate_worker_name;
 use crate::settings::toml::{Manifest, Site, TargetType};
 use crate::{commands, install};
@@ -12,7 +14,7 @@ pub fn generate(
     template: &str,
     target_type: Option<TargetType>,
     site: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     validate_worker_name(name)?;
 
     let new_name = if directory_exists(name).unwrap_or(true) {
@@ -46,7 +48,7 @@ pub fn generate(
     Ok(())
 }
 
-pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
+pub fn run_generate(name: &str, template: &str) -> Result<()> {
     let binary_path = install::install_cargo_generate()?;
 
     let args = ["generate", "--git", template, "--name", name, "--force"];
@@ -56,7 +58,7 @@ pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
     commands::run(command, &command_name)
 }
 
-fn generate_name(name: &str) -> Result<String, failure::Error> {
+fn generate_name(name: &str) -> Result<String> {
     let mut num = 1;
     let entry_names = read_current_dir()?;
     let mut new_name = construct_name(&name, num);
@@ -68,7 +70,7 @@ fn generate_name(name: &str) -> Result<String, failure::Error> {
     Ok(new_name)
 }
 
-fn read_current_dir() -> Result<Vec<OsString>, failure::Error> {
+fn read_current_dir() -> Result<Vec<OsString>> {
     let current_dir = env::current_dir()?;
     let mut entry_names = Vec::new();
 
@@ -82,7 +84,7 @@ fn read_current_dir() -> Result<Vec<OsString>, failure::Error> {
     Ok(entry_names)
 }
 
-fn directory_exists(dirname: &str) -> Result<bool, failure::Error> {
+fn directory_exists(dirname: &str) -> Result<bool> {
     let entry_names = read_current_dir()?;
     Ok(entry_names.contains(&OsString::from(dirname)))
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,13 +1,11 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+
 use crate::commands::validate_worker_name;
 use crate::settings::toml::{Manifest, Site, TargetType};
 use crate::terminal::message::{Message, StdOut};
-pub fn init(
-    name: Option<&str>,
-    target_type: Option<TargetType>,
-    site_flag: bool,
-) -> Result<(), failure::Error> {
+pub fn init(name: Option<&str>, target_type: Option<TargetType>, site_flag: bool) -> Result<()> {
     if Path::new("./wrangler.toml").exists() {
         if site_flag {
             let msg = r#"A wrangler.toml file already exists!
@@ -19,9 +17,9 @@ bucket = "" # this should point to the directory with static assets
 entry-point = "workers-site"
 
 "#;
-            failure::bail!(msg);
+            anyhow::bail!(msg);
         } else {
-            failure::bail!("A wrangler.toml file already exists! Please remove it before running this command again.");
+            anyhow::bail!("A wrangler.toml file already exists! Please remove it before running this command again.");
         }
     }
     let dirname = get_current_dirname()?;
@@ -50,7 +48,7 @@ entry-point = "workers-site"
     Ok(())
 }
 
-fn get_current_dirname() -> Result<String, failure::Error> {
+fn get_current_dirname() -> Result<String> {
     let current_path = std::env::current_dir()?;
     let parent = current_path.parent();
     let dirname = match parent {

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 
+use anyhow::{anyhow, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::commands::kv::validate_target;
@@ -14,12 +15,7 @@ use crate::kv::bulk::BATCH_KEY_MAX;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::message::{Message, StdErr};
-pub fn run(
-    target: &Target,
-    user: &GlobalUser,
-    namespace_id: &str,
-    filename: &Path,
-) -> Result<(), failure::Error> {
+pub fn run(target: &Target, user: &GlobalUser, namespace_id: &str, filename: &Path) -> Result<()> {
     validate_target(target)?;
 
     let pairs: Vec<KeyValuePair> = match &metadata(filename) {
@@ -28,14 +24,14 @@ pub fn run(
             let data_vec = serde_json::from_str(&data);
             match data_vec {
                 Ok(data_vec) => Ok(data_vec),
-                Err(_) => Err(failure::format_err!("Failed to decode JSON. Please make sure to follow the format, [{{\"key\": \"test_key\", \"value\": \"test_value\"}}, ...]"))
+                Err(_) => Err(anyhow!("Failed to decode JSON. Please make sure to follow the format, [{{\"key\": \"test_key\", \"value\": \"test_value\"}}, ...]"))
             }
         }
-        Ok(_) => Err(failure::format_err!(
+        Ok(_) => Err(anyhow!(
             "{} should be a JSON file, but is not",
             filename.display()
         )),
-        Err(e) => Err(failure::format_err!("{}", e)),
+        Err(e) => Err(anyhow!("{}", e)),
     }?;
 
     let len = pairs.len();

--- a/src/commands/kv/key/delete.rs
+++ b/src/commands/kv/key/delete.rs
@@ -1,18 +1,15 @@
 use cloudflare::endpoints::workerskv::delete_key::DeleteKey;
 use cloudflare::framework::apiclient::ApiClient;
 
+use anyhow::Result;
+
 use crate::commands::kv::{format_error, validate_target};
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::interactive;
 use crate::terminal::message::{Message, StdOut};
-pub fn delete(
-    target: &Target,
-    user: &GlobalUser,
-    id: &str,
-    key: &str,
-) -> Result<(), failure::Error> {
+pub fn delete(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<()> {
     validate_target(target)?;
     let client = http::cf_v4_client(user)?;
 
@@ -22,7 +19,7 @@ pub fn delete(
             StdOut::info(&format!("Not deleting key \"{}\"", key));
             return Ok(());
         }
-        Err(e) => failure::bail!(e),
+        Err(e) => anyhow::bail!(e),
     }
 
     let msg = format!("Deleting key \"{}\"", key);

--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -5,13 +5,15 @@
 
 use cloudflare::framework::response::ApiFailure;
 
+use anyhow::Result;
+
 use crate::commands::kv;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use std::io::{self, Write};
 
-pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<(), failure::Error> {
+pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<()> {
     kv::validate_target(target)?;
     let api_endpoint = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/values/{}",

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -6,6 +6,8 @@ use crate::kv::key::KeyList;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
+use anyhow::Result;
+
 // Note: this function only prints keys in json form, given that
 // the number of entries in each json blob is variable (so csv and tsv
 // representation won't make sense)
@@ -14,7 +16,7 @@ pub fn list(
     user: &GlobalUser,
     namespace_id: &str,
     prefix: Option<&str>,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     kv::validate_target(target)?;
     let client = http::cf_v4_client(&user)?;
     let key_list = KeyList::new(target, client, namespace_id, prefix)?;

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -5,6 +5,7 @@
 use std::fs;
 use std::fs::metadata;
 
+use anyhow::Result;
 use cloudflare::framework::response::ApiFailure;
 use url::Url;
 
@@ -26,7 +27,7 @@ pub struct KVMetaData {
     pub metadata: Option<serde_json::Value>,
 }
 
-pub fn parse_metadata(arg: Option<&str>) -> Result<Option<serde_json::Value>, failure::Error> {
+pub fn parse_metadata(arg: Option<&str>) -> Result<Option<serde_json::Value>> {
     match arg {
         None => Ok(None),
         Some(s) => {
@@ -36,18 +37,18 @@ pub fn parse_metadata(arg: Option<&str>) -> Result<Option<serde_json::Value>, fa
                     // try to help users that forget to double-quote a JSON string
                     let re = Regex::new(r#"^['"]?[^"'{}\[\]]*['"]?$"#)?;
                     if re.is_match(s) {
-                        failure::bail!(
+                        anyhow::bail!(
                             "did you remember to double quote strings, like --metadata '\"made with 🤠 wrangler\"'"
                         )
                     }
-                    failure::bail!(e.to_string())
+                    anyhow::bail!(e.to_string())
                 }
             }
         }
     }
 }
 
-pub fn put(target: &Target, user: &GlobalUser, data: KVMetaData) -> Result<(), failure::Error> {
+pub fn put(target: &Target, user: &GlobalUser, data: KVMetaData) -> Result<()> {
     kv::validate_target(target)?;
 
     let api_endpoint = format!(
@@ -91,7 +92,7 @@ fn get_response(
     data: KVMetaData,
     user: &GlobalUser,
     url: &Url,
-) -> Result<reqwest::blocking::Response, failure::Error> {
+) -> Result<reqwest::blocking::Response> {
     let url_into_str = url.to_string();
     let client = http::legacy_auth_client(user);
     let value_body = get_request_body(&data)?;
@@ -110,19 +111,19 @@ fn get_response(
 
 // If is_file is true, overwrite value to be the contents of the given
 // filename in the 'value' arg.
-fn get_request_body(data: &KVMetaData) -> Result<Vec<u8>, failure::Error> {
+fn get_request_body(data: &KVMetaData) -> Result<Vec<u8>> {
     if data.is_file {
         match &metadata(&data.value) {
             Ok(file_type) if file_type.is_file() => Ok(fs::read(&data.value)?),
-            Ok(file_type) if file_type.is_dir() => failure::bail!(
+            Ok(file_type) if file_type.is_dir() => anyhow::bail!(
                 "--path argument takes a file, {} is a directory",
                 data.value
             ),
-            Ok(_) => failure::bail!(
+            Ok(_) => anyhow::bail!(
                 "--path argument points to an entity that is not a file or a directory: {}",
                 data.value
             ),
-            Err(e) => failure::bail!("{}", e),
+            Err(e) => anyhow::bail!("{}", e),
         }
     } else {
         Ok(data.value.clone().into())

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use cloudflare::framework::response::ApiFailure;
 
+use anyhow::Result;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
 use crate::http;
@@ -38,7 +39,7 @@ fn kv_help(error_code: u16) -> &'static str {
     }
 }
 
-pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
+pub fn validate_target(target: &Target) -> Result<()> {
     let mut missing_fields = Vec::new();
 
     if target.account_id.is_empty() {
@@ -46,7 +47,7 @@ pub fn validate_target(target: &Target) -> Result<(), failure::Error> {
     };
 
     if !missing_fields.is_empty() {
-        failure::bail!(
+        anyhow::bail!(
             "Your configuration file is missing the following field(s): {:?}",
             missing_fields
         )
@@ -72,9 +73,9 @@ fn check_duplicate_namespaces(target: &Target) -> bool {
 }
 
 // Get namespace id for a given binding name.
-pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failure::Error> {
+pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String> {
     if check_duplicate_namespaces(&target) {
-        failure::bail!(
+        anyhow::bail!(
             "Namespace binding \"{}\" is duplicated in \"{}\"",
             binding,
             target.name
@@ -87,7 +88,7 @@ pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String, failur
         }
     }
 
-    failure::bail!(
+    anyhow::bail!(
         "Namespace binding \"{}\" not found in \"{}\"",
         binding,
         target.name

--- a/src/commands/kv/namespace/create.rs
+++ b/src/commands/kv/namespace/create.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use regex::Regex;
 
 use crate::commands::kv;
@@ -12,7 +13,7 @@ pub fn run(
     env: Option<&str>,
     user: &GlobalUser,
     binding: &str,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let account_id = manifest.get_account_id(env)?;
     let worker_name = manifest.worker_name(env);
     validate_binding(binding)?;
@@ -50,10 +51,10 @@ pub fn run(
     Ok(())
 }
 
-fn validate_binding(binding: &str) -> Result<(), failure::Error> {
+fn validate_binding(binding: &str) -> Result<()> {
     let re = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
     if !re.is_match(binding) {
-        failure::bail!(
+        anyhow::bail!(
             "A binding can only have alphanumeric and _ characters, and cannot begin with a number"
         )
     }

--- a/src/commands/kv/namespace/delete.rs
+++ b/src/commands/kv/namespace/delete.rs
@@ -5,7 +5,10 @@ use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::terminal::interactive;
 use crate::terminal::message::{Message, StdOut};
-pub fn run(target: &Target, user: &GlobalUser, id: &str) -> Result<(), failure::Error> {
+
+use anyhow::Result;
+
+pub fn run(target: &Target, user: &GlobalUser, id: &str) -> Result<()> {
     kv::validate_target(target)?;
     let client = http::cf_v4_client(user)?;
 
@@ -18,7 +21,7 @@ pub fn run(target: &Target, user: &GlobalUser, id: &str) -> Result<(), failure::
             StdOut::info(&format!("Not deleting namespace {}", id));
             return Ok(());
         }
-        Err(e) => failure::bail!(e),
+        Err(e) => anyhow::bail!(e),
     }
 
     let msg = format!("Deleting namespace {}", id);

--- a/src/commands/kv/namespace/list.rs
+++ b/src/commands/kv/namespace/list.rs
@@ -1,12 +1,12 @@
-extern crate serde_json;
-
 use crate::commands::kv;
 use crate::http;
 use crate::kv::namespace::list;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
-pub fn run(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
+use anyhow::Result;
+
+pub fn run(target: &Target, user: &GlobalUser) -> Result<()> {
     kv::validate_target(target)?;
 
     let client = http::cf_v4_client(user)?;
@@ -15,7 +15,7 @@ pub fn run(target: &Target, user: &GlobalUser) -> Result<(), failure::Error> {
         Ok(namespaces) => {
             println!("{}", serde_json::to_string(&namespaces)?);
         }
-        Err(e) => failure::bail!(e),
+        Err(e) => anyhow::bail!(e),
     }
     Ok(())
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,5 +1,6 @@
 use crate::login;
+use anyhow::Result;
 
-pub fn run() -> Result<(), failure::Error> {
+pub fn run() -> Result<()> {
     login::run()
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,18 +27,19 @@ pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;
 
+use anyhow::Result;
 use regex::Regex;
 
 pub const DEFAULT_CONFIG_PATH: &str = "./wrangler.toml";
 
 // Run the given command and return its stdout.
-pub fn run(mut command: Command, command_name: &str) -> Result<(), failure::Error> {
+pub fn run(mut command: Command, command_name: &str) -> Result<()> {
     log::info!("Running {:?}", command);
 
     let status = command.status()?;
 
     if !status.success() {
-        failure::bail!(
+        anyhow::bail!(
             "tried running command:\n{}\nexited with {}",
             command_name.replace("\"", ""),
             status
@@ -48,10 +49,10 @@ pub fn run(mut command: Command, command_name: &str) -> Result<(), failure::Erro
 }
 
 // Ensures that Worker name is valid.
-pub fn validate_worker_name(name: &str) -> Result<(), failure::Error> {
+pub fn validate_worker_name(name: &str) -> Result<()> {
     let re = Regex::new(r"^[a-z0-9_][a-z0-9-_]*$").unwrap();
     if !re.is_match(&name) {
-        failure::bail!("Worker name \"{}\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.", name)
+        anyhow::bail!("Worker name \"{}\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.", name)
     }
     Ok(())
 }

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -2,11 +2,13 @@ use crate::preview::{preview, PreviewOpt};
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
+use anyhow::Result;
+
 pub fn run(
     target: Target,
     user: Option<GlobalUser>,
     options: PreviewOpt,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     preview(target, user, options, verbose)
 }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,7 @@ pub fn publish(
     target: &mut Target,
     deployments: DeploymentSet,
     out: Output,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     validate_target_required_fields_present(target)?;
 
     let run_deploy = |target: &Target| match deploy::deploy(&user, &deployments) {
@@ -153,24 +154,24 @@ fn build_output_message(deploy_results: deploy::DeployResults, target_name: Stri
 
 // We don't want folks setting their bucket to the top level directory,
 // which is where wrangler commands are always called from.
-pub fn validate_bucket_location(bucket: &PathBuf) -> Result<(), failure::Error> {
+pub fn validate_bucket_location(bucket: &PathBuf) -> Result<()> {
     // TODO: this should really use a convenience function for "Wrangler Project Root"
     let current_dir = env::current_dir()?;
     if bucket.as_os_str() == current_dir {
-        failure::bail!(
+        anyhow::bail!(
             "{} Your bucket cannot be set to the parent directory of your configuration file",
             emoji::WARN
         )
     }
     let path = Path::new(&bucket);
     if !path.exists() {
-        failure::bail!(
+        anyhow::bail!(
             "{} bucket directory \"{}\" does not exist",
             emoji::WARN,
             path.display()
         )
     } else if !path.is_dir() {
-        failure::bail!(
+        anyhow::bail!(
             "{} bucket \"{}\" is not a directory",
             emoji::WARN,
             path.display()
@@ -180,7 +181,7 @@ pub fn validate_bucket_location(bucket: &PathBuf) -> Result<(), failure::Error> 
     Ok(())
 }
 
-fn validate_target_required_fields_present(target: &Target) -> Result<(), failure::Error> {
+fn validate_target_required_fields_present(target: &Target) -> Result<()> {
     let mut missing_fields = Vec::new();
 
     if target.account_id.is_empty() {
@@ -207,7 +208,7 @@ fn validate_target_required_fields_present(target: &Target) -> Result<(), failur
     };
 
     if !missing_fields.is_empty() {
-        failure::bail!(
+        anyhow::bail!(
             "{} Your configuration file is missing the {} {:?} which {} required to publish your worker!",
             emoji::WARN,
             field_pluralization,

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1,12 +1,11 @@
-extern crate serde_json;
-
+use anyhow::Result;
 use cloudflare::endpoints::workers::{DeleteRoute, ListRoutes};
 use cloudflare::framework::apiclient::ApiClient;
 
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::terminal::message::{Message, StdOut};
-pub fn list(zone_identifier: String, user: &GlobalUser) -> Result<(), failure::Error> {
+pub fn list(zone_identifier: String, user: &GlobalUser) -> Result<()> {
     let client = http::cf_v4_client(user)?;
 
     let result = client.request(&ListRoutes {
@@ -19,16 +18,12 @@ pub fn list(zone_identifier: String, user: &GlobalUser) -> Result<(), failure::E
             println!("{}", serde_json::to_string(&routes)?);
         }
 
-        Err(e) => failure::bail!("{}", http::format_error(e, None)),
+        Err(e) => anyhow::bail!("{}", http::format_error(e, None)),
     }
     Ok(())
 }
 
-pub fn delete(
-    zone_identifier: String,
-    user: &GlobalUser,
-    route_id: &str,
-) -> Result<(), failure::Error> {
+pub fn delete(zone_identifier: String, user: &GlobalUser, route_id: &str) -> Result<()> {
     let client = http::cf_v4_client(user)?;
 
     let result = client.request(&DeleteRoute {
@@ -42,7 +37,7 @@ pub fn delete(
             StdOut::success(&msg);
         }
 
-        Err(e) => failure::bail!("{}", http::format_error(e, Some(&error_suggestions))),
+        Err(e) => anyhow::bail!("{}", http::format_error(e, Some(&error_suggestions))),
     }
     Ok(())
 }

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -4,6 +4,7 @@ use crate::settings::toml::Target;
 use crate::terminal::message::{Message, StdOut};
 use crate::terminal::{emoji, interactive};
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
@@ -12,7 +13,7 @@ pub struct Subdomain {
 }
 
 impl Subdomain {
-    pub fn get(account_id: &str, user: &GlobalUser) -> Result<Option<String>, failure::Error> {
+    pub fn get(account_id: &str, user: &GlobalUser) -> Result<Option<String>> {
         let addr = subdomain_addr(account_id);
 
         let client = http::legacy_auth_client(user);
@@ -20,7 +21,7 @@ impl Subdomain {
         let response = client.get(&addr).send()?;
 
         if !response.status().is_success() {
-            failure::bail!(
+            anyhow::bail!(
                 "{} There was an error fetching your subdomain.\n Status Code: {}\n Msg: {}",
                 emoji::WARN,
                 response.status(),
@@ -31,7 +32,7 @@ impl Subdomain {
         Ok(response.result.map(|r| r.subdomain))
     }
 
-    pub fn put(name: &str, account_id: &str, user: &GlobalUser) -> Result<(), failure::Error> {
+    pub fn put(name: &str, account_id: &str, user: &GlobalUser) -> Result<()> {
         let addr = subdomain_addr(account_id);
         let subdomain = Subdomain {
             subdomain: name.to_string(),
@@ -66,7 +67,7 @@ impl Subdomain {
                     response_text
                 )
             };
-            failure::bail!(msg)
+            anyhow::bail!(msg)
         }
         StdOut::success(&format!("Success! You've registered {}.", name));
         Ok(())
@@ -107,11 +108,7 @@ fn subdomain_addr(account_id: &str) -> String {
     )
 }
 
-fn register_subdomain(
-    name: &str,
-    user: &GlobalUser,
-    target: &Target,
-) -> Result<(), failure::Error> {
+fn register_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<()> {
     let msg = format!(
         "Registering your subdomain, {}.workers.dev, this could take up to a minute.",
         name
@@ -120,9 +117,9 @@ fn register_subdomain(
     Subdomain::put(name, &target.account_id, user)
 }
 
-pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<()> {
     if target.account_id.is_empty() {
-        failure::bail!(format!(
+        anyhow::bail!(format!(
             "{} You must provide an account_id in your configuration file before creating a subdomain!",
             emoji::WARN
         ))
@@ -162,7 +159,7 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
                     StdOut::info(&format!("Keeping subdomain: {}.workers.dev", subdomain));
                     return Ok(());
                 }
-                Err(e) => failure::bail!(e),
+                Err(e) => anyhow::bail!(e),
             }
         }
     }
@@ -170,7 +167,7 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
     register_subdomain(&name, &user, &target)
 }
 
-pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::Error> {
+pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<()> {
     let subdomain = Subdomain::get(&target.account_id, user)?;
     if let Some(subdomain) = subdomain {
         let msg = format!("{}.workers.dev", subdomain);
@@ -183,10 +180,7 @@ pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<(), failure::
     Ok(())
 }
 
-fn get_subdomain_scripts(
-    account_id: &str,
-    user: &GlobalUser,
-) -> Result<Vec<String>, failure::Error> {
+fn get_subdomain_scripts(account_id: &str, user: &GlobalUser) -> Result<Vec<String>> {
     let addr = scripts_addr(account_id);
 
     let client = http::legacy_auth_client(user);
@@ -197,7 +191,7 @@ fn get_subdomain_scripts(
         .send()?;
 
     if !response.status().is_success() {
-        failure::bail!(
+        anyhow::bail!(
             "{} There was an error fetching scripts.\n Status Code: {}\n Msg: {}",
             emoji::WARN,
             response.status(),

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -119,10 +119,10 @@ fn register_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<
 
 pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<()> {
     if target.account_id.is_empty() {
-        anyhow::bail!(format!(
+        anyhow::bail!(
             "{} You must provide an account_id in your configuration file before creating a subdomain!",
             emoji::WARN
-        ))
+        )
     }
     let subdomain = Subdomain::get(&target.account_id, user)?;
     if let Some(subdomain) = subdomain {

--- a/src/commands/tail.rs
+++ b/src/commands/tail.rs
@@ -1,5 +1,7 @@
 use std::net::{SocketAddr, TcpListener};
 
+use anyhow::Result;
+
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 use crate::tail::Tail;
@@ -14,7 +16,7 @@ pub fn start(
     tunnel_port: Option<u16>,
     metrics_port: Option<u16>,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let tunnel_port = find_open_port(tunnel_port, DEFAULT_TUNNEL_PORT)?;
     let metrics_port = find_open_port(metrics_port, DEFAULT_METRICS_PORT)?;
 
@@ -29,12 +31,12 @@ pub fn start(
 }
 
 /// Find open port takes two arguments: an Optional requested port, and a default port.
-fn find_open_port(requested: Option<u16>, default: u16) -> Result<u16, failure::Error> {
+fn find_open_port(requested: Option<u16>, default: u16) -> Result<u16> {
     if let Some(port) = requested {
         let addr = format!("127.0.0.1:{}", port);
         match TcpListener::bind(addr) {
             Ok(socket) => Ok(socket.local_addr()?.port()),
-            Err(_) => failure::bail!("the specified port {} is unavailable", port),
+            Err(_) => anyhow::bail!("the specified port {} is unavailable", port),
         }
     } else {
         // try to use the default port; else get an ephemeral port from the OS

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -7,10 +7,11 @@ use cloudflare::endpoints::user::GetUserDetails;
 use cloudflare::framework::apiclient::ApiClient;
 use cloudflare::framework::response::ApiFailure;
 
+use anyhow::Result;
 use prettytable::{Cell, Row, Table};
 
 /// Tells the user who they are
-pub fn whoami(user: &GlobalUser) -> Result<(), failure::Error> {
+pub fn whoami(user: &GlobalUser) -> Result<()> {
     let mut missing_permissions: Vec<String> = Vec::with_capacity(2);
     // Attempt to print email for both GlobalKeyAuth and TokenAuth users
     let auth: String = match user {
@@ -91,7 +92,7 @@ pub fn display_account_id_maybe() {
 fn fetch_api_token_email(
     user: &GlobalUser,
     missing_permissions: &mut Vec<String>,
-) -> Result<Option<String>, failure::Error> {
+) -> Result<Option<String>> {
     let client = http::cf_v4_client(user)?;
     let response = client.request(&GetUserDetails {});
     match response {
@@ -104,18 +105,18 @@ fn fetch_api_token_email(
                 }
                 Ok(None)
             }
-            ApiFailure::Invalid(_) => failure::bail!(http::format_error(e, None)),
+            ApiFailure::Invalid(_) => anyhow::bail!(http::format_error(e, None)),
         },
     }
 }
 
 /// Fetch the accounts associated with a user
-fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>, failure::Error> {
+fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>> {
     let client = http::cf_v4_client(user)?;
     let response = client.request(&account::ListAccounts { params: None });
     match response {
         Ok(res) => Ok(res.result),
-        Err(e) => failure::bail!(http::format_error(e, None)),
+        Err(e) => anyhow::bail!(http::format_error(e, None)),
     }
 }
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -2,6 +2,7 @@ mod schedule;
 mod zoned;
 mod zoneless;
 
+use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
 pub use schedule::ScheduleTarget;
 pub use zoned::ZonedTarget;
@@ -19,10 +20,7 @@ pub enum DeployTarget {
     Schedule(ScheduleTarget),
 }
 
-pub fn deploy(
-    user: &GlobalUser,
-    deploy_targets: &[DeployTarget],
-) -> Result<DeployResults, failure::Error> {
+pub fn deploy(user: &GlobalUser, deploy_targets: &[DeployTarget]) -> Result<DeployResults> {
     let style = ProgressStyle::default_spinner().template("{spinner}   {msg}");
     let spinner = ProgressBar::new_spinner().with_style(style);
     spinner.enable_steady_tick(20);

--- a/src/deploy/schedule.rs
+++ b/src/deploy/schedule.rs
@@ -1,6 +1,8 @@
 use crate::http;
 use crate::settings::global_user::GlobalUser;
 
+use anyhow::Result;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScheduleTarget {
     pub account_id: String,
@@ -9,11 +11,7 @@ pub struct ScheduleTarget {
 }
 
 impl ScheduleTarget {
-    pub fn build(
-        account_id: String,
-        script_name: String,
-        crons: Vec<String>,
-    ) -> Result<Self, failure::Error> {
+    pub fn build(account_id: String, script_name: String, crons: Vec<String>) -> Result<Self> {
         // TODO: add validation for expressions before pushing them to the API
         // we can do this once the cron parser is open sourced
         Ok(Self {
@@ -23,7 +21,7 @@ impl ScheduleTarget {
         })
     }
 
-    pub fn deploy(&self, user: &GlobalUser) -> Result<Vec<String>, failure::Error> {
+    pub fn deploy(&self, user: &GlobalUser) -> Result<Vec<String>> {
         log::info!("publishing schedules");
         let schedule_worker_addr = format!(
             "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}/schedules",
@@ -40,7 +38,7 @@ impl ScheduleTarget {
             .send()?;
 
         if !res.status().is_success() {
-            failure::bail!(
+            anyhow::bail!(
                 "Something went wrong! Status: {}, Details {}",
                 res.status(),
                 res.text()?

--- a/src/deploy/zoneless.rs
+++ b/src/deploy/zoneless.rs
@@ -3,6 +3,8 @@ use crate::http;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::RouteConfig;
 
+use anyhow::Result;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ZonelessTarget {
     pub account_id: String,
@@ -10,7 +12,7 @@ pub struct ZonelessTarget {
 }
 
 impl ZonelessTarget {
-    pub fn build(script_name: &str, route_config: &RouteConfig) -> Result<Self, failure::Error> {
+    pub fn build(script_name: &str, route_config: &RouteConfig) -> Result<Self> {
         match route_config.account_id.as_ref() {
             // TODO: Deserialize empty strings to None; cannot do this for account id
             // yet without a large refactor.
@@ -20,17 +22,17 @@ impl ZonelessTarget {
             }),
             _ => {
                 display_account_id_maybe();
-                failure::bail!("field `account_id` is required to deploy to workers.dev")
+                anyhow::bail!("field `account_id` is required to deploy to workers.dev")
             }
         }
     }
 
-    pub fn deploy(&self, user: &GlobalUser) -> Result<String, failure::Error> {
+    pub fn deploy(&self, user: &GlobalUser) -> Result<String> {
         log::info!("publishing to workers.dev subdomain");
         log::info!("checking that subdomain is registered");
         let subdomain = match Subdomain::get(&self.account_id, user)? {
             Some(subdomain) => subdomain,
-            None => failure::bail!("Before publishing to workers.dev, you must register a subdomain. Please choose a name for your subdomain and run `wrangler subdomain <name>`.")
+            None => anyhow::bail!("Before publishing to workers.dev, you must register a subdomain. Please choose a name for your subdomain and run `wrangler subdomain <name>`.")
         };
 
         let sd_worker_addr = format!(
@@ -48,7 +50,7 @@ impl ZonelessTarget {
             .send()?;
 
         if !res.status().is_success() {
-            failure::bail!(
+            anyhow::bail!(
                 "Something went wrong! Status: {}, Details {}",
                 res.status(),
                 res.text()?

--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -6,11 +6,13 @@ use cloudflare::framework::response::ApiFailure;
 use cloudflare::framework::{Environment, HttpApiClient, HttpApiClientConfig};
 use http::StatusCode;
 
+use anyhow::Result;
+
 use crate::http::{feature::headers, Feature, DEFAULT_HTTP_TIMEOUT_SECONDS};
 use crate::settings::global_user::GlobalUser;
 use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
-pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
+pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient> {
     let config = HttpApiClientConfig {
         http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
         default_headers: headers(None),
@@ -21,13 +23,9 @@ pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> 
         config,
         Environment::Production,
     )
-    .map_err(|e| failure::format_err!("{}", e))
 }
 
-pub fn featured_cf_v4_client(
-    user: &GlobalUser,
-    feature: Feature,
-) -> Result<HttpApiClient, failure::Error> {
+pub fn featured_cf_v4_client(user: &GlobalUser, feature: Feature) -> Result<HttpApiClient> {
     let config = HttpApiClientConfig {
         http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
         default_headers: headers(Some(feature)),
@@ -38,19 +36,17 @@ pub fn featured_cf_v4_client(
         config,
         Environment::Production,
     )
-    .map_err(|e| failure::format_err!("{}", e))
 }
 
 pub fn cf_v4_api_client_async(
     user: &GlobalUser,
     config: HttpApiClientConfig,
-) -> Result<async_api::Client, failure::Error> {
+) -> Result<async_api::Client> {
     async_api::Client::new(
         Credentials::from(user.to_owned()),
         config,
         Environment::Production,
     )
-    .map_err(|e| failure::format_err!("{}", e))
 }
 
 // Format errors from the cloudflare-rs cli for printing.

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -3,6 +3,7 @@ pub mod target;
 
 use crate::terminal::emoji;
 
+use anyhow::{anyhow, Result};
 use binary_install::{Cache, Download};
 use log::info;
 use semver::Version;
@@ -22,20 +23,24 @@ enum ToolDownload {
     InstalledAt(Download),
 }
 
-pub fn install_cargo_generate() -> Result<PathBuf, failure::Error> {
+pub fn install_cargo_generate() -> Result<PathBuf> {
     let tool_name = "cargo-generate";
     let tool_author = "ashleygwilliams";
     let is_binary = true;
     let version = Version::parse(dependencies::GENERATE_VERSION)?;
-    install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
+    install(tool_name, tool_author, is_binary, version)?
+        .binary(tool_name)
+        .map_err(|e| anyhow::Error::from(e.compat()))
 }
 
-pub fn install_wasm_pack() -> Result<PathBuf, failure::Error> {
+pub fn install_wasm_pack() -> Result<PathBuf> {
     let tool_name = "wasm-pack";
     let tool_author = "rustwasm";
     let is_binary = true;
     let version = Version::parse(dependencies::WASM_PACK_VERSION)?;
-    install(tool_name, tool_author, is_binary, version)?.binary(tool_name)
+    install(tool_name, tool_author, is_binary, version)?
+        .binary(tool_name)
+        .map_err(|e| anyhow!(e.compat()))
 }
 
 pub fn install(
@@ -43,7 +48,7 @@ pub fn install(
     owner: &str,
     is_binary: bool,
     version: Version,
-) -> Result<Download, failure::Error> {
+) -> Result<Download> {
     let download = match tool_needs_update(tool_name, version)? {
         ToolDownload::NeedsInstall(version) => {
             println!("{}  Installing {} v{}...", emoji::DOWN, tool_name, version);
@@ -52,11 +57,7 @@ pub fn install(
                 download_prebuilt(tool_name, owner, &version.to_string(), binaries.as_ref());
             match download {
                 Ok(download) => Ok(download),
-                Err(e) => Err(failure::format_err!(
-                    "could not download `{}`\n{}",
-                    tool_name,
-                    e
-                )),
+                Err(e) => Err(anyhow!("could not download `{}`\n{}", tool_name, e)),
             }
         }
         ToolDownload::InstalledAt(download) => Ok(download),
@@ -65,10 +66,7 @@ pub fn install(
     Ok(download)
 }
 
-fn tool_needs_update(
-    tool_name: &str,
-    target_version: Version,
-) -> Result<ToolDownload, failure::Error> {
+fn tool_needs_update(tool_name: &str, target_version: Version) -> Result<ToolDownload> {
     let current_installation = get_installation(tool_name, &target_version);
     // if something goes wrong checking the current installation
     // we shouldn't fail, we should just re-install for them
@@ -87,7 +85,7 @@ fn tool_needs_update(
 fn get_installation(
     tool_name: &str,
     target_version: &Version,
-) -> Result<Option<(Version, PathBuf)>, failure::Error> {
+) -> Result<Option<(Version, PathBuf)>> {
     for entry in fs::read_dir(&CACHE.destination)? {
         let entry = entry?;
         let filename = entry.file_name().into_string();
@@ -114,10 +112,10 @@ fn download_prebuilt(
     owner: &str,
     version: &str,
     binaries: &[&str],
-) -> Result<Download, failure::Error> {
+) -> Result<Download> {
     let url = match prebuilt_url(tool_name, owner, version) {
         Some(url) => url,
-        None => failure::bail!(format!(
+        None => anyhow::bail!(format!(
             "no prebuilt {} binaries are available for this platform",
             tool_name
         )),
@@ -127,14 +125,18 @@ fn download_prebuilt(
 
     // no binaries are expected; downloading it as an artifact
     let res = if !binaries.is_empty() {
-        CACHE.download_version(true, tool_name, binaries, &url, version)?
+        CACHE
+            .download_version(true, tool_name, binaries, &url, version)
+            .map_err(|e| e.compat())?
     } else {
-        CACHE.download_artifact_version(tool_name, &url, version)?
+        CACHE
+            .download_artifact_version(tool_name, &url, version)
+            .map_err(|e| e.compat())?
     };
 
     match res {
         Some(download) => Ok(download),
-        None => failure::bail!("{} is not installed!", tool_name),
+        None => anyhow::bail!("{} is not installed!", tool_name),
     }
 }
 
@@ -163,10 +165,10 @@ fn prebuilt_url(tool_name: &str, owner: &str, version: &str) -> Option<String> {
     }
 }
 
-fn get_wrangler_cache() -> Result<Cache, failure::Error> {
+fn get_wrangler_cache() -> Result<Cache> {
     if let Ok(path) = env::var("WRANGLER_CACHE") {
         Ok(Cache::at(Path::new(&path)))
     } else {
-        Cache::new("wrangler")
+        Cache::new("wrangler").map_err(|e| anyhow::Error::from(e.compat()))
     }
 }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -115,10 +115,10 @@ fn download_prebuilt(
 ) -> Result<Download> {
     let url = match prebuilt_url(tool_name, owner, version) {
         Some(url) => url,
-        None => anyhow::bail!(format!(
+        None => anyhow::bail!(
             "no prebuilt {} binaries are available for this platform",
             tool_name
-        )),
+        ),
     };
 
     info!("prebuilt artifact {}", url);

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -22,12 +22,12 @@ use std::io;
 use std::path::Path;
 use std::process;
 
-use failure::{self, bail, ResultExt};
+use anyhow::{anyhow, bail, Result};
 
 pub fn install() -> ! {
     if let Err(e) = do_install() {
         eprintln!("{}", e);
-        for cause in e.iter_causes() {
+        for cause in e.chain() {
             eprintln!("Caused by: {}", cause);
         }
     }
@@ -45,7 +45,7 @@ pub fn install() -> ! {
     process::exit(0);
 }
 
-fn do_install() -> Result<(), failure::Error> {
+fn do_install() -> Result<()> {
     // Find `rustup.exe` in PATH, we'll be using its installation directory as
     // our installation directory.
     let rustup = match which::which("rustup") {
@@ -72,7 +72,7 @@ fn do_install() -> Result<(), failure::Error> {
     // Our relatively simple install step!
     let me = env::current_exe()?;
     fs::copy(&me, &destination)
-        .with_context(|_| format!("failed to copy executable to `{}`", destination.display()))?;
+        .map_err(|_| anyhow!("failed to copy executable to `{}`", destination.display()))?;
     println!(
         "info: successfully installed wrangler to `{}`",
         destination.display()
@@ -83,7 +83,7 @@ fn do_install() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn confirm_can_overwrite(dst: &Path) -> Result<(), failure::Error> {
+fn confirm_can_overwrite(dst: &Path) -> Result<()> {
     // If the `-f` argument was passed, we can always overwrite everything.
     if env::args().any(|arg| arg == "-f") {
         return Ok(());
@@ -110,7 +110,7 @@ fn confirm_can_overwrite(dst: &Path) -> Result<(), failure::Error> {
     let mut line = String::new();
     io::stdin()
         .read_line(&mut line)
-        .with_context(|_| "failed to read stdin")?;
+        .map_err(|_| anyhow!("failed to read stdin"))?;
 
     if line.starts_with('y') || line.starts_with('Y') {
         return Ok(());

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -20,17 +20,11 @@ use std::env;
 use std::fs;
 use std::io;
 use std::path::Path;
-use std::process;
 
 use anyhow::{anyhow, bail, Result};
 
-pub fn install() -> ! {
-    if let Err(e) = do_install() {
-        eprintln!("{}", e);
-        for cause in e.chain() {
-            eprintln!("Caused by: {}", cause);
-        }
-    }
+pub fn install() -> Result<()> {
+    do_install()?;
 
     // On Windows we likely popped up a console for the installation. If we were
     // to exit here immediately then the user wouldn't see any error that
@@ -42,7 +36,7 @@ pub fn install() -> ! {
         drop(io::stdin().read_line(&mut line));
     }
 
-    process::exit(0);
+    Ok(())
 }
 
 fn do_install() -> Result<()> {

--- a/src/kv/bulk.rs
+++ b/src/kv/bulk.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use anyhow::Result;
 use indicatif::ProgressBar;
 
 use cloudflare::endpoints::workerskv::delete_bulk::DeleteBulk;
@@ -22,7 +23,7 @@ const UPLOAD_MAX_SIZE: usize = 50 * 1024 * 1024;
 
 // Create a special API client that has a longer timeout than usual, given that KV operations
 // can be lengthy if payloads are large.
-fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
+fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient> {
     let config = HttpApiClientConfig {
         http_timeout: Duration::from_secs(5 * 60),
         default_headers: headers(None),
@@ -33,7 +34,6 @@ fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient, failure::Error> {
         config,
         Environment::Production,
     )
-    .map_err(|e| failure::format_err!("{}", e))
 }
 
 pub fn put(
@@ -42,7 +42,7 @@ pub fn put(
     namespace_id: &str,
     pairs: Vec<KeyValuePair>,
     progress_bar: &Option<ProgressBar>,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let client = bulk_api_client(user)?;
 
     for b in batch_keys_values(pairs) {
@@ -52,7 +52,7 @@ pub fn put(
             bulk_key_value_pairs: b.to_owned(),
         }) {
             Ok(_) => {}
-            Err(e) => failure::bail!("{}", format_error(e)),
+            Err(e) => anyhow::bail!("{}", format_error(e)),
         }
 
         if let Some(pb) = &progress_bar {
@@ -69,7 +69,7 @@ pub fn delete(
     namespace_id: &str,
     keys: Vec<String>,
     progress_bar: &Option<ProgressBar>,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let client = bulk_api_client(user)?;
 
     for b in batch_keys(keys) {
@@ -79,7 +79,7 @@ pub fn delete(
             bulk_keys: b.to_owned(),
         }) {
             Ok(_) => {}
-            Err(e) => failure::bail!("{}", format_error(e)),
+            Err(e) => anyhow::bail!("{}", format_error(e)),
         }
 
         if let Some(pb) = &progress_bar {

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use serde_json::value::Value as JsonValue;
 
 use cloudflare::endpoints::workerskv::list_namespace_keys::ListNamespaceKeys;
@@ -25,7 +26,7 @@ impl KeyList {
         client: HttpApiClient,
         namespace_id: &str,
         prefix: Option<&str>,
-    ) -> Result<KeyList, failure::Error> {
+    ) -> Result<KeyList> {
         let iter = KeyList {
             keys_result: None,
             prefix: prefix.map(str::to_string),

--- a/src/login/mod.rs
+++ b/src/login/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use eventual::Timer;
 use indicatif::{ProgressBar, ProgressStyle};
 use openssl::base64;
@@ -11,7 +12,7 @@ use crate::commands::config::global_config;
 use crate::settings::global_user::GlobalUser;
 use crate::terminal::{interactive, open_browser};
 
-pub fn run() -> Result<(), failure::Error> {
+pub fn run() -> Result<()> {
     let rsa = Rsa::generate(1024)?;
     let pubkey = rsa.public_key_to_pem_pkcs1()?;
 
@@ -29,7 +30,7 @@ pub fn run() -> Result<(), failure::Error> {
     let browser_permission =
         interactive::confirm("Allow Wrangler to open a page in your browser?")?;
     if !browser_permission {
-        failure::bail!("In order to log in you must allow Wrangler to open your browser. If you don't want to do this consider using `wrangler config`");
+        anyhow::bail!("In order to log in you must allow Wrangler to open your browser. If you don't want to do this consider using `wrangler config`");
     }
 
     open_browser(&format!(
@@ -58,7 +59,7 @@ struct TokenResponse {
 }
 
 /// Poll for token, bail after 500 seconds.
-fn poll_token(token_id: String) -> Result<String, failure::Error> {
+fn poll_token(token_id: String) -> Result<String> {
     let mut request_params = HashMap::new();
     request_params.insert("token-id", token_id);
 
@@ -86,7 +87,7 @@ fn poll_token(token_id: String) -> Result<String, failure::Error> {
         }
     }
 
-    failure::bail!(
+    anyhow::bail!(
         "Timed out while waiting for API token. Try using `wrangler config` if login fails to work."
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
             .expect("executable should have a filename")
             .starts_with("wrangler-init")
         {
-            installer::install();
+            installer::install()?;
         }
     }
     run()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use std::env;
 use std::path::Path;
 use std::str::FromStr;
 
+use anyhow::{anyhow, ensure, Result};
 use clap::{App, AppSettings, Arg, ArgGroup, SubCommand};
-use exitfailure::ExitFailure;
 use url::Url;
 
 use wrangler::commands;
@@ -23,7 +23,7 @@ use wrangler::terminal::message::{Message, Output, StdOut};
 use wrangler::terminal::{emoji, interactive, styles};
 use wrangler::version::background_check_for_updates;
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> Result<()> {
     env_logger::init();
     let latest_version_receiver = background_check_for_updates();
     if let Ok(me) = env::current_exe() {
@@ -59,7 +59,7 @@ fn main() -> Result<(), ExitFailure> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn run() -> Result<(), failure::Error> {
+fn run() -> Result<()> {
     // Define commonly used arguments and arg groups up front for consistency
     // The args below are for KV Subcommands
     let kv_binding_arg = Arg::with_name("binding")
@@ -696,7 +696,7 @@ fn run() -> Result<(), failure::Error> {
 
         let template = if site {
             if template.is_some() {
-                failure::bail!("You cannot pass a template and the --site flag to wrangler generate. If you'd like to use the default site boilerplate, run wrangler generate --site. If you'd like to use another site boilerplate, omit --site when running wrangler generate.")
+                anyhow::bail!("You cannot pass a template and the --site flag to wrangler generate. If you'd like to use the default site boilerplate, run wrangler generate --site. If you'd like to use another site boilerplate, omit --site when running wrangler generate.")
             }
             "https://github.com/cloudflare/worker-sites-template"
         } else {
@@ -770,7 +770,7 @@ fn run() -> Result<(), failure::Error> {
         let url = Url::parse(url)?;
 
         // Validate the URL scheme
-        failure::ensure!(
+        ensure!(
             matches!(url.scheme(), "http" | "https"),
             "Invalid URL scheme (use either \"https\" or \"http\")"
         );
@@ -911,12 +911,12 @@ fn run() -> Result<(), failure::Error> {
             None
         };
 
-        let zone_id: Result<String, failure::Error> = if let Some(zone_id) = env_zone_id {
+        let zone_id: Result<String> = if let Some(zone_id) = env_zone_id {
             Ok(zone_id.to_string())
         } else if let Some(zone_id) = manifest.zone_id {
             Ok(zone_id)
         } else {
-            failure::bail!(
+            anyhow::bail!(
                 "You must specify a zone_id in your configuration file to use `wrangler route` commands."
             )
         };
@@ -1060,10 +1060,8 @@ fn run() -> Result<(), failure::Error> {
                 let expiration_ttl = put_key_matches
                     .value_of("expiration-ttl")
                     .map(|t| t.to_string());
-                let metadata =
-                    parse_metadata(put_key_matches.value_of("metadata")).map_err(|e| {
-                        failure::format_err!("--metadata is not valid JSON: {}", e.to_string())
-                    })?;
+                let metadata = parse_metadata(put_key_matches.value_of("metadata"))
+                    .map_err(|e| anyhow!("--metadata is not valid JSON: {}", e.to_string()))?;
                 let kv_metadata = KVMetaData {
                     namespace_id,
                     key,

--- a/src/preview/http_method.rs
+++ b/src/preview/http_method.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use std::str::FromStr;
 
 #[derive(Clone, Debug)]
@@ -13,8 +14,8 @@ impl Default for HttpMethod {
 }
 
 impl FromStr for HttpMethod {
-    type Err = failure::Error;
-    fn from_str(s: &str) -> Result<Self, failure::Error> {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
         match s {
             "get" => Ok(HttpMethod::Get),
             "post" => Ok(HttpMethod::Post),

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -13,6 +13,7 @@ pub use upload::upload;
 use std::sync::mpsc::channel;
 use std::thread;
 
+use anyhow::Result;
 use log::info;
 use url::Url;
 use ws::{Sender, WebSocket};
@@ -30,10 +31,10 @@ pub fn preview(
     user: Option<GlobalUser>,
     options: PreviewOpt,
     verbose: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     if let Some(build) = &target.build {
         if matches!(build.upload, UploadFormat::Modules { .. }) {
-            failure::bail!("wrangler preview does not support previewing modules scripts. Please use wrangler dev instead.");
+            anyhow::bail!("wrangler preview does not support previewing modules scripts. Please use wrangler dev instead.");
         }
     }
 
@@ -121,11 +122,7 @@ fn client_request(payload: &RequestPayload, script_id: &str, sites_preview: bool
     StdOut::preview(&msg);
 }
 
-fn get(
-    url: &str,
-    cookie: &str,
-    client: &reqwest::blocking::Client,
-) -> Result<String, failure::Error> {
+fn get(url: &str, cookie: &str, client: &reqwest::blocking::Client) -> Result<String> {
     let res = client.get(url).header("Cookie", cookie).send();
     Ok(res?.text()?)
 }
@@ -135,7 +132,7 @@ fn post(
     cookie: &str,
     body: &Option<String>,
     client: &reqwest::blocking::Client,
-) -> Result<String, failure::Error> {
+) -> Result<String> {
     let res = match body {
         Some(s) => client
             .post(url)
@@ -156,7 +153,7 @@ fn watch_for_changes(
     verbose: bool,
     headless: bool,
     request_payload: RequestPayload,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let sites_preview: bool = target.site.is_some();
 
     let (tx, rx) = channel();

--- a/src/settings/environment.rs
+++ b/src/settings/environment.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 
+use anyhow::Result;
 use config::{ConfigError, Source, Value};
 
 const PREFIX_PATTERN: &str = "CF_";
@@ -8,7 +9,7 @@ const PREFIX_PATTERN: &str = "CF_";
 pub trait QueryEnvironment {
     fn get_var(&self, var: &'static str) -> Result<String, std::env::VarError>;
 
-    fn empty(&self) -> Result<bool, failure::Error>;
+    fn empty(&self) -> Result<bool>;
 }
 
 #[derive(Clone, Debug)]
@@ -27,7 +28,7 @@ impl QueryEnvironment for Environment {
         env::var(var)
     }
 
-    fn empty(&self) -> Result<bool, failure::Error> {
+    fn empty(&self) -> Result<bool> {
         let env = self.collect()?;
 
         Ok(env.is_empty())
@@ -83,7 +84,7 @@ impl QueryEnvironment for MockEnvironment {
         Ok("Some Mocked Result".to_string()) // Returns a mocked response
     }
 
-    fn empty(&self) -> Result<bool, failure::Error> {
+    fn empty(&self) -> Result<bool> {
         Ok(self.vars.is_empty())
     }
 }

--- a/src/settings/global_config.rs
+++ b/src/settings/global_config.rs
@@ -1,9 +1,11 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+
 pub const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 
-pub fn get_wrangler_home_dir() -> Result<PathBuf, failure::Error> {
+pub fn get_wrangler_home_dir() -> Result<PathBuf> {
     let config_dir = if let Ok(value) = env::var("WRANGLER_HOME") {
         log::info!("Using $WRANGLER_HOME: {}", value);
         Path::new(&value).to_path_buf()
@@ -16,7 +18,7 @@ pub fn get_wrangler_home_dir() -> Result<PathBuf, failure::Error> {
     Ok(config_dir)
 }
 
-pub fn get_global_config_path() -> Result<PathBuf, failure::Error> {
+pub fn get_global_config_path() -> Result<PathBuf> {
     let home_dir = get_wrangler_home_dir()?;
     let global_config_file = home_dir.join("config").join(DEFAULT_CONFIG_FILE_NAME);
     log::info!("Using global config file: {}", global_config_file.display());

--- a/src/settings/toml/builder.rs
+++ b/src/settings/toml/builder.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::upload::form::ModuleType;
@@ -58,14 +59,14 @@ fn upload_dir() -> PathBuf {
 }
 
 impl Builder {
-    pub fn verify_watch_dir(&self) -> Result<(), failure::Error> {
+    pub fn verify_watch_dir(&self) -> Result<()> {
         let watch_canonical = match self.watch_dir.canonicalize() {
             Ok(path) => path,
-            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => failure::bail!(
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => anyhow::bail!(
                 "Your provided watch_dir {} does not exist.",
                 self.watch_dir.display()
             ),
-            Err(e) => failure::bail!(
+            Err(e) => anyhow::bail!(
                 "Error encountered when verifying watch_dir: {}, provided path: {}",
                 e,
                 self.watch_dir.display()
@@ -73,10 +74,10 @@ impl Builder {
         };
         let root_canonical = project_root().canonicalize()?;
         if watch_canonical == root_canonical {
-            failure::bail!("Wrangler doesn't support using the project root as the watch_dir.");
+            anyhow::bail!("Wrangler doesn't support using the project root as the watch_dir.");
         }
         if !self.watch_dir.is_dir() {
-            failure::bail!(format!(
+            anyhow::bail!(format!(
                 "A path was provided for watch_dir that is not a directory: {}",
                 self.watch_dir.display()
             ));
@@ -84,7 +85,7 @@ impl Builder {
         Ok(())
     }
 
-    pub fn verify_upload_dir(&self) -> Result<(), failure::Error> {
+    pub fn verify_upload_dir(&self) -> Result<()> {
         let dir = match &self.upload {
             UploadFormat::Modules { dir, .. } => dir,
             UploadFormat::ServiceWorker {} => return Ok(()),
@@ -93,9 +94,9 @@ impl Builder {
         let upload_canonical = match dir.canonicalize() {
             Ok(path) => path,
             Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => {
-                failure::bail!("Your provided upload_dir {} does not exist.", dir.display())
+                anyhow::bail!("Your provided upload_dir {} does not exist.", dir.display())
             }
-            Err(e) => failure::bail!(
+            Err(e) => anyhow::bail!(
                 "Error encountered when verifying upload_dir: {}, provided path: {}",
                 e,
                 dir.display()
@@ -103,10 +104,10 @@ impl Builder {
         };
         let root_canonical = project_root().canonicalize()?;
         if upload_canonical == root_canonical {
-            failure::bail!("Wrangler doesn't support using the project root as the upload_dir.");
+            anyhow::bail!("Wrangler doesn't support using the project root as the upload_dir.");
         }
         if !dir.is_dir() {
-            failure::bail!(format!(
+            anyhow::bail!(format!(
                 "A path was provided for upload_dir that is not a directory: {}",
                 dir.display()
             ));

--- a/src/settings/toml/builder.rs
+++ b/src/settings/toml/builder.rs
@@ -77,10 +77,10 @@ impl Builder {
             anyhow::bail!("Wrangler doesn't support using the project root as the watch_dir.");
         }
         if !self.watch_dir.is_dir() {
-            anyhow::bail!(format!(
+            anyhow::bail!(
                 "A path was provided for watch_dir that is not a directory: {}",
                 self.watch_dir.display()
-            ));
+            );
         }
         Ok(())
     }
@@ -107,10 +107,10 @@ impl Builder {
             anyhow::bail!("Wrangler doesn't support using the project root as the upload_dir.");
         }
         if !dir.is_dir() {
-            anyhow::bail!(format!(
+            anyhow::bail!(
                 "A path was provided for upload_dir that is not a directory: {}",
                 dir.display()
-            ));
+            );
         }
         Ok(())
     }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -302,10 +302,10 @@ impl Manifest {
         if self.site.is_some() {
             match self.target_type {
                 TargetType::Rust => {
-                    anyhow::bail!(format!(
+                    anyhow::bail!(
                         "{} Workers Sites does not support Rust type projects.",
                         emoji::WARN
-                    ))
+                    )
                 }
                 TargetType::JavaScript => {
                     let error_message = format!(
@@ -384,17 +384,17 @@ impl Manifest {
                 if let Some(environment) = environment_table.get(environment_name) {
                     Ok(Some(environment))
                 } else {
-                    anyhow::bail!(format!(
+                    anyhow::bail!(
                         "{} Could not find environment with name \"{}\"",
                         emoji::WARN,
                         environment_name
-                    ))
+                    )
                 }
             } else {
-                anyhow::bail!(format!(
+                anyhow::bail!(
                     "{} There are no environments specified in your configuration file",
                     emoji::WARN
-                ))
+                )
             }
         } else {
             Ok(None)
@@ -548,12 +548,12 @@ fn check_for_duplicate_names(manifest: &Manifest) -> Result<()> {
         _ => None,
     };
     if let Some(message) = duplicate_message {
-        anyhow::bail!(format!(
+        anyhow::bail!(
             "{} Each name in your configuration file must be unique, {}: {}",
             emoji::WARN,
             message,
             duplicate_name_string
-        ))
+        )
     }
     Ok(())
 }

--- a/src/settings/toml/mod.rs
+++ b/src/settings/toml/mod.rs
@@ -18,6 +18,7 @@ pub use site::Site;
 pub use target::Target;
 pub use target_type::TargetType;
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -29,13 +30,15 @@ pub enum UsageModel {
 }
 
 impl FromStr for UsageModel {
-    type Err = failure::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "bundled" => Ok(UsageModel::Bundled),
             "unbound" => Ok(UsageModel::Unbound),
-            _ => failure::bail!("Invalid usage model; must be either \"bundled\" or \"unbound\""),
+            _ => Err(anyhow!(
+                "Invalid usage model; must be either \"bundled\" or \"unbound\""
+            )),
         }
     }
 }

--- a/src/settings/toml/site.rs
+++ b/src/settings/toml/site.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::commands::generate::run_generate;
@@ -38,7 +39,7 @@ impl Site {
         ))
     }
 
-    pub fn scaffold_worker(&self) -> Result<(), failure::Error> {
+    pub fn scaffold_worker(&self) -> Result<()> {
         let entry_point = &self.entry_point()?;
         let template = "https://github.com/cloudflare/worker-sites-init";
 

--- a/src/settings/toml/target_type.rs
+++ b/src/settings/toml/target_type.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -29,14 +30,14 @@ impl fmt::Display for TargetType {
 }
 
 impl FromStr for TargetType {
-    type Err = failure::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "javascript" => Ok(TargetType::JavaScript),
             "rust" => Ok(TargetType::Rust),
             "webpack" => Ok(TargetType::Webpack),
-            _ => failure::bail!("{} is not a valid wrangler build type!", s),
+            _ => Err(anyhow!("{} is not a valid wrangler build type!", s)),
         }
     }
 }

--- a/src/sites/sync.rs
+++ b/src/sites/sync.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use anyhow::Result;
 use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 
 use super::directory_keys_values;
@@ -17,7 +18,7 @@ pub fn sync(
     user: &GlobalUser,
     namespace_id: &str,
     path: &Path,
-) -> Result<(Vec<KeyValuePair>, Vec<String>, AssetManifest), failure::Error> {
+) -> Result<(Vec<KeyValuePair>, Vec<String>, AssetManifest)> {
     kv::validate_target(target)?;
     // First, find all changed files in given local directory (aka files that are now stale
     // in Workers KV).
@@ -34,7 +35,7 @@ pub fn sync(
             Ok(remote_key) => {
                 remote_keys.insert(remote_key.name);
             }
-            Err(e) => failure::bail!(kv::format_error(e)),
+            Err(e) => anyhow::bail!(kv::format_error(e)),
         }
     }
 

--- a/src/tail/log_server.rs
+++ b/src/tail/log_server.rs
@@ -1,4 +1,5 @@
 use crate::terminal::{emoji, styles};
+use anyhow::Result;
 use hyper::server::conn::AddrIncoming;
 use hyper::server::Builder;
 use hyper::service::{make_service_fn, service_fn};
@@ -29,7 +30,7 @@ impl LogServer {
         }
     }
 
-    pub async fn run(self) -> Result<(), failure::Error> {
+    pub async fn run(self) -> Result<()> {
         // this is so bad
         // but i also am so bad at types
         // TODO: make this less terrible
@@ -96,7 +97,7 @@ async fn print_logs_json(req: Request<Body>) -> Result<Response<Body>, hyper::Er
     }
 }
 
-async fn print_logs_pretty(req: Request<Body>) -> Result<Response<Body>, failure::Error> {
+async fn print_logs_pretty(req: Request<Body>) -> Result<Response<Body>> {
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => {
             let whole_body = hyper::body::to_bytes(req.into_body()).await?;

--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -20,6 +20,7 @@ use session::Session;
 use shutdown::ShutdownHandler;
 use tunnel::Tunnel;
 
+use anyhow::Result;
 use console::style;
 use tokio::runtime::Runtime as TokioRuntime;
 use which::which;
@@ -38,7 +39,7 @@ impl Tail {
         tunnel_port: u16,
         metrics_port: u16,
         verbose: bool,
-    ) -> Result<(), failure::Error> {
+    ) -> Result<()> {
         is_cloudflared_installed()?;
         print_startup_message(&target.name, tunnel_port, metrics_port);
 
@@ -89,13 +90,13 @@ impl Tail {
     }
 }
 
-fn is_cloudflared_installed() -> Result<(), failure::Error> {
+fn is_cloudflared_installed() -> Result<()> {
     // this can be removed once we automatically install cloudflared
     if which("cloudflared").is_err() {
         let install_url = style("https://developers.cloudflare.com/argo-tunnel/downloads/")
             .blue()
             .bold();
-        failure::bail!("You must install cloudflared to use wrangler tail.\n\nInstallation instructions can be found here:\n{}", install_url);
+        anyhow::bail!("You must install cloudflared to use wrangler tail.\n\nInstallation instructions can be found here:\n{}", install_url);
     } else {
         Ok(())
     }

--- a/src/tail/shutdown.rs
+++ b/src/tail/shutdown.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 
 pub struct ShutdownHandler {
@@ -18,7 +19,7 @@ impl ShutdownHandler {
 
     /// ShutdownHandler waits on a ctrl_c from the system, or a short circuit command from the top
     /// level error handler, and sends messages to each registered transmitter when it is received.
-    pub async fn run(self, short_circuit: Receiver<()>) -> Result<(), failure::Error> {
+    pub async fn run(self, short_circuit: Receiver<()>) -> Result<()> {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {}
             _ = short_circuit => {}

--- a/src/terminal/browser.rs
+++ b/src/terminal/browser.rs
@@ -1,7 +1,9 @@
 use crate::terminal::message::{Message, StdOut};
 use std::process::{Command, Stdio};
 
-pub fn open_browser(url: &str) -> Result<(), failure::Error> {
+use anyhow::Result;
+
+pub fn open_browser(url: &str) -> Result<()> {
     if cfg!(target_os = "windows") {
         let url_escaped = url.replace("&", "^&");
         let windows_cmd = format!("start {}", url_escaped);

--- a/src/terminal/interactive.rs
+++ b/src/terminal/interactive.rs
@@ -1,5 +1,7 @@
+use anyhow::Result;
 use atty::Stream;
 use std::io::{self, Read};
+
 // For interactively handling reading in a string
 pub fn get_user_input(prompt_string: &str) -> String {
     println!("{}", prompt_string);
@@ -36,7 +38,7 @@ const NO: &str = "n";
 // Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
 // and lowercasing logic below.
 // TODO: loop this to retry until valid input is received.
-pub fn confirm(prompt_string: &str) -> Result<bool, failure::Error> {
+pub fn confirm(prompt_string: &str) -> Result<bool> {
     println!("{} [y/n]", prompt_string);
     let mut response: String = read!("{}\n");
     response = response.split_whitespace().collect(); // remove whitespace
@@ -45,7 +47,7 @@ pub fn confirm(prompt_string: &str) -> Result<bool, failure::Error> {
     match response.as_ref() {
         YES => Ok(true),
         NO => Ok(false),
-        _ => failure::bail!("Response must either be \"y\" for yes or \"n\" for no"),
+        _ => anyhow::bail!("Response must either be \"y\" for yes or \"n\" for no"),
     }
 }
 

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -5,6 +5,7 @@ mod service_worker;
 mod text_blob;
 mod wasm_module;
 
+use anyhow::Result;
 use reqwest::blocking::multipart::Form;
 use std::fs;
 use std::path::Path;
@@ -28,7 +29,7 @@ pub fn build(
     target: &Target,
     asset_manifest: Option<AssetManifest>,
     session_config: Option<serde_json::Value>,
-) -> Result<Form, failure::Error> {
+) -> Result<Form> {
     let target_type = &target.target_type;
     let kv_namespaces = &target.kv_namespaces;
     let mut text_blobs: Vec<TextBlob> = Vec::new();
@@ -160,7 +161,7 @@ pub fn build(
     }
 }
 
-fn get_asset_manifest_blob(asset_manifest: AssetManifest) -> Result<String, failure::Error> {
+fn get_asset_manifest_blob(asset_manifest: AssetManifest) -> Result<String> {
     let asset_manifest = serde_json::to_string(&asset_manifest)?;
     Ok(asset_manifest)
 }
@@ -169,7 +170,7 @@ fn filestem_from_path(path: &PathBuf) -> Option<String> {
     path.file_stem()?.to_str().map(|s| s.to_string())
 }
 
-fn build_generated_dir() -> Result<(), failure::Error> {
+fn build_generated_dir() -> Result<()> {
     let dir = "./worker/generated";
     if !Path::new(dir).is_dir() {
         fs::create_dir("./worker/generated")?;
@@ -178,7 +179,7 @@ fn build_generated_dir() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn concat_js(name: &str) -> Result<(), failure::Error> {
+fn concat_js(name: &str) -> Result<()> {
     let bindgen_js_path = format!("./pkg/{}.js", name);
     let bindgen_js: String = fs::read_to_string(bindgen_js_path)?.parse()?;
 

--- a/src/upload/form/plain_text.rs
+++ b/src/upload/form/plain_text.rs
@@ -1,4 +1,5 @@
 use super::binding::Binding;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -8,7 +9,7 @@ pub struct PlainText {
 }
 
 impl PlainText {
-    pub fn new(name: String, value: String) -> Result<Self, failure::Error> {
+    pub fn new(name: String, value: String) -> Result<Self> {
         Ok(Self { name, value })
     }
 

--- a/src/upload/form/service_worker.rs
+++ b/src/upload/form/service_worker.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use reqwest::blocking::multipart::{Form, Part};
 use serde::Serialize;
 
@@ -14,7 +15,7 @@ struct Metadata {
 pub fn build_form(
     assets: &ServiceWorkerAssets,
     session_config: Option<serde_json::Value>,
-) -> Result<Form, failure::Error> {
+) -> Result<Form> {
     let mut form = Form::new();
 
     // The preview service in particular streams the request form, and requires that the
@@ -31,7 +32,7 @@ pub fn build_form(
     Ok(form)
 }
 
-fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, failure::Error> {
+fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
     form = form.file(assets.script_name(), assets.script_path())?;
 
     for wasm_module in &assets.wasm_modules {
@@ -49,7 +50,7 @@ fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, failu
     Ok(form)
 }
 
-fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, failure::Error> {
+fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
     let metadata_json = serde_json::json!(&Metadata {
         body_part: assets.script_name(),
         bindings: assets.bindings(),
@@ -64,10 +65,7 @@ fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form, fa
     Ok(form)
 }
 
-fn add_session_config(
-    mut form: Form,
-    session_config: serde_json::Value,
-) -> Result<Form, failure::Error> {
+fn add_session_config(mut form: Form, session_config: serde_json::Value) -> Result<Form> {
     let wrangler_session_config = Part::text(session_config.to_string())
         .file_name("")
         .mime_str("application/json")?;

--- a/src/upload/form/text_blob.rs
+++ b/src/upload/form/text_blob.rs
@@ -1,4 +1,5 @@
 use super::binding::Binding;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 // Note: This is only used for service-worker scripts.
@@ -11,7 +12,7 @@ pub struct TextBlob {
 }
 
 impl TextBlob {
-    pub fn new(data: String, binding: String) -> Result<Self, failure::Error> {
+    pub fn new(data: String, binding: String) -> Result<Self> {
         Ok(Self { data, binding })
     }
 

--- a/src/upload/form/wasm_module.rs
+++ b/src/upload/form/wasm_module.rs
@@ -1,9 +1,8 @@
 use std::path::PathBuf;
 
-use failure::format_err;
-
 use super::binding::Binding;
 use super::filestem_from_path;
+use anyhow::{anyhow, Result};
 
 // Note: This is only used for service-worker scripts.
 // modules scripts use the universal Module class instead of this.
@@ -16,9 +15,9 @@ pub struct WasmModule {
 }
 
 impl WasmModule {
-    pub fn new(path: PathBuf, binding: String) -> Result<Self, failure::Error> {
+    pub fn new(path: PathBuf, binding: String) -> Result<Self> {
         let filename = filestem_from_path(&path)
-            .ok_or_else(|| format_err!("filename should not be empty: {}", path.display()))?;
+            .ok_or_else(|| anyhow!("filename should not be empty: {}", path.display()))?;
 
         Ok(Self {
             filename,

--- a/src/upload/krate.rs
+++ b/src/upload/krate.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use anyhow::Result;
 use serde::{self, Deserialize};
 
 #[derive(Debug, Deserialize)]
@@ -14,10 +15,10 @@ struct KrateManifest {
 }
 
 impl Krate {
-    pub fn new(krate_path: &str) -> Result<Krate, failure::Error> {
+    pub fn new(krate_path: &str) -> Result<Krate> {
         let manifest_path = Path::new(krate_path).join("Cargo.toml");
         if !manifest_path.is_file() {
-            failure::bail!(
+            anyhow::bail!(
                 "crate directory is missing a `Cargo.toml` file; is `{}` the \
                  wrong directory?",
                 krate_path

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -5,6 +5,7 @@ pub mod package;
 use indicatif::{ProgressBar, ProgressStyle};
 pub use package::Package;
 
+use anyhow::Result;
 use reqwest::blocking::Client;
 
 use crate::settings::toml::Target;
@@ -14,7 +15,7 @@ pub fn script(
     client: &Client,
     target: &Target,
     asset_manifest: Option<AssetManifest>,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     let worker_addr = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}",
         target.account_id, target.name,
@@ -38,7 +39,7 @@ pub fn script(
 
     if !res_status.is_success() {
         let res_text = res.text()?;
-        failure::bail!(error_msg(res_status, res_text))
+        anyhow::bail!(error_msg(res_status, res_text))
     }
 
     if let Some(usage_model) = target.usage_model {
@@ -58,7 +59,7 @@ pub fn script(
 
         if !res_status.is_success() {
             let res_text = res.text()?;
-            failure::bail!(error_msg(res_status, res_text))
+            anyhow::bail!(error_msg(res_status, res_text))
         }
     }
 

--- a/src/upload/package.rs
+++ b/src/upload/package.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use anyhow::Result;
 use serde::{self, Deserialize};
 
 #[derive(Debug, Deserialize)]
@@ -11,13 +12,13 @@ pub struct Package {
     module: PathBuf,
 }
 impl Package {
-    pub fn main(&self, package_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
+    pub fn main(&self, package_dir: &PathBuf) -> Result<PathBuf> {
         if self.main == PathBuf::from("") {
-            failure::bail!(
+            anyhow::bail!(
                 "The `main` key in your `package.json` file is required; please specify the entry point of your Worker.",
             )
         } else if !package_dir.join(&self.main).exists() {
-            failure::bail!(
+            anyhow::bail!(
                 "The entrypoint of your Worker ({}) could not be found.",
                 self.main.display()
             )
@@ -25,13 +26,13 @@ impl Package {
             Ok(self.main.clone())
         }
     }
-    pub fn module(&self, package_dir: &PathBuf) -> Result<PathBuf, failure::Error> {
+    pub fn module(&self, package_dir: &PathBuf) -> Result<PathBuf> {
         if self.module == PathBuf::from("") {
-            failure::bail!(
+            anyhow::bail!(
                 "The `module` key in your `package.json` file is required when using the module script format; please specify the entry point of your Worker.",
             )
         } else if !package_dir.join(&self.module).exists() {
-            failure::bail!(
+            anyhow::bail!(
                 "The entrypoint of your Worker ({}) could not be found.",
                 self.module.display()
             )
@@ -42,10 +43,10 @@ impl Package {
 }
 
 impl Package {
-    pub fn new(package_dir: &PathBuf) -> Result<Package, failure::Error> {
+    pub fn new(package_dir: &PathBuf) -> Result<Package> {
         let manifest_path = package_dir.join("package.json");
         if !manifest_path.is_file() {
-            failure::bail!(
+            anyhow::bail!(
                 "Your JavaScript project is missing a `package.json` file; is `{}` the \
                  wrong directory?",
                 package_dir.display()

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 
 use crate::settings::get_wrangler_home_dir;
 
+use anyhow::Result;
 use reqwest::header::USER_AGENT;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -65,13 +66,13 @@ impl FromStr for LastCheckedVersion {
     }
 }
 
-fn get_installed_version() -> Result<Version, failure::Error> {
+fn get_installed_version() -> Result<Version> {
     let version = option_env!("CARGO_PKG_VERSION").unwrap_or_else(|| "unknown");
     let parsed_version = Version::parse(version)?;
     Ok(parsed_version)
 }
 
-fn check_wrangler_versions() -> Result<WranglerVersion, failure::Error> {
+fn check_wrangler_versions() -> Result<WranglerVersion> {
     let config_dir = get_wrangler_home_dir()?;
     let version_file = config_dir.join("version.toml");
     let current_time = SystemTime::now();
@@ -117,7 +118,7 @@ fn get_latest_version(
     installed_version: &str,
     version_file: &PathBuf,
     current_time: SystemTime,
-) -> Result<Version, failure::Error> {
+) -> Result<Version> {
     let latest_version = get_latest_version_from_api(installed_version)?;
     let updated_file_contents = toml::to_string(&LastCheckedVersion {
         latest_version: latest_version.to_string(),
@@ -127,7 +128,7 @@ fn get_latest_version(
     Ok(latest_version)
 }
 
-fn get_latest_version_from_api(installed_version: &str) -> Result<Version, failure::Error> {
+fn get_latest_version_from_api(installed_version: &str) -> Result<Version> {
     let url = "https://crates.io/api/v1/crates/wrangler";
     let user_agent = format!(
         "wrangler/{} ({})",

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -9,6 +9,7 @@ use crate::wranglerjs;
 use crate::{build::command, build_target};
 use crate::{commands, install};
 
+use anyhow::Result;
 use notify::{self, RecursiveMode, Watcher};
 use std::sync::mpsc;
 use std::thread;
@@ -23,16 +24,13 @@ const RUST_IGNORE: &[&str] = &["pkg", "target", "worker/generated"];
 
 // watch a project for changes and re-build it when necessary,
 // outputting a build event to tx.
-pub fn watch_and_build(
-    target: &Target,
-    tx: Option<mpsc::Sender<()>>,
-) -> Result<(), failure::Error> {
+pub fn watch_and_build(target: &Target, tx: Option<mpsc::Sender<()>>) -> Result<()> {
     let target_type = &target.target_type;
     let build = target.build.clone();
     match target_type {
         TargetType::JavaScript => {
             let target = target.clone();
-            thread::spawn::<_, Result<(), failure::Error>>(move || {
+            thread::spawn::<_, Result<()>>(move || {
                 let (watcher_tx, watcher_rx) = mpsc::channel();
                 let mut watcher = notify::watcher(watcher_tx, Duration::from_secs(1))?;
 

--- a/src/watch/watcher.rs
+++ b/src/watch/watcher.rs
@@ -3,16 +3,13 @@ use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
 
-use failure::{format_err, Error};
+use anyhow::{anyhow, Result};
 
 use crate::terminal::message::{Message, StdOut};
 use log::info;
 
 // Add cooldown for all types of events to watching logic
-pub fn wait_for_changes(
-    rx: &Receiver<DebouncedEvent>,
-    cooldown: Duration,
-) -> Result<PathBuf, Error> {
+pub fn wait_for_changes(rx: &Receiver<DebouncedEvent>, cooldown: Duration) -> Result<PathBuf> {
     loop {
         let event = rx.recv()?;
         match get_changed_path_from_event(event) {
@@ -33,10 +30,10 @@ pub fn wait_for_changes(
     }
 }
 
-fn get_changed_path_from_event(event: DebouncedEvent) -> Result<Option<PathBuf>, Error> {
+fn get_changed_path_from_event(event: DebouncedEvent) -> Result<Option<PathBuf>> {
     info!("Detected Event {:?}", event);
     match event {
-        DebouncedEvent::Error(error, _) => Err(format_err!("{:?}", error)),
+        DebouncedEvent::Error(error, _) => Err(anyhow!(error)),
         DebouncedEvent::NoticeWrite(path) => Ok(Some(path)),
         DebouncedEvent::Write(path) => Ok(Some(path)),
         DebouncedEvent::NoticeRemove(path) => Ok(Some(path)),

--- a/src/wranglerjs/bundle.rs
+++ b/src/wranglerjs/bundle.rs
@@ -1,4 +1,6 @@
+use anyhow::Result;
 use base64::decode;
+
 #[cfg(test)]
 use std::env;
 use std::fs;
@@ -29,7 +31,7 @@ impl Bundle {
         Bundle { out }
     }
 
-    pub fn write(&self, wranglerjs_output: &WranglerjsOutput) -> Result<(), failure::Error> {
+    pub fn write(&self, wranglerjs_output: &WranglerjsOutput) -> Result<()> {
         if !self.out.exists() {
             fs::create_dir(&self.out)?;
         }

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -14,6 +14,7 @@ use std::sync::mpsc::{channel, Sender};
 use std::thread;
 use std::time::Duration;
 
+use anyhow::Result;
 use fs2::FileExt;
 use notify::{self, RecursiveMode, Watcher};
 use output::WranglerjsOutput;
@@ -35,7 +36,7 @@ use guarded_command::GuardedCommand;
 // executable and wait for completion. The file will receive a serialized
 // {WranglerjsOutput} struct.
 // Note that the ability to pass a fd is platform-specific
-pub fn run_build(target: &Target) -> Result<WranglerjsOutput, failure::Error> {
+pub fn run_build(target: &Target) -> Result<WranglerjsOutput> {
     let (mut command, temp_file, bundle) = setup_build(target)?;
 
     log::info!("Running {:?}", command);
@@ -52,11 +53,11 @@ pub fn run_build(target: &Target) -> Result<WranglerjsOutput, failure::Error> {
         write_wranglerjs_output(&bundle, &wranglerjs_output, custom_webpack)?;
         Ok(wranglerjs_output)
     } else {
-        failure::bail!("failed to execute `{:?}`: exited with {}", command, status)
+        anyhow::bail!("failed to execute `{:?}`: exited with {}", command, status)
     }
 }
 
-pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<(), failure::Error> {
+pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()> {
     let (mut command, temp_file, bundle) = setup_build(target)?;
     command.arg("--watch=1");
 
@@ -66,7 +67,7 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
     log::info!("Running {:?} in watch mode", command);
 
     // Turbofish the result of the closure so we can use ?
-    thread::spawn::<_, Result<(), failure::Error>>(move || {
+    thread::spawn::<_, Result<()>>(move || {
         let _command_guard = GuardedCommand::spawn(command);
 
         let (watcher_tx, watcher_rx) = channel();
@@ -81,7 +82,7 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
                 watcher.watch(&bucket, RecursiveMode::Recursive)?;
                 log::info!("watching static sites asset file {:?}", &bucket);
             } else {
-                failure::bail!(
+                anyhow::bail!(
                     "Attempting to watch static assets bucket \"{}\" which doesn't exist",
                     bucket.display()
                 );
@@ -124,15 +125,15 @@ fn write_wranglerjs_output(
     bundle: &Bundle,
     output: &WranglerjsOutput,
     custom_webpack: bool,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     if output.has_errors() {
         StdErr::user_error(output.get_errors().as_str());
         if custom_webpack {
-            failure::bail!(
+            anyhow::bail!(
             "webpack returned an error. Try configuring `entry` in your webpack config relative to the current working directory, or setting `context = __dirname` in your webpack config."
         );
         } else {
-            failure::bail!(
+            anyhow::bail!(
             "webpack returned an error. You may be able to resolve this issue by running npm install."
         );
         }
@@ -148,7 +149,7 @@ fn write_wranglerjs_output(
 }
 
 //setup a build to run wranglerjs, return the command, the ipc temp file, and the bundle
-fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle), failure::Error> {
+fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle)> {
     for tool in &["node", "npm"] {
         env_dep_installed(tool)?;
     }
@@ -209,10 +210,7 @@ fn build_with_custom_webpack(command: &mut Command, webpack_config_path: &PathBu
     ));
 }
 
-fn build_with_default_webpack(
-    command: &mut Command,
-    package_dir: &PathBuf,
-) -> Result<(), failure::Error> {
+fn build_with_default_webpack(command: &mut Command, package_dir: &PathBuf) -> Result<()> {
     let package = Package::new(&package_dir)?;
     let package_main = package_dir
         .join(package.main(&package_dir)?)
@@ -226,7 +224,7 @@ fn build_with_default_webpack(
 
 // Run {npm install} in the specified directory. Skips the install if a
 // {node_modules} is found in the directory.
-fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
+fn run_npm_install(dir: &PathBuf) -> Result<()> {
     let flock_path = dir.join(&".install.lock");
     let flock = File::create(&flock_path)?;
     // avoid running multiple {npm install} at the same time (eg. in tests)
@@ -241,7 +239,7 @@ fn run_npm_install(dir: &PathBuf) -> Result<(), failure::Error> {
         let status = command.status()?;
 
         if !status.success() {
-            failure::bail!("failed to execute `{:?}`: exited with {}", command, status)
+            anyhow::bail!("failed to execute `{:?}`: exited with {}", command, status)
         }
     } else {
         log::info!("skipping npm install because node_modules exists");
@@ -274,9 +272,9 @@ fn build_npm_command() -> Command {
 }
 
 // Ensures the specified tool is available in our env.
-fn env_dep_installed(tool: &str) -> Result<(), failure::Error> {
+fn env_dep_installed(tool: &str) -> Result<()> {
     if which::which(tool).is_err() {
-        failure::bail!("You need to install {}", tool)
+        anyhow::bail!("You need to install {}", tool)
     }
     Ok(())
 }
@@ -290,7 +288,7 @@ fn get_source_dir() -> PathBuf {
 }
 
 // Install {wranglerjs} from our GitHub releases
-fn install() -> Result<PathBuf, failure::Error> {
+fn install() -> Result<PathBuf> {
     let wranglerjs_path = if install::target::DEBUG {
         let source_path = get_source_dir();
         let wranglerjs_path = source_path.join("wranglerjs");


### PR DESCRIPTION
Follow up to #1880 

Switch from deprecated `failure` to much better and cooler `anyhow`. seriously [read this](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md)

This makes error handling with `cloudflare-rs` easier, allowing us to preserve stack trace
information from any errors we encounter with the API.
