### PR TITLE
fix: skip kv pairs that have already been uploaded

### DIFF
--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -6,6 +6,7 @@ mod sync;
 pub use manifest::AssetManifest;
 pub use sync::sync;
 
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fs;
 use std::hash::Hasher;
@@ -64,6 +65,7 @@ pub fn add_namespace(user: &GlobalUser, target: &mut Target, preview: bool) -> R
 pub fn directory_keys_values(
     target: &Target,
     directory: &Path,
+    exclude: Option<&HashSet<String>>,
 ) -> Result<(Vec<KeyValuePair>, AssetManifest, Vec<String>)> {
     match fs::metadata(directory) {
         Ok(ref file_type) if file_type.is_dir() => {
@@ -95,6 +97,16 @@ pub fn directory_keys_values(
 
                     validate_key_size(&key)?;
 
+                    // asset manifest should always contain all files
+                    asset_manifest.insert(url_safe_path, key.clone());
+
+                    // skip uploading existing keys, if configured to do so
+                    if let Some(remote_keys) = exclude {
+                        if remote_keys.contains(&key) {
+                            continue;
+                        }
+                    }
+
                     upload_vec.push(KeyValuePair {
                         key: key.clone(),
                         value: b64_value,
@@ -102,8 +114,6 @@ pub fn directory_keys_values(
                         expiration_ttl: None,
                         base64: Some(true),
                     });
-
-                    asset_manifest.insert(url_safe_path, key);
                 }
             }
             Ok((upload_vec, asset_manifest, file_list))
@@ -371,7 +381,7 @@ mod tests {
             test_dir
         )))
         .unwrap();
-        let (_, _, file_list) = directory_keys_values(&target, Path::new(test_dir)).unwrap();
+        let (_, _, file_list) = directory_keys_values(&target, Path::new(test_dir), None).unwrap();
         if cfg!(windows) {
             assert!(!file_list.contains(&format!("{}\\.ignore_me.txt", test_dir)));
             assert!(file_list.contains(&format!("{}\\.well-known\\dontignoreme.txt", test_dir)));


### PR DESCRIPTION
This adds an optional param to the function which creates the kv pairs for upload. The logic was pulled from the `filter_files` function, which itself has been removed (along with its test). 

The primary motivation here is to skip any kv pair that has already been uploaded (checked by listing keys from the namespace), so we don't grow the `vec` so needlessly large.