### PR TITLE
Add `wrangler zone` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ $ wrangler publish
   - `ip`: ip to listen on. defaults to localhost
   - `port`: port to listen on. defaults to 8787
 
+### 🌎 `zone`
+
+  Fetch the Cloudflare Account & Zone ID of the supplied domain name.
+  
+  You can use the returned ID as the `zone_id` field of your `wrangler.toml` configuration file to publish a Worker on a custom domain.
+
+  ```bash
+  $ wrangler zone example.com
+  Zone information for example.com
+
+  Zone ID: e405e53ee0fb1190c104316d5d306a19
+  Account: Example Inc. (0f384009b201d49267977ca75b6b5918)
+  Status: Active
+  ```
+
 ## Additional Documentation
 
 All information regarding wrangler or Cloudflare Workers is located in the [Cloudflare Workers Developer Docs](https://developers.cloudflare.com/workers/). This includes:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub mod secret;
 pub mod subdomain;
 pub mod tail;
 pub mod whoami;
+pub mod zone;
 
 pub mod exec {
     pub use super::build::build;
@@ -28,6 +29,7 @@ pub mod exec {
     pub use super::subdomain::subdomain;
     pub use super::tail::tail;
     pub use super::whoami::whoami;
+    pub use super::zone::zone;
 }
 
 use std::net::IpAddr;
@@ -241,6 +243,14 @@ pub enum Command {
         /// Specifies a log to report (e.g. --log=1619728882567.log)
         #[structopt(name = "log", long)]
         log: Option<PathBuf>,
+    },
+
+    /// Fetch details on the specified Cloudflare zone
+    #[structopt(name = "zone")]
+    Zone {
+        /// The zone to fetch information for
+        #[structopt(index = 1, required = true)]
+        zone: String,
     },
 }
 

--- a/src/cli/zone.rs
+++ b/src/cli/zone.rs
@@ -1,0 +1,9 @@
+use crate::commands;
+use crate::settings::global_user::GlobalUser;
+
+use anyhow::Result;
+
+pub fn zone(zone: String) -> Result<()> {
+    log::info!("Getting User settings");
+    commands::zone(&GlobalUser::new()?, zone)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod secret;
 pub mod subdomain;
 pub mod tail;
 pub mod whoami;
+pub mod zone;
 
 pub use self::config::global_config;
 pub use self::preview::run as preview;
@@ -25,6 +26,7 @@ pub use secret::{create_secret, delete_secret, list_secrets};
 pub use subdomain::get_subdomain;
 pub use subdomain::set_subdomain;
 pub use whoami::whoami;
+pub use zone::zone;
 
 use anyhow::Result;
 use regex::Regex;

--- a/src/commands/zone.rs
+++ b/src/commands/zone.rs
@@ -1,0 +1,55 @@
+use crate::http;
+use crate::terminal::styles;
+
+use crate::settings::global_user::GlobalUser;
+
+use cloudflare::endpoints::zone::{ListZones, ListZonesParams};
+use cloudflare::framework::apiclient::ApiClient;
+
+use anyhow::Result;
+
+const ERR_MESSAGE: &str = "No matching zones found. Check you entered the zone name correctly and that Wrangler has permission to read zone information in your Cloudflare accounts.";
+
+pub fn zone(user: &GlobalUser, zone: String) -> Result<()> {
+    let api_client = http::cf_v4_client(user)?;
+
+    let resp = api_client.request(&ListZones {
+        params: ListZonesParams {
+            name: Some(zone),
+            status: None,
+            page: None,
+            per_page: Some(50),
+            order: None,
+            direction: None,
+            search_match: None,
+        },
+    })?;
+
+    if resp.result.len() == 0 {
+        println!("{}", styles::warning(ERR_MESSAGE));
+        return Ok(());
+    }
+
+    let zone = &resp.result[0];
+
+    let status = format!("{:?}", zone.status);
+
+    let title = format!("Zone information for {}", styles::url(&zone.name));
+
+    let information = &[
+        format!("{}\n", styles::bold(styles::underline(title))),
+        format!("Zone ID: {}", styles::cyan(&zone.id)),
+        format!(
+            "Account: {} ({})",
+            styles::cyan(&zone.account.name),
+            styles::cyan(&zone.account.id)
+        ),
+        format!("Status: {}", styles::cyan(status)),
+    ];
+
+    for info_item in information {
+        println!("{}", info_item);
+    }
+
+    Ok(())
+}

--- a/src/commands/zone.rs
+++ b/src/commands/zone.rs
@@ -25,7 +25,7 @@ pub fn zone(user: &GlobalUser, zone: String) -> Result<()> {
         },
     })?;
 
-    if resp.result.len() == 0 {
+    if resp.result.is_empty() {
         println!("{}", styles::warning(ERR_MESSAGE));
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,5 +113,6 @@ fn run() -> Result<()> {
         Command::Report { log } => commands::report::run(log.as_deref()).map(|_| {
             eprintln!("Report submission sucessful. Thank you!");
         }),
+        Command::Zone { zone } => exec::zone(zone),
     }
 }

--- a/src/terminal/styles.rs
+++ b/src/terminal/styles.rs
@@ -19,3 +19,7 @@ pub fn cyan<D>(msg: D) -> StyledObject<D> {
 pub fn bold<D>(msg: D) -> StyledObject<D> {
     style(msg).bold()
 }
+
+pub fn underline<D>(msg: D) -> StyledObject<D> {
+    style(msg).underlined()
+}


### PR DESCRIPTION
## What?

Adds a `wrangler zone` command to find the ID of a zone straight from the wrangler CLI.

<img width="1680" alt="Screenshot 2021-05-28 at 22 36 25" src="https://user-images.githubusercontent.com/20439493/120044126-2438be00-c005-11eb-813f-b04b7bb546e4.png">

## Why?

When generating a new project with wrangler you are directed to the dashboard for the final step to find the Zone ID for the domain you want to add the Worker to. This PR introduces a command which lets you remain in wrangler for the entire creation ➡️ publish to custom route flow.

## Caveats

- I could not find a way to do permission checking. When a token does not have permission the Cloudflare API just returns no entries, to counter this I've added a message when a zone is not found to check spelling but also check wrangler permissions.
- This may require a change in how tokens are created with `wrangler login`, they should include the `Zone.Zone` permission to be able to read zone information.

## ToDo

- [x] Document the new command in the README.md
- [ ] Document the new command in the [commands](https://developers.cloudflare.com/workers/cli-wrangler/commands) documentation page.
- [ ] Update references in wrangler itself to reference the new zone command instead of directing people to the dashboard (optional, this might not be a good idea if tokens are not retroactively updated, as it will then be a more strenous task than just going to fetch the zone ID).