### PR TITLE
Remove ServiceWorkerAssets::new

### DIFF
--- a/src/upload/form/mod.rs
+++ b/src/upload/form/mod.rs
@@ -85,17 +85,17 @@ pub fn build(
             wasm_modules.push(wasm_module);
             let script_path = PathBuf::from("./worker/generated/script.js");
 
-            let assets = ServiceWorkerAssets::new(
+            let assets = ServiceWorkerAssets {
                 script_path,
                 compatibility_date,
                 compatibility_flags,
                 wasm_modules,
-                kv_namespaces.to_vec(),
+                kv_namespaces: kv_namespaces.to_vec(),
                 durable_object_classes,
                 text_blobs,
                 plain_texts,
                 usage_model,
-            )?;
+            };
 
             service_worker::build_form(&assets, session_config)
         }
@@ -107,17 +107,17 @@ pub fn build(
                     let package = Package::new(&package_dir)?;
                     let script_path = package_dir.join(package.main(&package_dir)?);
 
-                    let assets = ServiceWorkerAssets::new(
+                    let assets = ServiceWorkerAssets {
                         script_path,
                         compatibility_date,
                         compatibility_flags,
                         wasm_modules,
-                        kv_namespaces.to_vec(),
+                        kv_namespaces: kv_namespaces.to_vec(),
                         durable_object_classes,
                         text_blobs,
                         plain_texts,
                         usage_model,
-                    )?;
+                    };
 
                     service_worker::build_form(&assets, session_config)
                 }
@@ -148,17 +148,17 @@ pub fn build(
                 let package = Package::new(&package_dir)?;
                 let script_path = package.main(&package_dir)?;
 
-                let assets = ServiceWorkerAssets::new(
+                let assets = ServiceWorkerAssets {
                     script_path,
                     compatibility_date,
                     compatibility_flags,
                     wasm_modules,
-                    kv_namespaces.to_vec(),
+                    kv_namespaces: kv_namespaces.to_vec(),
                     durable_object_classes,
                     text_blobs,
                     plain_texts,
                     usage_model,
-                )?;
+                };
 
                 service_worker::build_form(&assets, session_config)
             }
@@ -178,17 +178,17 @@ pub fn build(
                 wasm_modules.push(wasm_module);
             }
 
-            let assets = ServiceWorkerAssets::new(
+            let assets = ServiceWorkerAssets {
                 script_path,
                 compatibility_date,
                 compatibility_flags,
                 wasm_modules,
-                kv_namespaces.to_vec(),
+                kv_namespaces: kv_namespaces.to_vec(),
                 durable_object_classes,
                 text_blobs,
                 plain_texts,
                 usage_model,
-            )?;
+            };
 
             service_worker::build_form(&assets, session_config)
         }

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -20,8 +20,7 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
 pub struct ServiceWorkerAssets {
-    script_name: String,
-    script_path: PathBuf,
+    pub(crate) script_path: PathBuf,
     pub compatibility_date: Option<String>,
     pub compatibility_flags: Vec<String>,
     pub wasm_modules: Vec<WasmModule>,
@@ -33,35 +32,6 @@ pub struct ServiceWorkerAssets {
 }
 
 impl ServiceWorkerAssets {
-    #[allow(clippy::too_many_arguments)] // TODO: refactor?
-    pub fn new(
-        script_path: PathBuf,
-        compatibility_date: Option<String>,
-        compatibility_flags: Vec<String>,
-        wasm_modules: Vec<WasmModule>,
-        kv_namespaces: Vec<KvNamespace>,
-        durable_object_classes: Vec<DurableObjectsClass>,
-        text_blobs: Vec<TextBlob>,
-        plain_texts: Vec<PlainText>,
-        usage_model: Option<UsageModel>,
-    ) -> Result<Self> {
-        let script_name = filestem_from_path(&script_path)
-            .ok_or_else(|| anyhow!("filename should not be empty: {}", script_path.display()))?;
-
-        Ok(Self {
-            script_name,
-            script_path,
-            compatibility_date,
-            compatibility_flags,
-            wasm_modules,
-            kv_namespaces,
-            durable_object_classes,
-            text_blobs,
-            plain_texts,
-            usage_model,
-        })
-    }
-
     pub fn bindings(&self) -> Vec<Binding> {
         let mut bindings = Vec::new();
 
@@ -89,8 +59,13 @@ impl ServiceWorkerAssets {
         bindings
     }
 
-    pub fn script_name(&self) -> String {
-        self.script_name.to_string()
+    pub fn script_name(&self) -> Result<String> {
+        filestem_from_path(&self.script_path).ok_or_else(|| {
+            anyhow!(
+                "filename should not be empty: {}",
+                self.script_path.display()
+            )
+        })
     }
 
     pub fn script_path(&self) -> PathBuf {

--- a/src/upload/form/service_worker.rs
+++ b/src/upload/form/service_worker.rs
@@ -38,7 +38,7 @@ pub fn build_form(
 }
 
 fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
-    form = form.file(assets.script_name(), assets.script_path())?;
+    form = form.file(assets.script_name()?, assets.script_path())?;
 
     for wasm_module in &assets.wasm_modules {
         form = form.file(wasm_module.filename(), wasm_module.path())?;
@@ -57,7 +57,7 @@ fn add_files(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
 
 fn add_metadata(mut form: Form, assets: &ServiceWorkerAssets) -> Result<Form> {
     let metadata_json = serde_json::json!(&Metadata {
-        body_part: assets.script_name(),
+        body_part: assets.script_name()?,
         bindings: assets.bindings(),
         usage_model: assets.usage_model,
         compatibility_date: assets.compatibility_date.clone(),


### PR DESCRIPTION
It was almost exactly the same as the struct initializer, and it added a lot of
boilerplate. To avoid repeating the `filesystem_to_path` code everywhere, this
changes `script_name()` to load the name on-demand.

This builds on #2009 and should not be merged before.