### PR TITLE
fix: use latest cloudflare api client, resolving wrangler whoami issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e825a031f66d001bc76360ea75f818e3b08fc4c337f1486b79f612e22e69b04"
+checksum = "73d12edd02168d346742806d28d42796507aad648b81b7c3f65d5d648abae0c7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ binary-install = "0.0.3-alpha.1"
 chrome-devtools-rs = { version = "=0.0.0-alpha.1", features = ["color"] }
 chrono = "0.4.19"
 clap = "2.33.3"
-cloudflare = "0.8.1"
+cloudflare = "0.8.2"
 config = "0.10.1"
 console = "0.13.0"
 dirs = "3.0.1"


### PR DESCRIPTION
Updates `cloudflare-rs` crate to https://github.com/cloudflare/cloudflare-rs/commit/ae936d4b180155bafe5c44482a746fa490513df2, which should fix #1914.