### PR TITLE
fix: improve error message when no deployment info is provided

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -286,7 +286,7 @@ impl Manifest {
         };
 
         if durable_objects.is_none() && deployments.is_empty() {
-            anyhow::bail!("No deployments specified!")
+            anyhow::bail!("Please specify your deployment routes or `wrangler_dev = true` inside of your configuration file. For more information, see: https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys")
         }
 
         Ok(deployments)


### PR DESCRIPTION
Fixes #1694.

Adds clarification and links to documentation on how the project must be configured in order to deploy it.