### PR TITLE
Fix exponential backoff for retry of devtools connection

### DIFF
--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -88,7 +88,7 @@ async fn connect_retry(socket_url: &Url) -> WebSocketStream<MaybeTlsStream<TcpSt
                     wait_seconds
                 ));
                 sleep(Duration::from_secs(wait_seconds)).await;
-                wait_seconds = wait_seconds.pow(2);
+                wait_seconds *= 2;
                 if wait_seconds > maximum_wait_seconds {
                     // max out at 60 seconds
                     wait_seconds = maximum_wait_seconds;


### PR DESCRIPTION
This is merely a tiny and rather cosmetic fix, but I noticed that the wait time between retries does not follow the usual exponential backoff progression, but increases much more quickly:

```
⚠️  Failed to connect to devtools instance: HTTP error: 504 Gateway Timeout
⚠️  Will retry connection in 2 seconds
🌀  Retrying...
⚠️  Failed to connect to devtools instance: HTTP error: 504 Gateway Timeout
⚠️  Will retry connection in 4 seconds
🌀  Retrying...
⚠️  Failed to connect to devtools instance: HTTP error: 400 Bad Request
⚠️  Will retry connection in 16 seconds
🌀  Retrying...
⚠️  Failed to connect to devtools instance: HTTP error: 400 Bad Request
⚠️  Will retry connection in 60 seconds
🌀  Retrying...
⚠️  Failed to connect to devtools instance: HTTP error: 400 Bad Request
⚠️  Will retry connection in 60 seconds
🌀  Retrying...
⚠️  Failed to connect to devtools instance: HTTP error: 400 Bad Request
⚠️  Will retry connection in 60 seconds
```

This PR fixes the wait time so that it grows exponentially as expected (2, 4, 8, 16, etc.).