### PR TITLE
Log bad request error details during dev

### DIFF
--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -53,7 +53,7 @@ pub(super) fn upload(
         .multipart(script_upload_form)
         .send()?;
 
-    if &response.status() == &StatusCode::BAD_REQUEST {
+    if response.status() == StatusCode::BAD_REQUEST {
         return Err(BadRequestError(crate::format_api_errors(response.text()?)).into());
     }
     let response = response.error_for_status()?;

--- a/src/commands/dev/edge/setup.rs
+++ b/src/commands/dev/edge/setup.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 use std::path::Path;
 
 use crate::deploy::DeployTarget;
@@ -9,7 +11,7 @@ use crate::terminal::message::{Message, StdOut};
 use crate::upload;
 
 use anyhow::{anyhow, Result};
-use reqwest::Url;
+use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -49,8 +51,12 @@ pub(super) fn upload(
         .post(&address)
         .header("cf-preview-upload-config-token", session_token)
         .multipart(script_upload_form)
-        .send()?
-        .error_for_status()?;
+        .send()?;
+
+    if &response.status() == &StatusCode::BAD_REQUEST {
+        return Err(BadRequestError(crate::format_api_errors(response.text()?)).into());
+    }
+    let response = response.error_for_status()?;
 
     if !to_delete.is_empty() {
         if verbose {
@@ -188,4 +194,15 @@ struct Preview {
 #[derive(Debug, Serialize, Deserialize)]
 struct PreviewV4ApiResponse {
     pub result: Preview,
+}
+
+#[derive(Debug)]
+pub(crate) struct BadRequestError(pub(crate) String);
+
+impl Error for BadRequestError {}
+
+impl fmt::Display for BadRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }


### PR DESCRIPTION
Currently, when the edge preview service returns a 400 Bad Request error during a `wrangler dev` session because the user's worker is invalid, all you see is `Error: HTTP status client error (400 Bad Request) for url`. When calling `wrangler publish`, you are given the actual reason, for example:
```shell
Error: Something went wrong with the request to Cloudflare...
No event handlers were registered. This script does nothing.
 [API code: 10021]
```
These errors also terminate the process, meaning you have to restart `wrangler dev` each time.

This PR replaces the error text for 400 responses with the actual reason. If an error occurs when watching files, it is logged, but the watcher remains active, so the user is able to fix the issue and wrangler can try upload again:
```js
addEventListener("bad", (event) => {
  event.respondWith(new Response());
});
```
```shell
$ wrangler dev      
Error: Something went wrong with the request to Cloudflare...
No event handlers were registered. This script does nothing.
 [API code: 10021]

# changing "bad" to "fetch"
$ wrangler dev
💁  watching "./"
👂  Listening on http://127.0.0.1:8787
🌀  Detected changes... # changing "fetch" to "bad"
⚠️ Something went wrong with the request to Cloudflare...
No event handlers were registered. This script does nothing.
 [API code: 10021]
🌀  Detected changes... # changing "bad" to "fetch"
```