### PR TITLE
Allow showing a backtrace for errors returned from main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,9 @@ name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/cloudflare/wrangler"
 categories = ["wasm", "development-tools", "command-line-utilities", "web-programming"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 atty = "0.2.14"
 backtrace = { version = "0.3.58" }
 base64 = "0.13.0"


### PR DESCRIPTION
Example usage:

```
$ RUST_BACKTRACE=1 wrangler dev --inspect
Error: missing field `prewarm` at line 1 column 627

Stack backtrace:
   0: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/result.rs:1675:27
   1: wrangler::commands::dev::edge::setup::Session::new
             at /home/jnelson/src/wrangler/src/commands/dev/edge/setup.rs:103:48
   2: wrangler::commands::dev::edge::dev_once
             at /home/jnelson/src/wrangler/src/commands/dev/edge/mod.rs:90:19
   3: wrangler::commands::dev::edge::dev
             at /home/jnelson/src/wrangler/src/commands/dev/edge/mod.rs:46:21
   4: wrangler::commands::dev::dev
             at /home/jnelson/src/wrangler/src/commands/dev/mod.rs:75:20
   5: wrangler::cli::dev::dev
             at /home/jnelson/src/wrangler/src/cli/dev.rs:40:5
   6: wrangler::run
             at /home/jnelson/src/wrangler/src/main.rs:107:14
   7: wrangler::main_handling_errors
             at /home/jnelson/src/wrangler/src/main.rs:55:5
   8: wrangler::main
             at /home/jnelson/src/wrangler/src/main.rs:21:23
   9: core::ops::function::FnOnce::call_once
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/ops/function.rs:227:5
  10: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:125:18
  11: std::rt::lang_start::{{closure}}
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/rt.rs:49:18
  12: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/ops/function.rs:259:13
      std::panicking::try::do_call
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:401:40
      std::panicking::try
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:365:19
      std::panic::catch_unwind
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panic.rs:434:14
      std::rt::lang_start_internal
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/rt.rs:34:21
  13: std::rt::lang_start
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/rt.rs:48:5
  14: main
  15: __libc_start_main
  16: _start

```