### PR TITLE
Remove misleading `rustup install` and update rust-toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,13 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Rust
-        run: |
-          rustup update stable
-          rustup default stable
-          rustup component add rustfmt
-          rustup component add clippy
-
       - name: Check Formatting
         run: cargo fmt --all -- --check
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.49.0
+[toolchain]
+channel = "1.53.0"
+components = ["rustfmt", "clippy"]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -4,7 +4,7 @@ use crate::terminal::styles;
 use crate::wranglerjs;
 use crate::{commands, install};
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
@@ -68,7 +68,7 @@ pub fn build_target(target: &Target) -> Result<String> {
     }
 }
 
-pub fn command(args: &[&str], binary_path: &PathBuf) -> Command {
+pub fn command(args: &[&str], binary_path: &Path) -> Command {
     let mut c = if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");
         c.arg("/C");

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(not(target_os = "windows"))]
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use cloudflare::endpoints::user::{GetUserDetails, GetUserTokenStatus};
@@ -16,7 +16,7 @@ use crate::terminal::styles;
 
 // set the permissions on the dir, we want to avoid that other user reads to file
 #[cfg(not(target_os = "windows"))]
-pub fn set_file_mode(file: &PathBuf) {
+pub fn set_file_mode(file: &Path) {
     File::open(&file)
         .unwrap()
         .set_permissions(PermissionsExt::from_mode(0o600))

--- a/src/commands/kv/key/put.rs
+++ b/src/commands/kv/key/put.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn metadata_parser_legal() {
-        for input in vec![
+        for input in &[
             "true",
             "false",
             "123.456",
@@ -150,14 +150,14 @@ mod tests {
 
     #[test]
     fn metadata_parser_illegal() {
-        for input in vec!["something", "{key: 123}", "[1, 2"] {
+        for input in &["something", "{key: 123}", "[1, 2"] {
             assert!(parse_metadata(Some(input)).is_err());
         }
     }
 
     #[test]
     fn metadata_parser_error_message_unquoted_string_error_message() -> Result<(), &'static str> {
-        for input in vec!["abc", "'abc'", "'abc", "abc'", "\"abc", "abc\""] {
+        for input in &["abc", "'abc'", "'abc", "abc'", "\"abc", "abc\""] {
             match parse_metadata(Some(input)) {
                 Ok(_) => return Err("illegal value was parsed successfully"),
                 Err(e) => {

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -137,11 +137,11 @@ mod tests {
 
     #[test]
     fn it_encodes_slash() {
-        assert_eq!(kv::url_encode_key("/slash").to_string(), "%2Fslash");
+        assert_eq!(kv::url_encode_key("/slash"), "%2Fslash");
     }
 
     #[test]
     fn it_doesnt_double_encode_slash() {
-        assert_eq!(kv::url_encode_key("%2Fslash").to_string(), "%2Fslash");
+        assert_eq!(kv::url_encode_key("%2Fslash"), "%2Fslash");
     }
 }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -154,7 +154,7 @@ fn build_output_message(deploy_results: deploy::DeployResults, target_name: Stri
 
 // We don't want folks setting their bucket to the top level directory,
 // which is where wrangler commands are always called from.
-pub fn validate_bucket_location(bucket: &PathBuf) -> Result<()> {
+pub fn validate_bucket_location(bucket: &Path) -> Result<()> {
     // TODO: this should really use a convenience function for "Wrangler Project Root"
     let current_dir = env::current_dir()?;
     if bucket.as_os_str() == current_dir {

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -70,13 +70,9 @@ fn tool_needs_update(tool_name: &str, target_version: Version) -> Result<ToolDow
     let current_installation = get_installation(tool_name, &target_version);
     // if something goes wrong checking the current installation
     // we shouldn't fail, we should just re-install for them
-    if let Ok(current_installation) = current_installation {
-        if let Some((installed_version, installed_location)) = current_installation {
-            if installed_version.major == target_version.major
-                && installed_version >= target_version
-            {
-                return Ok(ToolDownload::InstalledAt(Download::at(&installed_location)));
-            }
+    if let Ok(Some((installed_version, installed_location))) = current_installation {
+        if installed_version.major == target_version.major && installed_version >= target_version {
+            return Ok(ToolDownload::InstalledAt(Download::at(&installed_location)));
         }
     }
     Ok(ToolDownload::NeedsInstall(target_version))

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -94,10 +94,7 @@ impl Iterator for KeyList {
                 Ok(mut keys) => {
                     let key = keys.pop();
                     self.keys_result = Some(keys);
-                    match key {
-                        Some(k) => Some(Ok(k)),
-                        None => None,
-                    }
+                    key.map(Ok)
                 }
                 Err(e) => Some(Err(e)),
             }

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -292,10 +292,8 @@ fn try_extract_payload(panic_info: &PanicInfo) -> Option<String> {
     // panic_any, we'll have to explicitly handle it here.
     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
         Some(s.to_string())
-    } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
-        Some(s.clone())
     } else {
-        None
+        panic_info.payload().downcast_ref::<String>().cloned()
     }
 }
 

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -91,7 +91,7 @@ impl Manifest {
     pub fn generate(
         name: String,
         target_type: Option<TargetType>,
-        config_path: &PathBuf,
+        config_path: &Path,
         site: Option<Site>,
     ) -> Result<Manifest> {
         let config_file = &config_path.join("wrangler.toml");

--- a/src/settings/toml/tests/deployments.rs
+++ b/src/settings/toml/tests/deployments.rs
@@ -177,7 +177,7 @@ fn it_can_get_a_scheduled_no_workers_dev_no_zoned() {
     let expected_deployments = vec![DeployTarget::Schedule(ScheduleTarget {
         account_id: ACCOUNT_ID.to_owned(),
         script_name: script_name.to_owned(),
-        crons: crons,
+        crons,
     })];
     let environment = None;
     let actual_deployments = manifest.get_deployments(environment).unwrap();

--- a/src/tail/tunnel.rs
+++ b/src/tail/tunnel.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str;
 
@@ -68,7 +68,7 @@ impl Tunnel {
 // TODO: let's not clumsily copy this from commands/build/mod.rs
 // We definitely want to keep the check for RUST_LOG=info below so we avoid
 // spamming user terminal with default cloudflared output (which is pretty darn sizable.)
-pub fn command(args: &[&str], binary_path: &PathBuf, verbose: bool) -> Command {
+pub fn command(args: &[&str], binary_path: &Path, verbose: bool) -> Command {
     let mut c = if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");
         c.arg("/C");

--- a/src/terminal/message.rs
+++ b/src/terminal/message.rs
@@ -48,6 +48,7 @@ pub trait Message {
 
     fn billboard(msg: &str);
     fn deprecation_warning(msg: &str);
+    #[allow(clippy::wrong_self_convention)]
     fn as_json<T>(value: &T)
     where
         T: ?Sized + Serialize;

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -182,7 +182,7 @@ fn get_asset_manifest_blob(asset_manifest: AssetManifest) -> Result<String> {
     Ok(asset_manifest)
 }
 
-fn filestem_from_path(path: &PathBuf) -> Option<String> {
+fn filestem_from_path(path: &Path) -> Option<String> {
     path.file_stem()?.to_str().map(|s| s.to_string())
 }
 

--- a/src/upload/form/wasm_module.rs
+++ b/src/upload/form/wasm_module.rs
@@ -20,8 +20,8 @@ impl WasmModule {
             .ok_or_else(|| anyhow!("filename should not be empty: {}", path.display()))?;
 
         Ok(Self {
-            filename,
             path,
+            filename,
             binding,
         })
     }

--- a/src/upload/package.rs
+++ b/src/upload/package.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use serde::{self, Deserialize};
@@ -15,7 +15,7 @@ pub struct Package {
     module: PathBuf,
 }
 impl Package {
-    pub fn main(&self, package_dir: &PathBuf) -> Result<PathBuf> {
+    pub fn main(&self, package_dir: &Path) -> Result<PathBuf> {
         if self.main == PathBuf::from("") {
             anyhow::bail!(PACKAGE_JSON_KEY_ERROR_MAIN,)
         } else if !package_dir.join(&self.main).exists() {
@@ -27,7 +27,7 @@ impl Package {
             Ok(self.main.clone())
         }
     }
-    pub fn module(&self, package_dir: &PathBuf) -> Result<PathBuf> {
+    pub fn module(&self, package_dir: &Path) -> Result<PathBuf> {
         if self.module == PathBuf::from("") {
             anyhow::bail!(PACKAGE_JSON_KEY_ERROR_MODULE)
         } else if !package_dir.join(&self.module).exists() {
@@ -42,7 +42,7 @@ impl Package {
 }
 
 impl Package {
-    pub fn new(package_dir: &PathBuf) -> Result<Package> {
+    pub fn new(package_dir: &Path) -> Result<Package> {
         let manifest_path = package_dir.join("package.json");
         if !manifest_path.is_file() {
             anyhow::bail!(

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::mpsc;
 use std::thread;
@@ -104,7 +104,7 @@ fn check_wrangler_versions() -> Result<WranglerVersion> {
 }
 
 /// Reads version out of version file, is `None` if file does not exist or is corrupted
-fn get_version_disk(version_file: &PathBuf) -> Option<LastCheckedVersion> {
+fn get_version_disk(version_file: &Path) -> Option<LastCheckedVersion> {
     match fs::read_to_string(&version_file) {
         Ok(contents) => match LastCheckedVersion::from_str(&contents) {
             Ok(last_checked_version) => Some(last_checked_version),
@@ -116,7 +116,7 @@ fn get_version_disk(version_file: &PathBuf) -> Option<LastCheckedVersion> {
 
 fn get_latest_version(
     installed_version: &str,
-    version_file: &PathBuf,
+    version_file: &Path,
     current_time: SystemTime,
 ) -> Result<Version> {
     let latest_version = get_latest_version_from_api(installed_version)?;

--- a/src/wranglerjs/bundle.rs
+++ b/src/wranglerjs/bundle.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::output::WranglerjsOutput;
 
@@ -20,7 +20,7 @@ pub struct Bundle {
 // We call a {Bundle} the output of a {Bundler}; representing what {Webpack}
 // produces.
 impl Bundle {
-    pub fn new(package_dir: &PathBuf) -> Bundle {
+    pub fn new(package_dir: &Path) -> Bundle {
         Bundle {
             out: package_dir.join(BUNDLE_OUT),
         }

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -203,17 +203,17 @@ fn setup_build(target: &Target) -> Result<(Command, PathBuf, Bundle)> {
     Ok((command, temp_file, bundle))
 }
 
-fn build_with_custom_webpack(command: &mut Command, webpack_config_path: &PathBuf) {
+fn build_with_custom_webpack(command: &mut Command, webpack_config_path: &Path) {
     command.arg(format!(
         "--webpack-config={}",
         &webpack_config_path.to_str().unwrap().to_string()
     ));
 }
 
-fn build_with_default_webpack(command: &mut Command, package_dir: &PathBuf) -> Result<()> {
-    let package = Package::new(&package_dir)?;
+fn build_with_default_webpack(command: &mut Command, package_dir: &Path) -> Result<()> {
+    let package = Package::new(package_dir)?;
     let package_main = package_dir
-        .join(package.main(&package_dir)?)
+        .join(package.main(package_dir)?)
         .to_str()
         .unwrap()
         .to_string();
@@ -224,7 +224,7 @@ fn build_with_default_webpack(command: &mut Command, package_dir: &PathBuf) -> R
 
 // Run {npm install} in the specified directory. Skips the install if a
 // {node_modules} is found in the directory.
-fn run_npm_install(dir: &PathBuf) -> Result<()> {
+fn run_npm_install(dir: &Path) -> Result<()> {
     let flock_path = dir.join(&".install.lock");
     let flock = File::create(&flock_path)?;
     // avoid running multiple {npm install} at the same time (eg. in tests)
@@ -232,7 +232,7 @@ fn run_npm_install(dir: &PathBuf) -> Result<()> {
 
     if !dir.join("node_modules").exists() {
         let mut command = build_npm_command();
-        command.current_dir(dir.clone());
+        command.current_dir(dir.to_path_buf());
         command.arg("install");
         log::info!("Running {:?} in directory {:?}", command, dir);
 


### PR DESCRIPTION
Previously, CI ran `rustup install stable` just before running lints, but didn't
actually use the new toolchain. This removes the unneeded download and updates
rust-toolchain to the latest stable version.

This also fixes a bunch of clippy warnings that were introduced since 1.49.