### PR TITLE
Improve `wrangler dev` error message for invalid tokens.

### DIFF
--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -125,7 +125,7 @@ pub(crate) fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>> {
                         StdOut::info("Your API token might be expired, or might not have the necessary permissions. Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.");
                     } else if error.code == 6003 {
                         // 6003 error code = Invalid request headers. A common case is when the value of an authorization method has been changed outside of wrangler commands
-                        StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please consider re-authenticating wrangler through `wrangler login` or `wrangler config`.")
+                        StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.")
                     }
 
                 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -122,7 +122,7 @@ pub(crate) fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>> {
                     let error = &api_errors.errors[0];
                     if error.code == 9109 {
                         // 9109 error code = Invalid access token
-                        StdOut::info("Token might be expired or might not have the necessary permissions. Please consider running `wranger logout` or re-authenticate wrangler through `wrangler login` or `wrangler config`.");
+                        StdOut::info("Your API token might be expired, or might not have the necessary permissions. Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.");
                     } else if error.code == 6003 {
                         // 6003 error code = Invalid request headers. A common case is when the value of an authorization method has been changed outside of wrangler commands
                         StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please consider re-authenticating wrangler through `wrangler login` or `wrangler config`.")

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -116,7 +116,24 @@ pub(crate) fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>> {
     let response = client.request(&account::ListAccounts { params: None });
     match response {
         Ok(res) => Ok(res.result),
-        Err(e) => anyhow::bail!(http::format_error(e, None)),
+        Err(e) => {
+            match e {
+                ApiFailure::Error(_, ref api_errors) => {
+                    let error = &api_errors.errors[0];
+                    if error.code == 9109 {
+                        // 9109 error code = Invalid access token
+                        StdOut::info("Token might be expired or might not have the necessary permissions. Please consider running `wranger logout` or re-authenticate wrangler through `wrangler login` or `wrangler config`.");
+                    } else if error.code == 6003 {
+                        // 6003 error code = Invalid request headers. A common case is when the value of an authorization method has been changed outside of wrangler commands
+                        StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please consider re-authenticating wrangler through `wrangler login` or `wrangler config`.")
+                    }
+
+                }
+                ApiFailure::Invalid(_) => StdOut::info("Something went wrong in processing a request. Please consider raising an issue at https://github.com/cloudflare/wrangler/issues"),
+            }
+
+            anyhow::bail!(http::format_error(e, None))
+        }
     }
 }
 

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -125,7 +125,7 @@ pub(crate) fn fetch_accounts(user: &GlobalUser) -> Result<Vec<Account>> {
                         StdOut::info("Your API token might be expired, or might not have the necessary permissions. Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.");
                     } else if error.code == 6003 {
                         // 6003 error code = Invalid request headers. A common case is when the value of an authorization method has been changed outside of wrangler commands
-                        StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.")
+                        StdOut::info("Your authentication method might be corrupted (e.g. API token value has been altered). Please re-authenticate wrangler by running `wrangler login` or `wrangler config`.");
                     }
 
                 }


### PR DESCRIPTION
This should display more info when dev fails(issue #2054) because of invalid tokens or invalid request headers. 