### PR TITLE
Implement `wrangler dev --inspect`

### DIFF
--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -13,6 +13,7 @@ pub fn dev(
     mut local_protocol: Option<Protocol>,
     mut upstream_protocol: Option<Protocol>,
     cli_params: &Cli,
+    inspect: bool,
 ) -> Result<()> {
     log::info!("Starting dev server");
     let manifest = Manifest::new(&cli_params.config)?;
@@ -44,5 +45,6 @@ pub fn dev(
         local_protocol,
         upstream_protocol,
         cli_params.verbose,
+        inspect,
     )
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -177,6 +177,10 @@ pub enum Command {
         /// but can be set to http
         #[structopt(name = "upstream-protocol")]
         upstream_protocol: Option<Protocol>,
+
+        /// Inspect the worker using Chrome DevTools
+        #[structopt(long)]
+        inspect: bool,
     },
 
     /// Publish your worker to the orange cloud

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -97,13 +97,20 @@ fn dev_once(
         verbose,
     )?;
 
-    let preview_token = Arc::new(Mutex::new(preview_token));
     let inspect = if inspect {
+        // prewarm the isolate
+        let client = crate::http::client();
+        client
+            .post(session.prewarm_url)
+            .header("cf-workers-preview-token", &preview_token)
+            .send()?
+            .error_for_status()?;
         Some(target.name.clone())
     } else {
         None
     };
 
+    let preview_token = Arc::new(Mutex::new(preview_token));
     {
         let preview_token = preview_token.clone();
         let session_token = session.preview_token.clone();

--- a/src/commands/dev/edge/mod.rs
+++ b/src/commands/dev/edge/mod.rs
@@ -22,6 +22,7 @@ use std::sync::{
 };
 use std::thread;
 
+#[allow(clippy::too_many_arguments)]
 pub fn dev(
     target: Target,
     user: GlobalUser,
@@ -30,6 +31,7 @@ pub fn dev(
     local_protocol: Protocol,
     upstream_protocol: Protocol,
     verbose: bool,
+    inspect: bool,
 ) -> Result<()> {
     let runtime = TokioRuntime::new()?;
     loop {
@@ -49,6 +51,7 @@ pub fn dev(
             local_protocol,
             upstream_protocol,
             verbose,
+            inspect,
             &runtime,
             sender,
             (rx_init_shutdown, tx_ack_shutdown),
@@ -79,6 +82,7 @@ fn dev_once(
     local_protocol: Protocol,
     upstream_protocol: Protocol,
     verbose: bool,
+    inspect: bool,
     runtime: &TokioRuntime,
     refresh_session_sender: Sender<Option<()>>,
     shutdown_channel: (oneshot::Receiver<()>, oneshot::Sender<()>),
@@ -94,6 +98,11 @@ fn dev_once(
     )?;
 
     let preview_token = Arc::new(Mutex::new(preview_token));
+    let inspect = if inspect {
+        Some(target.name.clone())
+    } else {
+        None
+    };
 
     {
         let preview_token = preview_token.clone();
@@ -115,6 +124,8 @@ fn dev_once(
 
     let devtools_listener = runtime.spawn(socket::listen(
         session.websocket_url,
+        server_config.clone(),
+        inspect,
         Some(refresh_session_sender),
     ));
     let server = match local_protocol {

--- a/src/commands/dev/gcs/mod.rs
+++ b/src/commands/dev/gcs/mod.rs
@@ -44,6 +44,18 @@ pub fn dev(
         verbose,
     )?;
 
+    // prewarm the request so `--inspect` works right away
+    // note that this doesn't make a normal GET request, since that might affect the worker state
+    if inspect.is_some() {
+        let client = reqwest::blocking::Client::builder().build()?;
+        client
+            .post("https://prewarm.cloudflareworkers.com/")
+            .header("CF-EW-Preview", &preview_id)
+            .body("") // so reqwest will set the Content-Length header
+            .send()?
+            .error_for_status()?;
+    }
+
     // the local server needs the preview ID to properly route
     // HTTP requests
     //

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 
 /// `wrangler dev` starts a server on a dev machine that routes incoming HTTP requests
 /// to a Cloudflare Workers runtime and returns HTTP responses
+#[allow(clippy::too_many_arguments)]
 pub fn dev(
     target: Target,
     deployments: DeploymentSet,
@@ -27,6 +28,7 @@ pub fn dev(
     local_protocol: Protocol,
     upstream_protocol: Protocol,
     verbose: bool,
+    inspect: bool,
 ) -> Result<()> {
     // before serving requests we must first build the Worker
     build_target(&target)?;
@@ -78,6 +80,7 @@ pub fn dev(
                 local_protocol,
                 upstream_protocol,
                 verbose,
+                inspect,
             );
         }
 
@@ -95,5 +98,5 @@ pub fn dev(
         anyhow::bail!("wrangler dev does not yet support unauthenticated sessions when using Durable Objects. Please run wrangler login or wrangler config first.")
     }
 
-    gcs::dev(target, server_config, local_protocol, verbose)
+    gcs::dev(target, server_config, local_protocol, verbose, inspect)
 }

--- a/src/commands/dev/server_config/protocol.rs
+++ b/src/commands/dev/server_config/protocol.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, str::FromStr};
 
@@ -36,5 +37,15 @@ impl FromStr for Protocol {
             "https" => Ok(Protocol::Https),
             _ => Err(anyhow!("Invalid protocol, must be http or https")),
         }
+    }
+}
+
+impl fmt::Display for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Protocol::Http => "http",
+            Protocol::Https => "https",
+        };
+        s.fmt(f)
     }
 }

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -49,21 +49,8 @@ pub async fn listen(
     // we loop here so we can issue a reconnect when something
     // goes wrong with the websocket connection
     loop {
-        // TODO: replace this with a prewarm call
-        if inspect.is_some() {
-            // Startup the edge isolate.
-            // TODO: does this need to be https in some cases?
-            // let scheme = if server_config.host.is_https() { "https" } else { "http" };
-
-            // Sleep for a bit first to give the webserver time to start up.
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            // TODO: should this be retried? It definitely doesn't need special logic to refresh the token,
-            // since anyone can access the worker's HTTP server.
-            reqwest::get(format!("http://{}", server_config.listening_address)).await?;
-        }
         let sender = refresh_session_sender.clone();
         let mut ws_stream = connect_retry(&socket_url, sender).await;
-        // let mut ws_stream = connect_retry(|| connect_async(&socket_url), sender).await.0;
 
         // console.log messages are in the Runtime domain
         // we must signal that we want to receive messages from the Runtime domain

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -1,4 +1,8 @@
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::net::SocketAddr;
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrome_devtools as protocol;
@@ -6,7 +10,14 @@ use chrome_devtools as protocol;
 use futures_util::future::TryFutureExt;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{SplitStream, StreamExt};
+use http::header::SEC_WEBSOCKET_KEY;
+use http::{HeaderValue, Request, Response, StatusCode};
+use hyper::upgrade::Upgraded;
+use hyper::{Body, Server};
+use log::{debug, error, info, trace, warn};
+use tokio::try_join;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_tungstenite::tungstenite::error::ProtocolError;
 
 use crate::terminal::colored_json_string;
 use crate::terminal::message::{Message, StdErr, StdOut};
@@ -20,21 +31,39 @@ use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream, WebSocketStr
 use anyhow::{anyhow, Result};
 use url::Url;
 
+use super::ServerConfig;
+
 const KEEP_ALIVE_INTERVAL: u64 = 10;
+const DEVTOOLS_PORT: u16 = 9230;
 
 /// connect to a Workers runtime WebSocket emitting the Chrome Devtools Protocol
 /// parse all console messages, and print them to stdout
+///
+/// `inspect` should be the name of the worker if `--inspect` is passed, or `None` otherwise.
 pub async fn listen(
     socket_url: Url,
+    server_config: ServerConfig,
+    inspect: Option<String>,
     refresh_session_sender: Option<Sender<Option<()>>>,
 ) -> Result<()> {
     // we loop here so we can issue a reconnect when something
     // goes wrong with the websocket connection
     loop {
-        let sender = refresh_session_sender.clone();
-        let ws_stream = connect_retry(&socket_url, sender).await;
+        // TODO: replace this with a prewarm call
+        if inspect.is_some() {
+            // Startup the edge isolate.
+            // TODO: does this need to be https in some cases?
+            // let scheme = if server_config.host.is_https() { "https" } else { "http" };
 
-        let (mut write, read) = ws_stream.split();
+            // Sleep for a bit first to give the webserver time to start up.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            // TODO: should this be retried? It definitely doesn't need special logic to refresh the token,
+            // since anyone can access the worker's HTTP server.
+            reqwest::get(format!("http://{}", server_config.listening_address)).await?;
+        }
+        let sender = refresh_session_sender.clone();
+        let mut ws_stream = connect_retry(&socket_url, sender).await;
+        // let mut ws_stream = connect_retry(|| connect_async(&socket_url), sender).await.0;
 
         // console.log messages are in the Runtime domain
         // we must signal that we want to receive messages from the Runtime domain
@@ -42,32 +71,255 @@ pub async fn listen(
         let enable_runtime = protocol::runtime::SendMethod::Enable(1.into());
         let enable_runtime = serde_json::to_string(&enable_runtime)?;
         let enable_runtime = tungstenite::protocol::Message::Text(enable_runtime);
-        write.send(enable_runtime).await?;
-
-        // if left unattended, the preview service will kill the socket
-        // that emits console messages
-        // send a keep alive message every so often in the background
-        let (keep_alive_tx, keep_alive_rx) = mpsc::unbounded_channel();
-
-        // every 10 seconds, send a keep alive message on the channel
-        let heartbeat = keep_alive(keep_alive_tx);
-
-        // when the keep alive channel receives a message from the
-        // heartbeat future, write it to the websocket
-        let keep_alive_to_ws = UnboundedReceiverStream::new(keep_alive_rx)
-            .map(Ok)
-            .forward(write)
-            .map_err(Into::into);
+        ws_stream.send(enable_runtime).await?;
 
         // parse all incoming messages and print them to stdout
-        let printer = print_ws_messages(read);
+        if let Some(worker_name) = &inspect {
+            StdErr::help(&format!(
+                "Open chrome://inspect, click 'Configure', and add localhost:{}",
+                DEVTOOLS_PORT
+            ));
 
-        // run the heartbeat and message printer in parallel
-        if tokio::try_join!(heartbeat, keep_alive_to_ws, printer).is_ok() {
-            break Ok(());
+            // Construct our SocketAddr to listen on...
+            let addr = SocketAddr::from(([127, 0, 0, 1], DEVTOOLS_PORT));
+
+            // And a MakeService to handle each connection...
+            use hyper::service::{make_service_fn, service_fn};
+            use rand::Rng;
+            let random_bytes = rand::thread_rng().gen();
+            let uuid = uuid::Builder::from_bytes(random_bytes)
+                .set_variant(uuid::Variant::RFC4122)
+                .set_version(uuid::Version::Random)
+                .build();
+
+            let remote_stream = Arc::new(tokio::sync::Mutex::new(ws_stream));
+            let make_service = make_service_fn(|_conn| {
+                let socket_url = socket_url.clone();
+                let remote_stream = remote_stream.clone();
+                let listening_address = server_config.listening_address.to_string();
+                let worker_name = worker_name.clone();
+                async move {
+                    Ok::<_, Infallible>(service_fn(move |req| {
+                        devtools_http_request(
+                            req,
+                            socket_url.clone(),
+                            listening_address.clone(),
+                            uuid,
+                            remote_stream.clone(),
+                            worker_name.clone(),
+                        )
+                    }))
+                }
+            });
+
+            // Then bind and serve indefinitely.
+            let server = Server::bind(&addr).serve(make_service);
+            if server.await.is_ok() {
+                error!("connection closed!!");
+                break Ok(());
+            } else {
+                info!("restarting HTTP server");
+            }
         } else {
+            let (write, read) = ws_stream.split();
+
+            // if left unattended, the preview service will kill the socket
+            // that emits console messages
+            // send a keep alive message every so often in the background
+            let (keep_alive_tx, keep_alive_rx) = mpsc::unbounded_channel();
+
+            // every 10 seconds, send a keep alive message on the channel
+            let heartbeat = keep_alive(keep_alive_tx);
+
+            // when the keep alive channel receives a message from the
+            // heartbeat future, write it to the websocket
+            let keep_alive_to_ws = UnboundedReceiverStream::new(keep_alive_rx)
+                .map(Ok)
+                .forward(write)
+                .map_err(Into::into);
+
+            // parse all incoming messages and print them to stdout
+            let printer = print_ws_messages(read);
+
+            // run the heartbeat and message printer in parallel
+            if tokio::try_join!(heartbeat, keep_alive_to_ws, printer).is_ok() {
+                break Ok(());
+            } else {
+            }
         }
     }
+}
+
+struct WebsocketError {
+    from_chrome: bool,
+    inner: tungstenite::Error,
+}
+
+impl Display for WebsocketError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let direction = if self.from_chrome {
+            "chrome -> edgeworker"
+        } else {
+            "edgeworker -> chrome"
+        };
+        write!(f, "{}: {}", direction, self.inner)
+    }
+}
+
+async fn websocket_handle_events(
+    local_stream: WebSocketStream<Upgraded>,
+    remote_stream: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+) -> std::result::Result<(), WebsocketError> {
+    info!("opened websocket stream between Chrome and edgeworker");
+    // proxy to the upstream websocket
+    let (local_write, local_read) = local_stream.split();
+    let (remote_write, remote_read) = remote_stream.split();
+    let edgeworker_to_chrome = remote_read
+        .inspect(|message| match message {
+            Ok(m) => debug!("edgeworker -> chrome: {}", m),
+            Err(e) => warn!("{}", e),
+        })
+        .forward(local_write)
+        .map_err(|e| WebsocketError {
+            inner: e,
+            from_chrome: false,
+        });
+    let chrome_to_edgeworker = local_read
+        .filter(|message| {
+            let should_forward = match message {
+                Ok(m) => {
+                    debug!("chrome -> edgeworker: {}", m);
+                    true
+                }
+                Err(e) => {
+                    warn!("{}", e);
+                    // When the user closes the inspect window, chrome will abruptly terminate the
+                    // TCP connection, causing tungstenite to mark the stream as poisoned.
+                    // However, this isn't actually a fatal error: if the user opens a new window,
+                    // Chrome will continue to send packets through the websocket.
+                    // Hide this error from the remote so it doesn't give an error when new packets come it.
+                    !matches!(e, tungstenite::Error::ConnectionClosed)
+                }
+            };
+            std::future::ready(should_forward)
+        })
+        .forward(remote_write)
+        .map_err(|e| WebsocketError {
+            inner: e,
+            from_chrome: true,
+        });
+    try_join!(edgeworker_to_chrome, chrome_to_edgeworker)?;
+    Ok(())
+}
+
+async fn start_websocket(
+    req: Request<Body>,
+    remote_stream: Arc<tokio::sync::Mutex<WebSocketStream<MaybeTlsStream<TcpStream>>>>,
+) -> Result<Response<Body>> {
+    let key = req
+        .headers()
+        .get(SEC_WEBSOCKET_KEY)
+        .expect("missing SEC_WEBSOCKET_KEY header")
+        .clone();
+
+    tokio::spawn(async move {
+        let upgraded = hyper::upgrade::on(req).await.expect("failed to upgrade");
+        let local_stream = WebSocketStream::from_raw_socket(
+            upgraded,
+            tokio_tungstenite::tungstenite::protocol::Role::Server,
+            None,
+        )
+        .await;
+        // NOTE: keeps the mutex locked until the connection is closed.
+        // This is fine because we don't support simultaneous clients anyway.
+        let mut remote_stream = remote_stream.lock().await;
+        use tungstenite::Error;
+        match websocket_handle_events(local_stream, &mut remote_stream).await {
+            Ok(()) => {}
+            Err(WebsocketError {
+                inner:
+                    Error::ConnectionClosed
+                    | Error::Protocol(ProtocolError::ResetWithoutClosingHandshake),
+                ..
+            }) => {
+                info!("websocket connection closed");
+            }
+            Err(e) => panic!("failed to run websocket server: {}", e),
+        }
+    });
+
+    use hyper::header::{CONNECTION, SEC_WEBSOCKET_ACCEPT, UPGRADE};
+
+    let mut upgrade_response = Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .body(Body::empty())
+        .unwrap();
+
+    let headers = upgrade_response.headers_mut();
+    headers.insert(UPGRADE, HeaderValue::from_static("WebSocket"));
+    headers.insert(CONNECTION, HeaderValue::from_static("Upgrade"));
+    headers.insert(SEC_WEBSOCKET_ACCEPT, key);
+
+    Ok(upgrade_response)
+}
+
+async fn devtools_http_request(
+    req: Request<Body>,
+    remote_ws: Url,
+    listening_address: String,
+    uuid: uuid::Uuid,
+    remote_stream: Arc<tokio::sync::Mutex<WebSocketStream<MaybeTlsStream<TcpStream>>>>,
+    worker_name: String,
+) -> Result<Response<Body>> {
+    let path = req.uri().path();
+    if path == "/json/version" {
+        // TODO: get actual protocol version from remote
+        let version = format!(
+            r#"{{
+            "Browser": "wrangler/v{version}", "Protocol-Version": "1.3",
+        }}"#,
+            version = env!("CARGO_PKG_VERSION")
+        );
+        return Response::builder().body(version.into()).map_err(Into::into);
+    } else if path == "/json" || path == "/json/list" {
+        let devtools_info = format!(
+            r#"
+        [ {{
+            "description": "wrangler dev --inspect instance",
+            "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost:{port}{path}",
+            "devtoolsFrontendUrlCompat": "devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=localhost:{port}{path}",
+            "id": "{uuid}",
+            "type": "node",
+            "title": "wrangler[{worker}]",
+            "url": "http://{local_address}",
+            "faviconUrl": "https://workers.cloudflare.com/resources/logo/logo.svg",
+            "webSocketDebuggerUrl": "ws://localhost:{port}{path}"
+          }} ]
+        "#,
+            uuid = uuid,
+            worker = worker_name,
+            local_address = listening_address,
+            port = DEVTOOLS_PORT,
+            path = remote_ws.path()
+        );
+
+        trace!(
+            "sending json description for {} back:{}",
+            remote_ws.as_str(),
+            devtools_info
+        );
+        return Response::builder()
+            .header("Content-Type", "application/json")
+            .body(devtools_info.into())
+            .map_err(Into::into);
+    } else if path == remote_ws.path() {
+        return start_websocket(req, remote_stream).await;
+    }
+    warn!("inspect: unknown request URL {}: {:?}", req.uri(), req);
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body("".into())
+        .map_err(Into::into)
 }
 
 // Endlessly retry connecting to the chrome devtools instance with exponential backoff.
@@ -129,10 +381,10 @@ async fn print_ws_messages(
 ) -> Result<()> {
     while let Some(message) = read.next().await {
         let message = message?;
-        let message_text = message.into_text().unwrap();
-        log::info!("{}", &message_text);
+        let message_text = message.to_text().unwrap();
+        log::info!("{}", message_text);
 
-        let parsed_message: Result<protocol::Runtime> = serde_json::from_str(&message_text)
+        let parsed_message: Result<protocol::Runtime> = serde_json::from_str(message_text)
             .map_err(|e| anyhow!("Failed to parse event:\n{}", e));
 
         match parsed_message {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ fn run() -> Result<()> {
             port,
             local_protocol,
             upstream_protocol,
+            inspect,
         } => exec::dev(
             host,
             ip,
@@ -93,6 +94,7 @@ fn run() -> Result<()> {
             local_protocol,
             upstream_protocol,
             &cli_params,
+            inspect,
         ),
         Command::Whoami => exec::whoami(),
         Command::Publish {


### PR DESCRIPTION
Helps with #946.

## How do I use this?

1. `wrangler dev --inspect`, which should have output similar to this:
```
💁  watching "./"
👂  Listening on http://127.0.0.1:8787
[2021-07-28 13:38:20] GET worker.jnelson.workers.dev/ HTTP/1.1 200 OK
🕵️  Open chrome://inspect, click 'Configure', and add localhost:9230
```
2. Follow the instructions about chrome://inspect. You should see a screen like this: ![image](https://user-images.githubusercontent.com/23638587/127370321-c9d9e9f2-b184-4aab-99d7-09c2af222182.png)
3. Click 'inspect', which should bring up a devtools popup:
![image](https://user-images.githubusercontent.com/23638587/127370409-ff2e00c8-5ab9-4870-9e75-849d91ee39f5.png)

## What features are implemented?

- Sources tab
- Profiler tab

## What features are not implemented?

- Memory tab. This loads fine, but doesn't report accurate information. This is likely an issue that needs to be fixed upstream in the remote Worker.
- Breakpoints. These need to be implemented upstream in the remote Worker.
- Console tab. I'm not sure why this isn't working.
- 'Trace' button on chrome://inspect. Hitting this will cause Chrome to send a GET request without a path, to which wrangler returns a 400 Bad Request. I suspect there's something wrong with the JSON endpoint that wouldn't be too hard to fix.
- Closing and re-opening the devtools window only sporadically works; you sometimes need to restart wrangler to fix it. This happens because wrangler currently uses a single persistent websocket connection to the remote. I tried changing it to open a new websocket each time Chrome connects, but that fails with 502 errors on the later connections, and this at least sometimes works.
- Making changes to your code will live-update the preview, but will not live-update the websocket. This can be confusing, since the code you're debugging is no longer running on cloudflareworkers.com. I have no idea how to make this work.