### PR TITLE
Fix `wrangler dev` retry issues caused by expired preview token

### DIFF
--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -50,9 +50,7 @@ pub fn dev(
 
     let runtime = TokioRuntime::new()?;
     runtime.block_on(async {
-        let devtools_listener = tokio::spawn(socket::listen(
-            session.lock().unwrap().websocket_url.to_owned(),
-        ));
+        let devtools_listener = tokio::spawn(socket::listen(session.clone()));
         let server = match local_protocol {
             Protocol::Https => tokio::spawn(server::https(
                 server_config.clone(),

--- a/src/commands/dev/edge/server/http.rs
+++ b/src/commands/dev/edge/server/http.rs
@@ -1,4 +1,5 @@
 use super::preview_request;
+use crate::commands::dev::edge::setup::Session;
 use crate::commands::dev::utils::{get_path_as_str, rewrite_redirect};
 use crate::commands::dev::{Protocol, ServerConfig};
 use crate::terminal::emoji;
@@ -13,8 +14,8 @@ use hyper_rustls::HttpsConnector;
 
 pub async fn http(
     server_config: ServerConfig,
+    session: Arc<Mutex<Session>>,
     preview_token: Arc<Mutex<String>>,
-    host: String,
     upstream_protocol: Protocol,
 ) -> Result<()> {
     // set up https client to connect to the preview service
@@ -27,7 +28,7 @@ pub async fn http(
     let make_service = make_service_fn(move |_| {
         let client = client.to_owned();
         let preview_token = preview_token.to_owned();
-        let host = host.to_owned();
+        let host = session.lock().unwrap().host.to_owned();
         let server_config = server_config.to_owned();
 
         async move {

--- a/src/commands/dev/edge/server/https.rs
+++ b/src/commands/dev/edge/server/https.rs
@@ -1,4 +1,5 @@
 use super::preview_request;
+use crate::commands::dev::edge::setup::Session;
 use crate::commands::dev::utils::{get_path_as_str, rewrite_redirect};
 use crate::commands::dev::{tls, Protocol, ServerConfig};
 use crate::terminal::emoji;
@@ -16,8 +17,8 @@ use tokio::net::TcpListener;
 
 pub async fn https(
     server_config: ServerConfig,
+    session: Arc<Mutex<Session>>,
     preview_token: Arc<Mutex<String>>,
-    host: String,
 ) -> Result<()> {
     tls::generate_cert()?;
 
@@ -31,7 +32,7 @@ pub async fn https(
     let service = make_service_fn(move |_| {
         let client = client.to_owned();
         let preview_token = preview_token.to_owned();
-        let host = host.to_owned();
+        let host = session.lock().unwrap().host.to_owned();
         let server_config = server_config.to_owned();
 
         async move {

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use crate::commands::dev::session;
 use crate::deploy::DeployTarget;
 use crate::kv::bulk;
 use crate::settings::global_user::GlobalUser;
@@ -77,7 +76,7 @@ pub struct Session {
     pub preview_token: String,
 }
 
-impl session::Session for Session {
+impl crate::commands::dev::Session for Session {
     fn get_socket_url(&self) -> &Url {
         &self.websocket_url
     }

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -72,9 +72,6 @@ pub(super) fn upload(
 
 #[derive(Debug, Clone)]
 pub struct Session {
-    pub target: Target,
-    pub user: GlobalUser,
-    pub deploy_target: DeployTarget,
     pub host: String,
     pub websocket_url: Url,
     pub preview_token: String,
@@ -83,10 +80,6 @@ pub struct Session {
 impl session::Session for Session {
     fn get_socket_url(&self) -> &Url {
         &self.websocket_url
-    }
-
-    fn refresh(&self) -> Result<Self> {
-        Session::new(&self.target, &self.user, &self.deploy_target)
     }
 }
 
@@ -124,9 +117,6 @@ impl Session {
         let preview_token = response.token;
 
         Ok(Session {
-            target: target.clone(),
-            user: user.clone(),
-            deploy_target: deploy_target.clone(),
             host,
             websocket_url,
             preview_token,

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use crate::deploy::DeployTarget;
 use crate::kv::bulk;
@@ -17,7 +18,7 @@ pub(super) fn upload(
     target: &mut Target,
     deploy_target: &DeployTarget,
     user: &GlobalUser,
-    session_token: String,
+    session: Arc<Mutex<Session>>,
     verbose: bool,
 ) -> Result<String> {
     let client = crate::http::legacy_auth_client(&user);
@@ -44,6 +45,7 @@ pub(super) fn upload(
     let address = get_upload_address(target)?;
 
     let script_upload_form = upload::form::build(target, asset_manifest, Some(session_config))?;
+    let session_token = &session.lock().unwrap().preview_token;
 
     let response = client
         .post(&address)

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use crate::commands::dev::session;
 use crate::deploy::DeployTarget;
 use crate::kv::bulk;
 use crate::settings::global_user::GlobalUser;
@@ -71,9 +72,22 @@ pub(super) fn upload(
 
 #[derive(Debug, Clone)]
 pub struct Session {
+    pub target: Target,
+    pub user: GlobalUser,
+    pub deploy_target: DeployTarget,
     pub host: String,
     pub websocket_url: Url,
     pub preview_token: String,
+}
+
+impl session::Session for Session {
+    fn get_socket_url(&self) -> &Url {
+        &self.websocket_url
+    }
+
+    fn refresh(&self) -> Result<Self> {
+        Session::new(&self.target, &self.user, &self.deploy_target)
+    }
 }
 
 impl Session {
@@ -110,6 +124,9 @@ impl Session {
         let preview_token = response.token;
 
         Ok(Session {
+            target: target.clone(),
+            user: user.clone(),
+            deploy_target: deploy_target.clone(),
             host,
             websocket_url,
             preview_token,

--- a/src/commands/dev/edge/watch.rs
+++ b/src/commands/dev/edge/watch.rs
@@ -19,7 +19,10 @@ pub fn watch_for_changes(
     let (sender, receiver) = mpsc::channel();
     watch_and_build(&target, Some(sender))?;
 
-    while receiver.recv().is_ok() {
+    loop {
+        if let Err(e) = receiver.recv() {
+            panic!("The channel for file changes was disconnected: {}", e);
+        }
         let user = user.clone();
         let target = target.clone();
         let deploy_target = deploy_target.clone();
@@ -36,6 +39,4 @@ pub fn watch_for_changes(
         // to the proper script
         *preview_token = setup::upload(&mut target, &deploy_target, &user, session_token, verbose)?;
     }
-
-    Ok(())
 }

--- a/src/commands/dev/gcs/mod.rs
+++ b/src/commands/dev/gcs/mod.rs
@@ -6,7 +6,7 @@ mod watch;
 use setup::{get_preview_id, get_session_id};
 use watch::watch_for_changes;
 
-use crate::commands::dev::gcs::setup::{Session, get_socket_url};
+use crate::commands::dev::gcs::setup::{get_socket_url, Session};
 use crate::commands::dev::{socket, Protocol, ServerConfig};
 use crate::settings::toml::Target;
 

--- a/src/commands/dev/gcs/setup.rs
+++ b/src/commands/dev/gcs/setup.rs
@@ -54,10 +54,4 @@ impl session::Session for Session {
     fn get_socket_url(&self) -> &Url {
         &self.socket_url
     }
-
-    fn refresh(&self) -> Result<Self> {
-        let session_id = get_session_id()?;
-        let socket_url = get_socket_url(&session_id)?;
-        Ok(Self { socket_url })
-    }
 }

--- a/src/commands/dev/gcs/setup.rs
+++ b/src/commands/dev/gcs/setup.rs
@@ -1,9 +1,10 @@
-use crate::commands::dev::ServerConfig;
+use crate::commands::dev::{session, ServerConfig};
 use crate::preview::upload;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
 
 use anyhow::Result;
+use url::Url;
 use uuid::Uuid;
 
 /// generate a unique uuid that lasts the entirety of the
@@ -36,4 +37,27 @@ pub fn get_preview_id(
         server_config.host.is_https() as u8,
         server_config.host
     ))
+}
+
+pub fn get_socket_url(session_id: &str) -> Result<Url, url::ParseError> {
+    Url::parse(&format!(
+        "wss://cloudflareworkers.com/inspect/{}",
+        session_id
+    ))
+}
+
+pub struct Session {
+    pub socket_url: Url,
+}
+
+impl session::Session for Session {
+    fn get_socket_url(&self) -> &Url {
+        &self.socket_url
+    }
+
+    fn refresh(&self) -> Result<Self> {
+        let session_id = get_session_id()?;
+        let socket_url = get_socket_url(&session_id)?;
+        Ok(Self { socket_url })
+    }
 }

--- a/src/commands/dev/gcs/setup.rs
+++ b/src/commands/dev/gcs/setup.rs
@@ -1,4 +1,4 @@
-use crate::commands::dev::{session, ServerConfig};
+use crate::commands::dev::ServerConfig;
 use crate::preview::upload;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
@@ -50,7 +50,7 @@ pub struct Session {
     pub socket_url: Url,
 }
 
-impl session::Session for Session {
+impl crate::commands::dev::Session for Session {
     fn get_socket_url(&self) -> &Url {
         &self.socket_url
     }

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -1,7 +1,6 @@
 mod edge;
 mod gcs;
 mod server_config;
-mod session;
 mod socket;
 mod tls;
 mod utils;
@@ -17,6 +16,7 @@ use crate::terminal::message::{Message, StdOut};
 use crate::terminal::styles;
 
 use anyhow::Result;
+use url::Url;
 
 /// `wrangler dev` starts a server on a dev machine that routes incoming HTTP requests
 /// to a Cloudflare Workers runtime and returns HTTP responses
@@ -97,4 +97,8 @@ pub fn dev(
     }
 
     gcs::dev(target, server_config, local_protocol, verbose)
+}
+
+pub trait Session: Sized {
+    fn get_socket_url(&self) -> &Url;
 }

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -1,6 +1,7 @@
 mod edge;
 mod gcs;
 mod server_config;
+mod session;
 mod socket;
 mod tls;
 mod utils;

--- a/src/commands/dev/session.rs
+++ b/src/commands/dev/session.rs
@@ -1,0 +1,7 @@
+use anyhow::Result;
+use url::Url;
+
+pub trait Session: Sized {
+    fn get_socket_url(&self) -> &Url;
+    fn refresh(&self) -> Result<Self>;
+}

--- a/src/commands/dev/session.rs
+++ b/src/commands/dev/session.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
 use url::Url;
 
 pub trait Session: Sized {
     fn get_socket_url(&self) -> &Url;
-    fn refresh(&self) -> Result<Self>;
 }

--- a/src/commands/dev/session.rs
+++ b/src/commands/dev/session.rs
@@ -1,5 +1,0 @@
-use url::Url;
-
-pub trait Session: Sized {
-    fn get_socket_url(&self) -> &Url;
-}

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -93,11 +93,6 @@ async fn connect_retry(
                     wait_seconds
                 ));
                 sleep(Duration::from_secs(wait_seconds)).await;
-                {
-                    StdOut::info("Starting a new session because the existing token has expired");
-                    let mut session = session.lock().unwrap();
-                    *session = session.refresh().expect("Could not start a new session");
-                }
                 wait_seconds = wait_seconds.pow(2);
                 if wait_seconds > maximum_wait_seconds {
                     // max out at 60 seconds

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -19,7 +19,7 @@ use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream, WebSocketStr
 
 use anyhow::{anyhow, Result};
 
-use super::session::Session;
+use super::Session;
 
 const KEEP_ALIVE_INTERVAL: u64 = 10;
 


### PR DESCRIPTION
EDIT: See also PR #2008, which is a fix for the same issue with a different approach.

This PR aims to fix the underlying issue first addressed in #1974 (related to the issues #1738 and #1995).

## Root Cause

After running `wrangler dev` for some time, the upload  at [src/commands/dev/edge/setup.rs#L48](https://github.com/cloudflare/wrangler/blob/acb988d5c6de92b73817795945bdb5bec0c90a38/src/commands/dev/edge/setup.rs#L48) starts failing with the following message:

```json
{
  "result": null,
  "success": false,
  "errors": [
    {
      "code": 10049,
      "message": "workers.api.error.expired_preview_token"
    }
  ],
  "messages": []
}
```

This expired token then causes 2 issues: The devtools connection will start to respond with `400 Bad Request` (usually after a `504 Gateway Timeout`) and the upload initiated after a file change at [src/commands/dev/edge/watch.rs#L37](https://github.com/cloudflare/wrangler/blob/acb988d5c6de92b73817795945bdb5bec0c90a38/src/commands/dev/edge/watch.rs#L37) will return an error, thus exiting the whole `while` loop and returning an error from [src/commands/dev/edge/watch.rs#L11](https://github.com/cloudflare/wrangler/blob/acb988d5c6de92b73817795945bdb5bec0c90a38/src/commands/dev/edge/watch.rs#L11) (which is silently ignored). This will then in turn lead to the channel being dropped by the receiver, after which all later `send` calls in [src/watch/mod.rs#L137](https://github.com/cloudflare/wrangler/blob/acb988d5c6de92b73817795945bdb5bec0c90a38/src/watch/mod.rs#L137) will fail.

PR #1974 only addresses the very last point in this chain by ignoring the failed `send`. But after disconnecting from the channel there is no possibility of recovering from this error.

## Proposed Fix

Since I cannot investigate why the token expires in the first place (the `400` response does not include a response body with further details), this PR fixes the issue by starting a new session whenever an upload fails either after a file change or while connecting to the devtools, which then generates a new token. (This requires threading an `Arc<Mutex<Session>>` to all invocations of the `upload` and `connect_retry` functions and is probably not the cleanest solution, but seemed to be the most straightforward solution if the current architecture needs to be kept, which manages the retries and the error handling at the point where the token is being used in a request.)

The PR also changes the watch loop slightly so that it now panics if the upload fails instead of silently dropping the channel, which should make debugging similar issues in the future a bit easier.