### PR TITLE
Don't panic when the user isn't logged in

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -29,7 +29,7 @@ pub fn global_config(user: &GlobalUser, verify: bool) -> Result<()> {
         validate_credentials(user)?;
     }
 
-    let config_file = get_global_config_path()?;
+    let config_file = get_global_config_path();
     user.to_file(&config_file)?;
 
     // set permissions on the file

--- a/src/commands/dev/tls/certs.rs
+++ b/src/commands/dev/tls/certs.rs
@@ -16,7 +16,7 @@ use crate::settings::get_wrangler_home_dir;
 use crate::terminal::message::{Message, StdOut};
 /// Create files for cert and private key
 fn create_output_files() -> Result<Option<(PathBuf, PathBuf)>> {
-    let home = get_wrangler_home_dir()?.join("config");
+    let home = get_wrangler_home_dir().join("config");
     let cert = home.join("dev-cert.pem");
     let privkey = home.join("dev-privkey.rsa");
 

--- a/src/commands/dev/tls/mod.rs
+++ b/src/commands/dev/tls/mod.rs
@@ -19,7 +19,7 @@ use crate::settings::get_wrangler_home_dir;
 
 // Build TLS configuration
 pub(super) fn get_tls_acceptor() -> Result<TlsAcceptor> {
-    let home = get_wrangler_home_dir()?.join("config");
+    let home = get_wrangler_home_dir().join("config");
     let cert = home.join("dev-cert.pem");
     let privkey = home.join("dev-privkey.rsa");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![warn(clippy::todo)] // TODO(jyn514): remove this once clippy warns about it by default
 
 #[macro_use]
 extern crate text_io;

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -153,7 +153,7 @@ fn latest_report() -> Result<Report> {
 
 // returns the path to the location of wrangler's error report log files
 fn error_report_dir() -> Result<PathBuf> {
-    let base = settings::get_wrangler_home_dir()?;
+    let base = settings::get_wrangler_home_dir();
     let report_dir = base.join(Path::new("errors"));
     fs::create_dir_all(report_dir.clone())?;
     Ok(report_dir)

--- a/src/settings/global_config.rs
+++ b/src/settings/global_config.rs
@@ -1,12 +1,10 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
-
 pub const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 
-pub fn get_wrangler_home_dir() -> Result<PathBuf> {
-    let config_dir = if let Ok(value) = env::var("WRANGLER_HOME") {
+pub fn get_wrangler_home_dir() -> PathBuf {
+    if let Ok(value) = env::var("WRANGLER_HOME") {
         log::info!("Using $WRANGLER_HOME: {}", value);
         Path::new(&value).to_path_buf()
     } else {
@@ -14,13 +12,12 @@ pub fn get_wrangler_home_dir() -> Result<PathBuf> {
         dirs::home_dir()
             .expect("Could not find home directory")
             .join(".wrangler")
-    };
-    Ok(config_dir)
+    }
 }
 
-pub fn get_global_config_path() -> Result<PathBuf> {
-    let home_dir = get_wrangler_home_dir()?;
+pub fn get_global_config_path() -> PathBuf {
+    let home_dir = get_wrangler_home_dir();
     let global_config_file = home_dir.join("config").join(DEFAULT_CONFIG_FILE_NAME);
     log::info!("Using global config file: {}", global_config_file.display());
-    Ok(global_config_file)
+    global_config_file
 }

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -28,7 +28,7 @@ impl GlobalUser {
     pub fn new() -> Result<Self> {
         let environment = Environment::with_whitelist(ENV_VAR_WHITELIST.to_vec());
 
-        let config_path = get_global_config_path()?;
+        let config_path = get_global_config_path();
         GlobalUser::build(environment, config_path)
     }
 

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -579,22 +579,16 @@ impl LazyAccountId {
     /// Load the account ID, possibly prompting the user.
     pub(crate) fn load(&self) -> Result<&String> {
         self.0.get_or_try_init(|| {
-            if let Ok(user) = GlobalUser::new() {
-                let accounts = fetch_accounts(&user)?;
-                let account_id = match accounts.as_slice() {
-                    [] => unreachable!("auth token without account?"),
-                    [single] => single.id.clone(),
-                    _multiple => {
-                        StdOut::user_error("You have multiple accounts.");
-                        whoami::display_account_id_maybe();
-                        anyhow::bail!("field `account_id` is required")
-                    }
-                };
-
-                return Ok(account_id);
+            let user = GlobalUser::new()?;
+            match fetch_accounts(&user)?.as_slice() {
+                [] => unreachable!("auth token without account?"),
+                [single] => Ok(single.id.clone()),
+                _multiple => {
+                    StdOut::user_error("You have multiple accounts.");
+                    whoami::display_account_id_maybe();
+                    anyhow::bail!("field `account_id` is required")
+                }
             }
-
-            todo!()
         })
     }
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -73,7 +73,7 @@ fn get_installed_version() -> Result<Version> {
 }
 
 fn check_wrangler_versions() -> Result<WranglerVersion> {
-    let config_dir = get_wrangler_home_dir()?;
+    let config_dir = get_wrangler_home_dir();
     let version_file = config_dir.join("version.toml");
     let current_time = SystemTime::now();
 


### PR DESCRIPTION
Previously, `wrangler dev` would panic if `~/.wrangler/config.toml` didn't exist
(or had a syntax error).

Follow-up to #1966.