### PR TITLE
Update Rust toolchain to 1.54

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.53.0"
+channel = "1.54"
 components = ["rustfmt", "clippy"]

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -20,7 +20,7 @@ pub(super) fn upload(
     session_token: String,
     verbose: bool,
 ) -> Result<String> {
-    let client = crate::http::legacy_auth_client(&user);
+    let client = crate::http::legacy_auth_client(user);
 
     let (to_delete, asset_manifest, site_namespace_id) = if let Some(site_config) =
         target.site.clone()
@@ -96,7 +96,7 @@ impl Session {
             _ => unreachable!(),
         };
 
-        let client = crate::http::legacy_auth_client(&user);
+        let client = crate::http::legacy_auth_client(user);
         let response = client.get(exchange_url).send()?.error_for_status()?;
         let text = &response.text()?;
         let response: InspectorV4ApiResponse = serde_json::from_str(text)?;
@@ -153,7 +153,7 @@ fn get_upload_address(target: &mut Target) -> Result<String> {
 }
 
 fn get_exchange_url(deploy_target: &DeployTarget, user: &GlobalUser) -> Result<Url> {
-    let client = crate::http::legacy_auth_client(&user);
+    let client = crate::http::legacy_auth_client(user);
     let address = get_session_address(deploy_target);
     let url = Url::parse(&address)?;
     let response = client.get(url).send()?.error_for_status()?;

--- a/src/commands/dev/edge/watch.rs
+++ b/src/commands/dev/edge/watch.rs
@@ -19,7 +19,7 @@ pub fn watch_for_changes(
     refresh_session_channel: Sender<Option<()>>,
 ) -> Result<()> {
     let (sender, receiver) = mpsc::channel();
-    watch_and_build(&target, Some(sender), Some(refresh_session_channel.clone()))?;
+    watch_and_build(target, Some(sender), Some(refresh_session_channel.clone()))?;
 
     while receiver.recv().is_ok() {
         let user = user.clone();

--- a/src/commands/dev/server_config/host.rs
+++ b/src/commands/dev/server_config/host.rs
@@ -12,7 +12,7 @@ pub struct Host {
 impl Host {
     pub fn new(host: &str, default: bool) -> Result<Self> {
         // try to create a url from host
-        let url = match Url::parse(&host) {
+        let url = match Url::parse(host) {
             Ok(host) => Ok(host),
             // if it doesn't work, it might be because there was no scheme
             // default to https

--- a/src/commands/dev/tls/certs.rs
+++ b/src/commands/dev/tls/certs.rs
@@ -80,7 +80,7 @@ fn create_ca() -> Result<(X509, PKey<Private>)> {
 
 fn create_req(privkey: &PKey<Private>) -> Result<X509Req> {
     let mut req_builder = X509ReqBuilder::new()?;
-    req_builder.set_pubkey(&privkey)?;
+    req_builder.set_pubkey(privkey)?;
 
     let mut x509_name = X509NameBuilder::new()?;
     x509_name.append_entry_by_text("C", "US")?;
@@ -90,7 +90,7 @@ fn create_req(privkey: &PKey<Private>) -> Result<X509Req> {
     let x509_name = x509_name.build();
     req_builder.set_subject_name(&x509_name)?;
 
-    req_builder.sign(&privkey, MessageDigest::sha256())?;
+    req_builder.sign(privkey, MessageDigest::sha256())?;
     let req = req_builder.build();
     Ok(req)
 }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -61,11 +61,11 @@ pub fn run_generate(name: &str, template: &str) -> Result<()> {
 fn generate_name(name: &str) -> Result<String> {
     let mut num = 1;
     let entry_names = read_current_dir()?;
-    let mut new_name = construct_name(&name, num);
+    let mut new_name = construct_name(name, num);
 
     while entry_names.contains(&OsString::from(&new_name)) {
         num += 1;
-        new_name = construct_name(&name, num);
+        new_name = construct_name(name, num);
     }
     Ok(new_name)
 }

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -42,7 +42,7 @@ pub fn run(target: &Target, user: &GlobalUser, namespace_id: &str, filename: &Pa
         None
     };
 
-    put(target, &user, namespace_id, pairs, &progress_bar)?;
+    put(target, user, namespace_id, pairs, &progress_bar)?;
 
     if let Some(pb) = &progress_bar {
         pb.finish_with_message(&format!("uploaded {} key value pairs", len));

--- a/src/commands/kv/key/get.rs
+++ b/src/commands/kv/key/get.rs
@@ -21,7 +21,7 @@ pub fn get(target: &Target, user: &GlobalUser, id: &str, key: &str) -> Result<()
         kv::url_encode_key(key)
     );
 
-    let client = http::legacy_auth_client(&user);
+    let client = http::legacy_auth_client(user);
 
     let res = client.get(&api_endpoint).send()?;
 

--- a/src/commands/kv/key/list.rs
+++ b/src/commands/kv/key/list.rs
@@ -17,7 +17,7 @@ pub fn list(
     namespace_id: &str,
     prefix: Option<&str>,
 ) -> Result<()> {
-    let client = http::cf_v4_client(&user)?;
+    let client = http::cf_v4_client(user)?;
     let key_list = KeyList::new(target, client, namespace_id, prefix)?;
 
     print!("["); // Open json list bracket

--- a/src/commands/kv/mod.rs
+++ b/src/commands/kv/mod.rs
@@ -57,7 +57,7 @@ fn check_duplicate_namespaces(target: &Target) -> bool {
 
 // Get namespace id for a given binding name.
 pub fn get_namespace_id(target: &Target, binding: &str) -> Result<String> {
-    if check_duplicate_namespaces(&target) {
+    if check_duplicate_namespaces(target) {
         anyhow::bail!(
             "Namespace binding \"{}\" is duplicated in \"{}\"",
             binding,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,7 +46,7 @@ pub fn run(mut command: Command, command_name: &str) -> Result<()> {
 // Ensures that Worker name is valid.
 pub fn validate_worker_name(name: &str) -> Result<()> {
     let re = Regex::new(r"^[a-z0-9_][a-z0-9-_]*$").unwrap();
-    if !re.is_match(&name) {
+    if !re.is_match(name) {
         anyhow::bail!("Worker name \"{}\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.", name)
     }
     Ok(())

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -32,7 +32,7 @@ pub fn publish(
 ) -> Result<()> {
     validate_target_required_fields_present(target)?;
 
-    let run_deploy = |target: &Target| match deploy::deploy(&user, &deployments) {
+    let run_deploy = |target: &Target| match deploy::deploy(user, &deployments) {
         Ok(results) => {
             build_output_message(results, target.name.clone(), out);
             Ok(())
@@ -41,7 +41,7 @@ pub fn publish(
     };
 
     // Build the script before uploading and log build result
-    let build_result = build_target(&target);
+    let build_result = build_target(target);
     match build_result {
         Ok(msg) => {
             StdErr::success(&msg);
@@ -62,7 +62,7 @@ pub fn publish(
         let site_namespace = sites::add_namespace(user, target, false)?;
 
         let (to_upload, to_delete, asset_manifest) =
-            sites::sync(target, user, &site_namespace.id, &path)?;
+            sites::sync(target, user, &site_namespace.id, path)?;
 
         // First, upload all existing files in bucket directory
         StdErr::working("Uploading site files");
@@ -90,7 +90,7 @@ pub fn publish(
         let upload_client = http::featured_legacy_auth_client(user, Feature::Sites);
 
         // Next, upload and deploy the worker with the updated asset_manifest
-        upload::script(&upload_client, &target, Some(asset_manifest))?;
+        upload::script(&upload_client, target, Some(asset_manifest))?;
 
         run_deploy(target)?;
 
@@ -123,7 +123,7 @@ pub fn publish(
     } else {
         let upload_client = http::legacy_auth_client(user);
 
-        upload::script(&upload_client, &target, None)?;
+        upload::script(&upload_client, target, None)?;
         run_deploy(target)?;
     }
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -26,7 +26,7 @@ pub fn delete(zone_identifier: &str, user: &GlobalUser, route_id: &str) -> Resul
     let client = http::cf_v4_client(user)?;
 
     let result = client.request(&DeleteRoute {
-        zone_identifier: &zone_identifier,
+        zone_identifier,
         identifier: route_id,
     });
 

--- a/src/commands/secret.rs
+++ b/src/commands/secret.rs
@@ -129,7 +129,7 @@ pub fn delete_secret(name: &str, user: &GlobalUser, target: &Target) -> Result<(
     let response = client.request(&DeleteSecret {
         account_identifier: target.account_id.load()?,
         script_name: &target.name,
-        secret_name: &name,
+        secret_name: name,
     });
 
     match response {

--- a/src/commands/subdomain.rs
+++ b/src/commands/subdomain.rs
@@ -159,7 +159,7 @@ pub fn set_subdomain(name: &str, user: &GlobalUser, target: &Target) -> Result<(
         }
     }
 
-    register_subdomain(&name, &user, &target)
+    register_subdomain(name, user, target)
 }
 
 pub fn get_subdomain(user: &GlobalUser, target: &Target) -> Result<()> {

--- a/src/deploy/zoned.rs
+++ b/src/deploy/zoned.rs
@@ -56,7 +56,7 @@ impl ZonedTarget {
     pub fn deploy(&self, user: &GlobalUser) -> Result<Vec<String>> {
         log::info!("publishing to zone {}", self.zone_id);
 
-        let published_routes = publish_routes(&user, self)?;
+        let published_routes = publish_routes(user, self)?;
 
         let display_results: Vec<String> = published_routes.iter().map(|r| r.to_string()).collect();
 
@@ -180,7 +180,7 @@ fn deploy_route(
     }
 
     // if none of the existing routes match this one, we should create a new route
-    match create(user, zone_id, &route) {
+    match create(user, zone_id, route) {
         // we want to show the new route along with its id
         Ok(created) => RouteUploadResult::New(created),
         // if there is an error, we want to know which route triggered it

--- a/src/http/legacy.rs
+++ b/src/http/legacy.rs
@@ -49,8 +49,8 @@ fn add_auth_headers(headers: &mut HeaderMap, user: &GlobalUser) {
             );
         }
         GlobalUser::GlobalKeyAuth { email, api_key } => {
-            headers.insert("X-Auth-Email", HeaderValue::from_str(&email).unwrap());
-            headers.insert("X-Auth-Key", HeaderValue::from_str(&api_key).unwrap());
+            headers.insert("X-Auth-Email", HeaderValue::from_str(email).unwrap());
+            headers.insert("X-Auth-Key", HeaderValue::from_str(api_key).unwrap());
         }
     }
 }

--- a/src/login/mod.rs
+++ b/src/login/mod.rs
@@ -22,7 +22,7 @@ pub fn run() -> Result<()> {
         .lines()
         .filter(|line| !line.starts_with("---"))
         .fold(String::new(), |mut data, line| {
-            data.push_str(&line);
+            data.push_str(line);
             data
         });
     let pubkey_encoded = percent_encode(pubkey_filtered.as_bytes(), NON_ALPHANUMERIC).to_string();

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -114,8 +114,8 @@ fn client_request(payload: &RequestPayload, script_id: &str, sites_preview: bool
     let cookie = payload.cookie(script_id);
 
     let worker_res = match method {
-        HttpMethod::Get => get(&url, &cookie, &client).unwrap(),
-        HttpMethod::Post => post(&url, &cookie, &body, &client).unwrap(),
+        HttpMethod::Get => get(url, &cookie, &client).unwrap(),
+        HttpMethod::Post => post(url, &cookie, body, &client).unwrap(),
     };
 
     let msg = if sites_preview {

--- a/src/preview/upload.rs
+++ b/src/preview/upload.rs
@@ -54,10 +54,10 @@ pub fn upload(
         Some(user) => {
             log::info!("GlobalUser set, running with authentication");
 
-            let missing_fields = validate(&target);
+            let missing_fields = validate(target);
 
             if missing_fields.is_empty() {
-                let client = http::legacy_auth_client(&user);
+                let client = http::legacy_auth_client(user);
 
                 if let Some(site_config) = target.site.clone() {
                     let site_namespace = add_namespace(user, target, true)?;
@@ -73,7 +73,7 @@ pub fn upload(
 
                     bulk::put(target, user, &site_namespace.id, to_upload, &None)?;
 
-                    let preview = authenticated_upload(&client, &target, Some(asset_manifest))?;
+                    let preview = authenticated_upload(&client, target, Some(asset_manifest))?;
                     if !to_delete.is_empty() {
                         if verbose {
                             StdOut::info("Deleting stale files...");
@@ -84,7 +84,7 @@ pub fn upload(
 
                     preview
                 } else {
-                    authenticated_upload(&client, &target, None)?
+                    authenticated_upload(&client, target, None)?
                 }
             } else {
                 StdOut::warn(&format!(
@@ -96,7 +96,7 @@ pub fn upload(
                     anyhow::bail!(SITES_UNAUTH_PREVIEW_ERR)
                 }
 
-                unauthenticated_upload(&target)?
+                unauthenticated_upload(target)?
             }
         }
         None => {
@@ -113,7 +113,7 @@ pub fn upload(
                 anyhow::bail!(SITES_UNAUTH_PREVIEW_ERR)
             }
 
-            unauthenticated_upload(&target)?
+            unauthenticated_upload(target)?
         }
     };
 

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -704,7 +704,7 @@ mod tests {
             toml_path,
             None,
         )?;
-        assert_eq!(toml.name.to_string(), "test".to_string());
+        assert_eq!(toml.name, "test".to_string());
         assert_eq!(toml.target_type.to_string(), "javascript".to_string());
         fs::remove_file(toml_path.with_file_name("wrangler.toml"))?;
 

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -36,7 +36,7 @@ pub fn add_namespace(user: &GlobalUser, target: &mut Target, preview: bool) -> R
         format!("__{}-{}", target.name, "workers_sites_assets")
     };
 
-    let site_namespace = match upsert(target, &user, title)? {
+    let site_namespace = match upsert(target, user, title)? {
         UpsertedNamespace::Created(namespace) => {
             let msg = format!("Created namespace for Workers Site \"{}\"", namespace.title);
             StdErr::working(&msg);
@@ -85,7 +85,7 @@ pub fn directory_keys_values(
                     spinner.set_message(&format!("{}", path.display()));
 
                     file_list.push(path.to_str().unwrap().to_string());
-                    validate_file_size(&path)?;
+                    validate_file_size(path)?;
 
                     let value = std::fs::read(path)?;
 
@@ -192,7 +192,7 @@ fn build_ignore(target: &Target, directory: &Path) -> Result<Override> {
         if let Some(included) = &site.include {
             required_ignore(&mut required_override)?;
             for i in included {
-                required_override.add(&i)?;
+                required_override.add(i)?;
                 log::info!("Including {}", i);
             }
         } else {
@@ -381,7 +381,7 @@ mod tests {
             // partial hash digest of the file in the "key". call generate_path_and_key to obtain
             // for later comparison.
             let (_, key_with_hash) =
-                generate_path_and_key(&Path::new(path), &tmpdir, Some("".into())).unwrap();
+                generate_path_and_key(Path::new(path), &tmpdir, Some("".into())).unwrap();
             exclude.insert(key_with_hash);
         }
 

--- a/src/sites/sync.rs
+++ b/src/sites/sync.rs
@@ -26,7 +26,7 @@ pub fn sync(
     // Turn it into a HashSet. This will be used by upload() to figure out which
     // files to exclude from upload (because their current version already exists in
     // the Workers KV remote).
-    let client = http::cf_v4_client(&user)?;
+    let client = http::cf_v4_client(user)?;
     let remote_keys_iter = KeyList::new(target, client, namespace_id, None)?;
     let mut remote_keys: HashSet<String> = HashSet::new();
     for remote_key in remote_keys_iter {

--- a/src/tail/session.rs
+++ b/src/tail/session.rs
@@ -47,12 +47,12 @@ impl Session {
         // activity but since we limit the number of tails allowed on a single script we should at
         // least try to delete them as we go.
         if let Some(tail_id) = &self.tail_id {
-            let client = http::cf_v4_api_client_async(&user, HttpApiClientConfig::default())?;
+            let client = http::cf_v4_api_client_async(user, HttpApiClientConfig::default())?;
             client
                 .request(&DeleteTail {
                     account_identifier: target.account_id.load()?,
                     script_name: &target.name,
-                    tail_id: &tail_id,
+                    tail_id,
                 })
                 .await?;
         }
@@ -103,7 +103,7 @@ impl Session {
 
                     loop {
                         delay.await;
-                        let heartbeat_result = send_heartbeat(&target, &client, &tail_id).await;
+                        let heartbeat_result = send_heartbeat(target, &client, &tail_id).await;
                         if heartbeat_result.is_err() {
                             return heartbeat_result;
                         }

--- a/src/terminal/json.rs
+++ b/src/terminal/json.rs
@@ -15,5 +15,5 @@ pub fn colored_json_string(value: &serde_json::Value) -> Result<String, serde_js
         },
     );
 
-    formatter.to_colored_json_auto(&value)
+    formatter.to_colored_json_auto(value)
 }

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -281,7 +281,7 @@ fn build_type_matchers(rules: Vec<ModuleRule>) -> Result<Vec<ModuleMatcher>> {
             let mut builder = GlobSetBuilder::new();
 
             for glob in &r.globs {
-                let glob = new_glob(&glob)?;
+                let glob = new_glob(glob)?;
                 builder.add(glob);
             }
 

--- a/src/wranglerjs/output.rs
+++ b/src/wranglerjs/output.rs
@@ -29,7 +29,7 @@ impl WranglerjsOutput {
         let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
 
         // approximation of how projects are gzipped
-        e.write_all(&self.script.as_bytes())
+        e.write_all(self.script.as_bytes())
             .expect("could not write script buffer");
 
         if let Some(wasm) = &self.wasm {


### PR DESCRIPTION
This commit can be replicated by updating `rust-toolchain`, then running
`cargo clippy --fix --allow-dirty`.