### PR TITLE
feat: remove warning about template type/generate param mismatch

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -116,11 +116,6 @@ impl Manifest {
             });
 
         config_template.warn_on_account_info();
-        if let Some(target_type) = &target_type {
-            if config_template.target_type != *target_type {
-                StdOut::warn(&format!("The template recommends the \"{}\" type. Using type \"{}\" may cause errors, we recommend changing the type field in wrangler.toml to \"{}\"", config_template.target_type, target_type, config_template.target_type));
-            }
-        }
 
         let default_workers_dev = match &config_template.route {
             Some(route) if route.is_empty() => Some(true),


### PR DESCRIPTION
`wrangler` provides a warning when a template used from the `generate` command has a different `type = "X"` configuration than the one that was passed to the command initially. 

I suppose this could be helpful, but in practice it's unlikely we should even need to care about this. The only way you get a template is from `wrangler generate --type X`, and we hardcode the location of these templates. Without `--type` provided, the user will get a `type = "javascript"` plain Worker project. If the user provides their own Git repo location as the last argument passed to `wrangler generate`, then there is no way to determine if there is a type mismatch (nor should we really care?) 

In particular is a bit annoying when using the new Rust template, since it's generated with `--type rust`, but uses a `type = "javascript"` so it can run a custom build. 

This PR removes the mismatch check and the corresponding warning. 