### PR TITLE
Allow running `wrangler dev` without an account_id

### DIFF
--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -137,8 +137,8 @@ fn get_session_config(target: &DeployTarget) -> serde_json::Value {
     }
 }
 
-fn get_session_address(target: &DeployTarget) -> String {
-    match target {
+fn get_session_address(target: &DeployTarget) -> Result<String> {
+    let addr = match target {
         DeployTarget::Zoned(config) => format!(
             "https://api.cloudflare.com/client/v4/zones/{}/workers/edge-preview",
             config.zone_id
@@ -146,10 +146,11 @@ fn get_session_address(target: &DeployTarget) -> String {
         // TODO: zoneless is probably wrong
         DeployTarget::Zoneless(config) => format!(
             "https://api.cloudflare.com/client/v4/accounts/{}/workers/subdomain/edge-preview",
-            config.account_id
+            config.account_id.load()?,
         ),
         _ => unreachable!(),
-    }
+    };
+    Ok(addr)
 }
 
 fn get_upload_address(target: &mut Target) -> Result<String> {
@@ -162,7 +163,7 @@ fn get_upload_address(target: &mut Target) -> Result<String> {
 
 fn get_exchange_url(deploy_target: &DeployTarget, user: &GlobalUser) -> Result<Url> {
     let client = crate::http::legacy_auth_client(user);
-    let address = get_session_address(deploy_target);
+    let address = get_session_address(deploy_target)?;
     let url = Url::parse(&address)?;
     let response = client.get(url).send()?.error_for_status()?;
     let text = &response.text()?;

--- a/src/deploy/zoneless.rs
+++ b/src/deploy/zoneless.rs
@@ -1,36 +1,37 @@
 use crate::commands::subdomain::Subdomain;
 use crate::http;
 use crate::settings::global_user::GlobalUser;
+use crate::settings::toml::target::LazyAccountId;
 use crate::settings::toml::RouteConfig;
 
 use anyhow::Result;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ZonelessTarget {
-    pub account_id: String,
+    pub account_id: LazyAccountId,
     pub script_name: String,
 }
 
 impl ZonelessTarget {
     pub fn build(script_name: &str, route_config: &RouteConfig) -> Result<Self> {
-        let account_id = route_config.account_id.load()?;
         Ok(Self {
             script_name: script_name.to_string(),
-            account_id: account_id.to_string(),
+            account_id: route_config.account_id.clone(),
         })
     }
 
     pub fn deploy(&self, user: &GlobalUser) -> Result<String> {
         log::info!("publishing to workers.dev subdomain");
         log::info!("checking that subdomain is registered");
-        let subdomain = match Subdomain::get(&self.account_id, user)? {
+        let subdomain = match Subdomain::get(self.account_id.load()?, user)? {
             Some(subdomain) => subdomain,
             None => anyhow::bail!("Before publishing to workers.dev, you must register a subdomain. Please choose a name for your subdomain and run `wrangler subdomain <name>`.")
         };
 
         let sd_worker_addr = format!(
             "https://api.cloudflare.com/client/v4/accounts/{}/workers/scripts/{}/subdomain",
-            self.account_id, self.script_name,
+            self.account_id.load()?,
+            self.script_name,
         );
 
         let client = http::legacy_auth_client(user);

--- a/src/settings/toml/mod.rs
+++ b/src/settings/toml/mod.rs
@@ -7,7 +7,7 @@ mod manifest;
 pub mod migrations;
 mod route;
 mod site;
-mod target;
+pub(crate) mod target;
 mod target_type;
 mod triggers;
 

--- a/src/settings/toml/target.rs
+++ b/src/settings/toml/target.rs
@@ -1,6 +1,6 @@
 use super::durable_objects::DurableObjects;
 use super::kv_namespace::KvNamespace;
-use super::manifest::LazyAccountId;
+pub(crate) use super::manifest::LazyAccountId;
 use super::site::Site;
 use super::target_type::TargetType;
 use super::UsageModel;


### PR DESCRIPTION
Previously, running it with no account_id and no config in ~/.wrangler would give an error:

```
Error: config path does not exist /home/jnelson/.wrangler/config/default.toml. Try running `wrangler login` or `wrangler config`
```

This is not technically a regression from loading account_id lazily, because in wrangler 1.17 it would just error earlier that account_id was required:
```
🕵️  You can find your account_id in the right sidebar of your account's Workers page
Error: field `account_id` is required to deploy to workers.dev
```

However, it seems odd that you'd have to have an account to run an unauthenticated preview.
This changes wrangler to only require an account_id or config file if you're actually deploying your site.

Fixes https://github.com/cloudflare/wrangler/issues/1525