### PR TITLE
Fix expired preview token by restarting whole command

### DIFF
--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -3,17 +3,22 @@ mod setup;
 mod watch;
 
 use setup::{upload, Session};
+use tokio::task::JoinHandle;
 use watch::watch_for_changes;
 
 use crate::commands::dev::{socket, Protocol, ServerConfig};
 use crate::deploy::DeployTarget;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::Target;
+use crate::terminal::message::{Message, StdOut};
 use anyhow::Result;
 
 use tokio::runtime::Runtime as TokioRuntime;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    mpsc::{self, Sender},
+    Arc, Mutex,
+};
 use std::thread;
 
 pub fn dev(
@@ -25,8 +30,46 @@ pub fn dev(
     upstream_protocol: Protocol,
     verbose: bool,
 ) -> Result<()> {
+    let runtime = TokioRuntime::new()?;
+    loop {
+        let target = target.clone();
+        let user = user.clone();
+        let server_config = server_config.clone();
+        let deploy_target = deploy_target.clone();
+        let (sender, receiver) = mpsc::channel();
+
+        let tasks = dev_once(
+            target,
+            user,
+            server_config,
+            deploy_target,
+            local_protocol,
+            upstream_protocol,
+            verbose,
+            &runtime,
+            sender,
+        )?;
+
+        receiver.recv()?;
+        for task in tasks {
+            task.abort();
+        }
+        StdOut::info("Starting a new session because the existing token has expired");
+    }
+}
+
+fn dev_once(
+    mut target: Target,
+    user: GlobalUser,
+    server_config: ServerConfig,
+    deploy_target: DeployTarget,
+    local_protocol: Protocol,
+    upstream_protocol: Protocol,
+    verbose: bool,
+    runtime: &TokioRuntime,
+    refresh_session_sender: Sender<()>,
+) -> Result<Vec<JoinHandle<Result<()>>>> {
     let session = Session::new(&target, &user, &deploy_target)?;
-    let mut target = target;
 
     let preview_token = upload(
         &mut target,
@@ -44,37 +87,30 @@ pub fn dev(
 
         thread::spawn(move || {
             watch_for_changes(
-                target,
+                &target,
                 &deploy_target,
                 &user,
                 Arc::clone(&preview_token),
                 session_token,
                 verbose,
+                refresh_session_sender,
             )
         });
     }
 
-    let runtime = TokioRuntime::new()?;
-    runtime.block_on(async {
-        let devtools_listener = tokio::spawn(socket::listen(session.websocket_url));
-        let server = match local_protocol {
-            Protocol::Https => tokio::spawn(server::https(
-                server_config.clone(),
-                Arc::clone(&preview_token),
-                session.host.clone(),
-            )),
-            Protocol::Http => tokio::spawn(server::http(
-                server_config,
-                Arc::clone(&preview_token),
-                session.host,
-                upstream_protocol,
-            )),
-        };
-
-        let res = tokio::try_join!(async { devtools_listener.await? }, async { server.await? });
-        match res {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
-    })
+    let devtools_listener = runtime.spawn(socket::listen(session.websocket_url));
+    let server = match local_protocol {
+        Protocol::Https => runtime.spawn(server::https(
+            server_config.clone(),
+            Arc::clone(&preview_token),
+            session.host.clone(),
+        )),
+        Protocol::Http => runtime.spawn(server::http(
+            server_config,
+            Arc::clone(&preview_token),
+            session.host,
+            upstream_protocol,
+        )),
+    };
+    Ok(vec![devtools_listener, server])
 }

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -50,7 +50,7 @@ pub fn dev(
             sender,
         )?;
 
-        receiver.recv()?;
+        while let None = receiver.recv()? {}
         for task in tasks {
             task.abort();
         }
@@ -67,7 +67,7 @@ fn dev_once(
     upstream_protocol: Protocol,
     verbose: bool,
     runtime: &TokioRuntime,
-    refresh_session_sender: Sender<()>,
+    refresh_session_sender: Sender<Option<()>>,
 ) -> Result<Vec<JoinHandle<Result<()>>>> {
     let session = Session::new(&target, &user, &deploy_target)?;
 

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -84,6 +84,7 @@ fn dev_once(
     {
         let preview_token = preview_token.clone();
         let session_token = session.preview_token.clone();
+        let refresh_session_sender = refresh_session_sender.clone();
 
         thread::spawn(move || {
             watch_for_changes(
@@ -98,7 +99,10 @@ fn dev_once(
         });
     }
 
-    let devtools_listener = runtime.spawn(socket::listen(session.websocket_url));
+    let devtools_listener = runtime.spawn(socket::listen(
+        session.websocket_url,
+        Some(refresh_session_sender),
+    ));
     let server = match local_protocol {
         Protocol::Https => runtime.spawn(server::https(
             server_config.clone(),

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -50,7 +50,7 @@ pub fn dev(
             sender,
         )?;
 
-        while let None = receiver.recv()? {}
+        while receiver.recv()?.is_none() {}
         for task in tasks {
             task.abort();
         }
@@ -58,6 +58,7 @@ pub fn dev(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn dev_once(
     mut target: Target,
     user: GlobalUser,
@@ -105,9 +106,9 @@ fn dev_once(
     ));
     let server = match local_protocol {
         Protocol::Https => runtime.spawn(server::https(
-            server_config.clone(),
+            server_config,
             Arc::clone(&preview_token),
-            session.host.clone(),
+            session.host,
         )),
         Protocol::Http => runtime.spawn(server::http(
             server_config,

--- a/src/commands/dev/edge/server/http.rs
+++ b/src/commands/dev/edge/server/http.rs
@@ -10,12 +10,14 @@ use chrono::prelude::*;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client as HyperClient, Request, Server};
 use hyper_rustls::HttpsConnector;
+use tokio::sync::oneshot::{Receiver, Sender};
 
 pub async fn http(
     server_config: ServerConfig,
     preview_token: Arc<Mutex<String>>,
     host: String,
     upstream_protocol: Protocol,
+    shutdown_channel: (Receiver<()>, Sender<()>),
 ) -> Result<()> {
     // set up https client to connect to the preview service
     let https = HttpsConnector::with_native_roots();
@@ -72,12 +74,19 @@ pub async fn http(
         }
     });
 
-    let server = Server::bind(&listening_address).serve(make_service);
+    let (rx, tx) = shutdown_channel;
+    let server = Server::bind(&listening_address)
+        .serve(make_service)
+        .with_graceful_shutdown(async {
+            rx.await.expect("Could not receive shutdown initiation");
+        });
     println!("{} Listening on http://{}", emoji::EAR, listening_address);
 
     if let Err(e) = server.await {
         eprintln!("{}", e);
     }
+    tx.send(())
+        .expect("Could not acknowledge listener shutdown");
 
     Ok(())
 }

--- a/src/commands/dev/edge/server/https.rs
+++ b/src/commands/dev/edge/server/https.rs
@@ -13,11 +13,13 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client as HyperClient, Request, Server};
 use hyper_rustls::HttpsConnector;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot::{Receiver, Sender};
 
 pub async fn https(
     server_config: ServerConfig,
     preview_token: Arc<Mutex<String>>,
     host: String,
+    shutdown_channel: (Receiver<()>, Sender<()>),
 ) -> Result<()> {
     tls::generate_cert()?;
 
@@ -102,10 +104,14 @@ pub async fn https(
     .into_stream()
     .boxed();
 
+    let (rx, tx) = shutdown_channel;
     let server = Server::builder(tls::HyperAcceptor {
         acceptor: incoming_tls_stream,
     })
-    .serve(service);
+    .serve(service)
+    .with_graceful_shutdown(async {
+        rx.await.expect("Could not receive shutdown initiation");
+    });
 
     println!("{} Listening on https://{}", emoji::EAR, listening_address);
     StdOut::info("Generated certificate is not verified, browsers will give a warning and curl will require `--insecure`");
@@ -113,6 +119,8 @@ pub async fn https(
     if let Err(e) = server.await {
         eprintln!("{}", e);
     }
+    tx.send(())
+        .expect("Could not acknowledge listener shutdown");
 
     Ok(())
 }

--- a/src/commands/dev/edge/watch.rs
+++ b/src/commands/dev/edge/watch.rs
@@ -1,3 +1,4 @@
+use std::sync::mpsc::Sender;
 use std::sync::{mpsc, Arc, Mutex};
 
 use crate::commands::dev::edge::setup;
@@ -9,12 +10,13 @@ use crate::watch::watch_and_build;
 use anyhow::Result;
 
 pub fn watch_for_changes(
-    target: Target,
+    target: &Target,
     deploy_target: &DeployTarget,
     user: &GlobalUser,
     preview_token: Arc<Mutex<String>>,
     session_token: String,
     verbose: bool,
+    refresh_session_channel: Sender<()>,
 ) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
     watch_and_build(&target, Some(sender))?;
@@ -34,7 +36,13 @@ pub fn watch_for_changes(
         //
         // this allows the server to route subsequent requests
         // to the proper script
-        *preview_token = setup::upload(&mut target, &deploy_target, &user, session_token, verbose)?;
+        let uploaded = setup::upload(&mut target, &deploy_target, &user, session_token, verbose);
+        if let Ok(token) = uploaded {
+            *preview_token = token;
+        } else {
+            refresh_session_channel.send(())?;
+            break;
+        }
     }
 
     Ok(())

--- a/src/commands/dev/edge/watch.rs
+++ b/src/commands/dev/edge/watch.rs
@@ -16,10 +16,10 @@ pub fn watch_for_changes(
     preview_token: Arc<Mutex<String>>,
     session_token: String,
     verbose: bool,
-    refresh_session_channel: Sender<()>,
+    refresh_session_channel: Sender<Option<()>>,
 ) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
-    watch_and_build(&target, Some(sender))?;
+    watch_and_build(&target, Some(sender), Some(refresh_session_channel.clone()))?;
 
     while receiver.recv().is_ok() {
         let user = user.clone();
@@ -40,7 +40,7 @@ pub fn watch_for_changes(
         if let Ok(token) = uploaded {
             *preview_token = token;
         } else {
-            refresh_session_channel.send(())?;
+            refresh_session_channel.send(Some(()))?;
             break;
         }
     }

--- a/src/commands/dev/gcs/mod.rs
+++ b/src/commands/dev/gcs/mod.rs
@@ -74,7 +74,7 @@ pub fn dev(
     // and we must block the main thread on the completion of
     // said futures
     runtime.block_on(async {
-        let devtools_listener = tokio::spawn(socket::listen(socket_url.clone()));
+        let devtools_listener = tokio::spawn(socket::listen(socket_url.clone(), None));
 
         let server = match local_protocol {
             Protocol::Https => tokio::spawn(server::https(

--- a/src/commands/dev/gcs/watch.rs
+++ b/src/commands/dev/gcs/watch.rs
@@ -16,7 +16,7 @@ pub fn watch_for_changes(
     verbose: bool,
 ) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
-    watch_and_build(&target, Some(sender))?;
+    watch_and_build(&target, Some(sender), None)?;
 
     while receiver.recv().is_ok() {
         let target = target.clone();

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -24,7 +24,10 @@ const KEEP_ALIVE_INTERVAL: u64 = 10;
 
 /// connect to a Workers runtime WebSocket emitting the Chrome Devtools Protocol
 /// parse all console messages, and print them to stdout
-pub async fn listen(socket_url: Url, refresh_session_sender: Option<Sender<()>>) -> Result<()> {
+pub async fn listen(
+    socket_url: Url,
+    refresh_session_sender: Option<Sender<Option<()>>>,
+) -> Result<()> {
     // we loop here so we can issue a reconnect when something
     // goes wrong with the websocket connection
     loop {
@@ -71,7 +74,7 @@ pub async fn listen(socket_url: Url, refresh_session_sender: Option<Sender<()>>)
 // The backoff maxes out at 60 seconds.
 async fn connect_retry(
     socket_url: &Url,
-    sender: Option<Sender<()>>,
+    sender: Option<Sender<Option<()>>>,
 ) -> WebSocketStream<MaybeTlsStream<TcpStream>> {
     let mut wait_seconds = 2;
     let maximum_wait_seconds = 60;
@@ -99,7 +102,7 @@ async fn connect_retry(
                         StdOut::info(
                             "Starting a new session to retry the connection with a new token",
                         );
-                        sender.send(()).ok();
+                        sender.send(Some(())).ok();
                     }
                 }
                 if wait_seconds > maximum_wait_seconds {

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -161,7 +161,7 @@ fn watch_for_changes(
     let sites_preview: bool = target.site.is_some();
 
     let (tx, rx) = channel();
-    watch_and_build(&target, Some(tx))?;
+    watch_and_build(&target, Some(tx), None)?;
 
     while rx.recv().is_ok() {
         if let Ok(new_id) = upload(&mut target, user, sites_preview, verbose) {

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -92,7 +92,7 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
         let mut is_first = true;
 
         loop {
-            match wait_for_changes(&watcher_rx, COOLDOWN_PERIOD) {
+            match wait_for_changes(&watcher_rx, None, COOLDOWN_PERIOD) {
                 Ok(_) => {
                     if is_first {
                         is_first = false;


### PR DESCRIPTION
This is another attempt to fix the underlying issue first addressed in #1974 (related to the issues #1738 and #1995) and is a more principled alternative to #2006 (see that PR for a description of the root cause).

I was not entirely satisfied with the somewhat hacky approach of #2006, which swapped out the session with a new one once the token expires. This PR instead restarts the whole `wrangler dev` command as soon as the main loop is notified through a channel, which makes for a cleaner separation of concerns but ends up requiring quite a few changes if all the currently running threads and async tasks are to be properly aborted.

(The issue is fixed by the first 2 commits, the latter 2 commits improve the DX by making sure that `wrangler dev` is restarted once the devtools listener receives a `4xx` response and that only a single watcher thread is active at any time.)