### PR TITLE
Downgrade panic when no account IDs match a token to an error

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -586,7 +586,11 @@ impl LazyAccountId {
         self.0.get_or_try_init(|| {
             let user = GlobalUser::new()?;
             match fetch_accounts(&user)?.as_slice() {
-                [] => unreachable!("auth token without account?"),
+                [] => {
+                    StdOut::user_error("Your authentication token does not match any account ID.");
+                    whoami::display_account_id_maybe();
+                    anyhow::bail!("field `account_id` is required")
+                }
                 [single] => Ok(single.id.clone()),
                 _multiple => {
                     StdOut::user_error("You have multiple accounts.");


### PR DESCRIPTION
I'm still not sure exactly how this could happen, and I feel there's a bug here somewhere ...  but
people are hitting this in practice (enough that someone ran `wrangler report`) and this will help
the user experience in the meantime.

r? @nilslice