### PR TITLE
Updated cloudflared download link

### DIFF
--- a/src/tail/mod.rs
+++ b/src/tail/mod.rs
@@ -93,7 +93,7 @@ impl Tail {
 fn is_cloudflared_installed() -> Result<()> {
     // this can be removed once we automatically install cloudflared
     if which("cloudflared").is_err() {
-        let install_url = style("https://developers.cloudflare.com/argo-tunnel/downloads/")
+        let install_url = style("https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation")
             .blue()
             .bold();
         anyhow::bail!("You must install cloudflared to use wrangler tail.\n\nInstallation instructions can be found here:\n{}", install_url);


### PR DESCRIPTION
Hello 🙂

The commit included with this PR updates the download link for cloudflared, as the previous link is no longer current and is now a redirect to https://developers.cloudflare.com/cloudflare-one/connections/connect-apps instead of directly to the installation/download page at https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation