### PR TITLE
Tell Dependabot to only make PRs for new major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: daily
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: npm
     directory: /wranglerjs
     schedule:


### PR DESCRIPTION
This avoids constant small PRs which aren't necessary. Dependabot will still
make PRs for security updates, which is good because we keep Cargo.lock checked
into git and Cargo will keep using yanked versions until you update Cargo.lock.

See
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore
for documentation on these options.