### PR TITLE
Cleanup code in socket.rs

### DIFF
--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -148,7 +148,8 @@ async fn print_ws_messages(
                     serde_json::from_str(&*event.to_string());
                 print_json(json_parse, event.to_string());
             }
-            _ => {}
+            Ok(protocol::Runtime::Method(_)) => {}
+            Err(err) => log::debug!("{}", err),
         }
     }
     Ok(())

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -115,44 +115,40 @@ async fn print_ws_messages(
     mut read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 ) -> Result<()> {
     while let Some(message) = read.next().await {
-        match message {
-            Ok(message) => {
-                let message_text = message.into_text().unwrap();
-                log::info!("{}", &message_text);
+        let message = message?;
+        let message_text = message.into_text().unwrap();
+        log::info!("{}", &message_text);
 
-                let parsed_message: Result<protocol::Runtime> = serde_json::from_str(&message_text)
-                    .map_err(|e| anyhow!("Failed to parse event:\n{}", e));
+        let parsed_message: Result<protocol::Runtime> = serde_json::from_str(&message_text)
+            .map_err(|e| anyhow!("Failed to parse event:\n{}", e));
 
-                match parsed_message {
-                    Ok(protocol::Runtime::Event(ExceptionThrown(params))) => {
-                        let default_description = "N/A".to_string();
-                        let description = params
-                            .exception_details
-                            .exception
-                            .description
-                            .as_ref()
-                            .unwrap_or(&default_description);
+        match parsed_message {
+            Ok(protocol::Runtime::Event(ExceptionThrown(params))) => {
+                let default_description = "N/A".to_string();
+                let description = params
+                    .exception_details
+                    .exception
+                    .description
+                    .as_ref()
+                    .unwrap_or(&default_description);
 
-                        StdOut::message(&format!(
-                            "{} at line {:?}, col {:?}",
-                            description,
-                            params.exception_details.line_number,
-                            params.exception_details.column_number,
-                        ));
+                StdOut::message(&format!(
+                    "{} at line {:?}, col {:?}",
+                    description,
+                    params.exception_details.line_number,
+                    params.exception_details.column_number,
+                ));
 
-                        let json_parse = serde_json::to_value(params.clone());
-                        print_json(json_parse, format!("{:?}", params));
-                    }
-                    Ok(protocol::Runtime::Event(event)) => {
-                        // Try to parse json to pretty print, otherwise just print string
-                        let json_parse: Result<serde_json::Value, serde_json::Error> =
-                            serde_json::from_str(&*event.to_string());
-                        print_json(json_parse, event.to_string());
-                    }
-                    _ => {}
-                }
+                let json_parse = serde_json::to_value(params.clone());
+                print_json(json_parse, format!("{:?}", params));
             }
-            Err(error) => return Err(error.into()),
+            Ok(protocol::Runtime::Event(event)) => {
+                // Try to parse json to pretty print, otherwise just print string
+                let json_parse: Result<serde_json::Value, serde_json::Error> =
+                    serde_json::from_str(&*event.to_string());
+                print_json(json_parse, event.to_string());
+            }
+            _ => {}
         }
     }
     Ok(())


### PR DESCRIPTION
This can just use `?` instead of an explicit match.