### PR TITLE
Implement compatibility date and flags.

### DIFF
--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -114,6 +114,8 @@ mod tests {
             build: None,
             wasm_modules: None,
             usage_model: None,
+            compatibility_date: None,
+            compatibility_flags: Vec::new(),
         };
         assert!(kv::get_namespace_id(&target_with_dup_kv_bindings, "").is_err());
     }

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -63,6 +63,8 @@ pub struct Manifest {
     pub durable_objects: Option<DurableObjects>,
     #[serde(default, with = "string_empty_as_none")]
     pub usage_model: Option<UsageModel>,
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Option<Vec<String>>,
 }
 
 impl Manifest {
@@ -352,6 +354,8 @@ impl Manifest {
             text_blobs: self.text_blobs.clone(), // Inherited
             usage_model: self.usage_model, // Top level
             wasm_modules: self.wasm_modules.clone(),
+            compatibility_date: self.compatibility_date.clone(),
+            compatibility_flags: self.compatibility_flags.clone().unwrap_or(Vec::new()),
         };
 
         let environment = self.get_environment(environment_name)?;

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -355,7 +355,7 @@ impl Manifest {
             usage_model: self.usage_model, // Top level
             wasm_modules: self.wasm_modules.clone(),
             compatibility_date: self.compatibility_date.clone(),
-            compatibility_flags: self.compatibility_flags.clone().unwrap_or(Vec::new()),
+            compatibility_flags: self.compatibility_flags.clone().unwrap_or_default(),
         };
 
         let environment = self.get_environment(environment_name)?;

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -64,7 +64,8 @@ pub struct Manifest {
     #[serde(default, with = "string_empty_as_none")]
     pub usage_model: Option<UsageModel>,
     pub compatibility_date: Option<String>,
-    pub compatibility_flags: Option<Vec<String>>,
+    #[serde(default)]
+    pub compatibility_flags: Vec<String>,
 }
 
 impl Manifest {
@@ -355,7 +356,7 @@ impl Manifest {
             usage_model: self.usage_model, // Top level
             wasm_modules: self.wasm_modules.clone(),
             compatibility_date: self.compatibility_date.clone(),
-            compatibility_flags: self.compatibility_flags.clone().unwrap_or_default(),
+            compatibility_flags: self.compatibility_flags.clone(),
         };
 
         let environment = self.get_environment(environment_name)?;

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -26,6 +26,8 @@ pub struct Target {
     pub text_blobs: Option<HashMap<String, PathBuf>>,
     pub usage_model: Option<UsageModel>,
     pub wasm_modules: Option<HashMap<String, PathBuf>>,
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Vec<String>,
 }
 
 impl Target {

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -332,6 +332,8 @@ mod tests {
             text_blobs: None,
             usage_model: None,
             wasm_modules: None,
+            compatibility_date: None,
+            compatibility_flags: Vec::new(),
         }
     }
 

--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -31,6 +31,8 @@ pub fn build(
     session_config: Option<serde_json::Value>,
 ) -> Result<Form> {
     let target_type = &target.target_type;
+    let compatibility_date = target.compatibility_date.clone();
+    let compatibility_flags = target.compatibility_flags.clone();
     let kv_namespaces = &target.kv_namespaces;
     let durable_object_classes = target
         .durable_objects
@@ -85,6 +87,8 @@ pub fn build(
 
             let assets = ServiceWorkerAssets::new(
                 script_path,
+                compatibility_date,
+                compatibility_flags,
                 wasm_modules,
                 kv_namespaces.to_vec(),
                 durable_object_classes,
@@ -105,6 +109,8 @@ pub fn build(
 
                     let assets = ServiceWorkerAssets::new(
                         script_path,
+                        compatibility_date,
+                        compatibility_flags,
                         wasm_modules,
                         kv_namespaces.to_vec(),
                         durable_object_classes,
@@ -123,6 +129,8 @@ pub fn build(
 
                     let module_config = ModuleConfig::new(main, dir, rules);
                     let assets = ModulesAssets::new(
+                        compatibility_date,
+                        compatibility_flags,
                         module_config.get_modules()?,
                         kv_namespaces.to_vec(),
                         durable_object_classes,
@@ -142,6 +150,8 @@ pub fn build(
 
                 let assets = ServiceWorkerAssets::new(
                     script_path,
+                    compatibility_date,
+                    compatibility_flags,
                     wasm_modules,
                     kv_namespaces.to_vec(),
                     durable_object_classes,
@@ -170,6 +180,8 @@ pub fn build(
 
             let assets = ServiceWorkerAssets::new(
                 script_path,
+                compatibility_date,
+                compatibility_flags,
                 wasm_modules,
                 kv_namespaces.to_vec(),
                 durable_object_classes,

--- a/src/upload/form/modules_worker.rs
+++ b/src/upload/form/modules_worker.rs
@@ -15,7 +15,9 @@ struct Metadata {
     pub bindings: Vec<Binding>,
     pub migrations: Option<ApiMigration>,
     pub usage_model: Option<UsageModel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compatibility_date: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub compatibility_flags: Vec<String>,
 }
 

--- a/src/upload/form/modules_worker.rs
+++ b/src/upload/form/modules_worker.rs
@@ -15,6 +15,8 @@ struct Metadata {
     pub bindings: Vec<Binding>,
     pub migrations: Option<ApiMigration>,
     pub usage_model: Option<UsageModel>,
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Vec<String>,
 }
 
 pub fn build_form(
@@ -53,6 +55,8 @@ fn add_metadata(mut form: Form, assets: &ModulesAssets) -> Result<Form> {
         bindings: assets.bindings(),
         migrations: assets.migration.clone(),
         usage_model: assets.usage_model,
+        compatibility_date: assets.compatibility_date.clone(),
+        compatibility_flags: assets.compatibility_flags.clone(),
     });
 
     let metadata = Part::text(metadata_json.to_string())

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -22,6 +22,8 @@ use std::collections::{HashMap, HashSet};
 pub struct ServiceWorkerAssets {
     script_name: String,
     script_path: PathBuf,
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Vec<String>,
     pub wasm_modules: Vec<WasmModule>,
     pub kv_namespaces: Vec<KvNamespace>,
     pub durable_object_classes: Vec<DurableObjectsClass>,
@@ -33,6 +35,8 @@ pub struct ServiceWorkerAssets {
 impl ServiceWorkerAssets {
     pub fn new(
         script_path: PathBuf,
+        compatibility_date: Option<String>,
+        compatibility_flags: Vec<String>,
         wasm_modules: Vec<WasmModule>,
         kv_namespaces: Vec<KvNamespace>,
         durable_object_classes: Vec<DurableObjectsClass>,
@@ -46,6 +50,8 @@ impl ServiceWorkerAssets {
         Ok(Self {
             script_name,
             script_path,
+            compatibility_date,
+            compatibility_flags,
             wasm_modules,
             kv_namespaces,
             durable_object_classes,
@@ -330,6 +336,8 @@ fn build_type_matchers(rules: Vec<ModuleRule>) -> Result<Vec<ModuleMatcher>> {
 }
 
 pub struct ModulesAssets {
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Vec<String>,
     pub manifest: ModuleManifest,
     pub kv_namespaces: Vec<KvNamespace>,
     pub durable_object_classes: Vec<DurableObjectsClass>,
@@ -340,6 +348,8 @@ pub struct ModulesAssets {
 
 impl ModulesAssets {
     pub fn new(
+        compatibility_date: Option<String>,
+        compatibility_flags: Vec<String>,
         manifest: ModuleManifest,
         kv_namespaces: Vec<KvNamespace>,
         durable_object_classes: Vec<DurableObjectsClass>,
@@ -348,6 +358,8 @@ impl ModulesAssets {
         usage_model: Option<UsageModel>,
     ) -> Result<Self> {
         Ok(Self {
+            compatibility_date,
+            compatibility_flags,
             manifest,
             kv_namespaces,
             durable_object_classes,

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -33,6 +33,7 @@ pub struct ServiceWorkerAssets {
 }
 
 impl ServiceWorkerAssets {
+    #[allow(clippy::too_many_arguments)] // TODO: refactor?
     pub fn new(
         script_path: PathBuf,
         compatibility_date: Option<String>,
@@ -347,6 +348,7 @@ pub struct ModulesAssets {
 }
 
 impl ModulesAssets {
+    #[allow(clippy::too_many_arguments)] // TODO: refactor?
     pub fn new(
         compatibility_date: Option<String>,
         compatibility_flags: Vec<String>,

--- a/src/upload/form/service_worker.rs
+++ b/src/upload/form/service_worker.rs
@@ -11,7 +11,9 @@ struct Metadata {
     pub body_part: String,
     pub bindings: Vec<Binding>,
     pub usage_model: Option<UsageModel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compatibility_date: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub compatibility_flags: Vec<String>,
 }
 

--- a/src/upload/form/service_worker.rs
+++ b/src/upload/form/service_worker.rs
@@ -11,6 +11,8 @@ struct Metadata {
     pub body_part: String,
     pub bindings: Vec<Binding>,
     pub usage_model: Option<UsageModel>,
+    pub compatibility_date: Option<String>,
+    pub compatibility_flags: Vec<String>,
 }
 
 pub fn build_form(
@@ -56,6 +58,8 @@ fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
         body_part: assets.script_name(),
         bindings: assets.bindings(),
         usage_model: assets.usage_model,
+        compatibility_date: assets.compatibility_date.clone(),
+        compatibility_flags: assets.compatibility_flags.clone(),
     });
 
     let metadata = Part::text(metadata_json.to_string())


### PR DESCRIPTION
This adds support for a new part of the Workers upload API in which the developer may specify a "compatibility date" and one or more "compatibility flags". These settings affect behavior of certain Workers Runtime APIs, especially in cases where the API was originally introduced with a bug, and the bug could not be directly fixed because some deployed workers might be depending on it.

Setting the compatibility date opts your worker into exactly the behavior as it was on that date, guaranteeing that bug fixes introduced later will not break you. If you don't set a compatibility date, the default is the date when your named worker was first created. In the future, we will recommend all workers set an explicit date to avoid confusion.

Compatibility flags can further augment behavior by opting into upcoming bug fixes that aren't on by default yet, or opting into old buggy behavior even when your compatibility date is current. Most people won't use this -- it's mainly useful for testing, and as an escape hatch.

Compatibility level is controlled by adding one or two lines to `wrangler.toml`, like:

```
compatibility_date = "2021-07-12"
compatibility_flags = [ "formdata_parser_supports_files" ]
```

This example sets the "compatibility date" to July 7, 2021. The Workers Runtime API will mostly behave as it did for new Workers created on that date. However, this example also sets the additional flag `formdata_parser_supports_files`. This flag fixes a bug in the `FormData` API: Currently, the `FormData` parser converts uploaded files to strings. With this flag set, it correctly represents them as `File` objects, as required by standards. This change couldn't just be rolled out for everyone automatically, because it is possible that some Workers in production are relying on the conversion to string today, and we wouldn't want to break them. Currently, `formdata_parser_supports_files` can only be enabled by specifying it as a flag. However, at some date in the future, we will make it the default. Workers which set `compatibility_date` to that date or later will then get the fixed behavior.

For those interested, as of this writing, two compatibility flags exist:

- `formdata_parser_supports_files`: Parsing `FormData`, e.g. with `request.formData()`, will correctly represent file uploads as `File` objects instead of strings.
- `fetch_refuses_unknown_protocols`: `fetch()` will throw an error if the URL's protocol is anything other than `http:` or `https:`. Previously, it silently replaced other protocols with `http:`.

As of this writing, since we haven't yet chosen specific dates for these flags to become default, `compatibility_date` does not yet have any effect. However, you must set a date in order to use flags.