### PR TITLE
chore: update binary dep wasm-pack 

### DIFF
--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
-pub const WASM_PACK_VERSION: &str = "0.9.1";
-pub const GENERATE_VERSION: &str = "0.5.0";
+pub const WASM_PACK_VERSION: &str = "0.10.0";
+pub const GENERATE_VERSION: &str = "0.7.2";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.10.0";
-pub const GENERATE_VERSION: &str = "0.7.2";
+pub const GENERATE_VERSION: &str = "0.5.0";


### PR DESCRIPTION
Updates runtime installed binary deps `wasm-pack` and `cargo-generate`.

Manually tested these are downloaded properly and function as expected.