### PR TITLE
fix: override rust type to javascript

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -143,7 +143,11 @@ impl Manifest {
             config_template_doc["workers_dev"] = toml_edit::value(default_workers_dev);
         }
         if let Some(target_type) = &target_type {
-            config_template_doc["type"] = toml_edit::value(target_type.to_string());
+            if target_type.to_string() == "rust" {
+                config_template_doc["type"] = toml_edit::value(TargetType::JavaScript.to_string());
+            } else {
+                config_template_doc["type"] = toml_edit::value(target_type.to_string());
+            }
         }
         if let Some(site) = site {
             if config_template.site.is_none() {


### PR DESCRIPTION
the `rust` type seems to only have been added as a way to automatically trigger wasm-pack, but it's much better to put that in a custom `[build]` step instead. eventually, we really should phase out the `rust` type from `wrangler` altogether, but this at minimum makes the new rust template work. 