### PR TITLE
fix: remove panic when send fails, log error instead

### DIFF
--- a/src/commands/dev/edge/server/http.rs
+++ b/src/commands/dev/edge/server/http.rs
@@ -85,8 +85,9 @@ pub async fn http(
     if let Err(e) = server.await {
         eprintln!("{}", e);
     }
-    tx.send(())
-        .expect("Could not acknowledge listener shutdown");
+    if let Err(e) = tx.send(()) {
+        log::error!("Could not acknowledge dev http listener shutdown: {:?}", e);
+    }
 
     Ok(())
 }

--- a/src/commands/dev/edge/server/https.rs
+++ b/src/commands/dev/edge/server/https.rs
@@ -119,8 +119,9 @@ pub async fn https(
     if let Err(e) = server.await {
         eprintln!("{}", e);
     }
-    tx.send(())
-        .expect("Could not acknowledge listener shutdown");
+    if let Err(e) = tx.send(()) {
+        log::error!("Could not acknowledge dev https listener shutdown: {:?}", e);
+    }
 
     Ok(())
 }

--- a/src/commands/dev/socket.rs
+++ b/src/commands/dev/socket.rs
@@ -421,7 +421,9 @@ async fn keep_alive(tx: mpsc::UnboundedSender<tungstenite::protocol::Message>) -
         let keep_alive_message = serde_json::to_string(&keep_alive_message)
             .expect("Could not convert keep alive message to JSON");
         let keep_alive_message = tungstenite::protocol::Message::Text(keep_alive_message);
-        tx.send(keep_alive_message).unwrap();
+        if let Err(e) = tx.send(keep_alive_message) {
+            log::error!("failed to send keepalive message: {}", e);
+        }
         id += 1;
         delay = sleep(duration);
     }

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -109,7 +109,9 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
                     if write_wranglerjs_output(&bundle, &wranglerjs_output, custom_webpack).is_ok()
                     {
                         if let Some(tx) = tx.clone() {
-                            tx.send(()).expect("--watch change message failed to send");
+                            if tx.send(()).is_err() {
+                                log::error!("wranglerjs watch operation failed to notify");
+                            }
                         }
                     }
                 }

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -109,8 +109,8 @@ pub fn run_build_and_watch(target: &Target, tx: Option<Sender<()>>) -> Result<()
                     if write_wranglerjs_output(&bundle, &wranglerjs_output, custom_webpack).is_ok()
                     {
                         if let Some(tx) = tx.clone() {
-                            if tx.send(()).is_err() {
-                                log::error!("wranglerjs watch operation failed to notify");
+                            if let Err(e) = tx.send(()) {
+                                log::error!("wranglerjs watch operation failed to notify: {}", e);
                             }
                         }
                     }


### PR DESCRIPTION
Removes the panic on send failure from the last remaining place for this particular `--watch` error. 