### PR TITLE
Small typo in error message

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -289,7 +289,7 @@ impl Manifest {
         };
 
         if durable_objects.is_none() && deployments.is_empty() {
-            anyhow::bail!("Please specify your deployment routes or `wrangler_dev = true` inside of your configuration file. For more information, see: https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys")
+            anyhow::bail!("Please specify your deployment routes or `workers_dev = true` inside of your configuration file. For more information, see: https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys")
         }
 
         Ok(deployments)


### PR DESCRIPTION
I came across this error message:

> Please specify your deployment routes or **wrangler_dev = true** inside of your configuration file

But I _think_ `wrangler_dev` should be `workers_dev`