### PR TITLE
Warn if a PR has `todo!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![warn(clippy::todo)] // TODO(jyn514): remove this once clippy warns about it by default
 
 #[macro_use]
 extern crate text_io;


### PR DESCRIPTION
Example warning:

```
warning: `todo` should not be present in production code
   --> src/settings/toml/manifest.rs:597:13
    |
597 |             todo!()
    |             ^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:2:9
    |
2   | #![warn(clippy::todo)] // TODO(jyn514): remove this once clippy warns about it by default
    |         ^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#todo
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This would have caught the regression fixed in https://github.com/cloudflare/wrangler/pull/2012.