### PR TITLE
Allow listing 1000 KV namespaces per page instead of 100

### DIFF
--- a/src/kv/namespace/list.rs
+++ b/src/kv/namespace/list.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use crate::commands::kv;
 use crate::settings::toml::Target;
 
-const MAX_NAMESPACES_PER_PAGE: u32 = 100;
+const MAX_NAMESPACES_PER_PAGE: u32 = 1000;
 
 pub fn list(client: &impl ApiClient, target: &Target) -> Result<Vec<WorkersKvNamespace>> {
     let mut namespaces: Vec<WorkersKvNamespace> = Vec::new();


### PR DESCRIPTION
The API supports it, so just in case something is broken about
pagination then this will paper over that problem for now. And even if
nothing is broken with pagination, this will improve latencies by
requiring fewer API requests on accounts with more than 100 namespaces.