### PR TITLE
Allow the API endpoint to be configured via an environment variable

### DIFF
--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::time::Duration;
 
 use cloudflare::framework::async_api;
@@ -12,17 +13,37 @@ use crate::http::{feature::headers, DEFAULT_HTTP_TIMEOUT_SECONDS};
 use crate::settings::global_user::GlobalUser;
 use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
+
+const ENDPOINT_URL: &str = "ENDPOINT_URL";
+
+// Allow endpoint to be configured via an environment variable
+pub fn get_environment() -> Result<Environment> {
+    let env_hostname = match env::var(ENDPOINT_URL) {
+        Ok(value) => {
+            if let Ok(url) = url::Url::parse(&value) {
+                url
+            } else {
+                anyhow::bail!("Failed to parse URL from environment variable. Please make sure your API endpoint URL is valid.")
+            }
+        }
+        Err(_) => return Ok(Environment::Production),
+    };
+
+    Ok(Environment::Custom(env_hostname))
+}
+
 pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient> {
     let config = HttpApiClientConfig {
         http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
         default_headers: headers(None),
     };
 
-    HttpApiClient::new(
-        Credentials::from(user.to_owned()),
-        config,
-        Environment::Production,
-    )
+    let environment = match get_environment() {
+        Ok(env) => env,
+        Err(err) => anyhow::bail!(err),
+    };
+
+    HttpApiClient::new(Credentials::from(user.to_owned()), config, environment)
 }
 
 pub fn cf_v4_api_client_async(user: &GlobalUser) -> Result<async_api::Client> {
@@ -31,11 +52,12 @@ pub fn cf_v4_api_client_async(user: &GlobalUser) -> Result<async_api::Client> {
         default_headers: headers(None),
     };
 
-    async_api::Client::new(
-        Credentials::from(user.to_owned()),
-        config,
-        Environment::Production,
-    )
+    let environment = match get_environment() {
+        Ok(env) => env,
+        Err(err) => anyhow::bail!(err),
+    };
+
+    async_api::Client::new(Credentials::from(user.to_owned()), config, environment)
 }
 
 // Format errors from the cloudflare-rs cli for printing.

--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -14,11 +14,11 @@ use crate::settings::global_user::GlobalUser;
 use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
 
-const ENDPOINT_URL: &str = "ENDPOINT_URL";
+const ENDPOINT_BASE_URL: &str = "ENDPOINT_BASE_URL";
 
 // Allow endpoint to be configured via an environment variable
 pub fn get_environment() -> Result<Environment> {
-    let env_hostname = match env::var(ENDPOINT_URL) {
+    let env_hostname = match env::var(ENDPOINT_BASE_URL) {
         Ok(value) => {
             if let Ok(url) = url::Url::parse(&value) {
                 url
@@ -95,4 +95,46 @@ fn print_status_code_context(status_code: StatusCode) {
       StatusCode::GATEWAY_TIMEOUT => StdOut::warn("Returned status code 504, Gateway Timeout. Please try again in a few seconds"),
       _ => (),
   }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gets_environment_tests() {
+        // Tests are run in parallel, so dividing these three tests can lead
+        // to an undesired interleaving in set and unset of the environment variables.
+
+        // Test #1
+        // Tests that the API endpoint base URL can be read from an environment variable
+        let url = "https://github.com/cloudflare/wrangler";
+
+        env::set_var(ENDPOINT_BASE_URL, url);
+        let test_environment_url = url::Url::from(&get_environment().unwrap());
+
+        let expected_environment_url = url::Url::parse(url).unwrap();
+        assert_eq!(test_environment_url, expected_environment_url);
+        env::remove_var(ENDPOINT_BASE_URL);
+
+        // Test #2
+        // Tests that it fails with an invalid url
+        let url = "thisisaninvalidurl";
+
+        env::set_var(ENDPOINT_BASE_URL, url);
+        let test_environment = get_environment();
+
+        assert!(test_environment.is_err());
+        env::remove_var(ENDPOINT_BASE_URL);
+
+        // Test #3
+        // Tests that the API endpoint base URL is set to production if no environment variable is set
+
+        // unset the environment variable
+        env::remove_var(ENDPOINT_BASE_URL);
+        let test_environment_url = url::Url::from(&get_environment().unwrap());
+
+        let expected_environment_url = url::Url::from(&Environment::Production);
+        assert_eq!(test_environment_url, expected_environment_url);
+    }
 }

--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -14,11 +14,11 @@ use crate::settings::global_user::GlobalUser;
 use crate::terminal::emoji;
 use crate::terminal::message::{Message, StdOut};
 
-const ENDPOINT_BASE_URL: &str = "ENDPOINT_BASE_URL";
+const CF_API_BASE_URL: &str = "CF_API_BASE_URL";
 
 // Allow endpoint to be configured via an environment variable
 pub fn get_environment() -> Result<Environment> {
-    let env_hostname = match env::var(ENDPOINT_BASE_URL) {
+    let env_hostname = match env::var(CF_API_BASE_URL) {
         Ok(value) => {
             if let Ok(url) = url::Url::parse(&value) {
                 url
@@ -104,28 +104,28 @@ mod tests {
         // Tests that the API endpoint base URL can be read from an environment variable
         let url = "https://github.com/cloudflare/wrangler";
 
-        env::set_var(ENDPOINT_BASE_URL, url);
+        env::set_var(CF_API_BASE_URL, url);
         let test_environment_url = url::Url::from(&get_environment().unwrap());
 
         let expected_environment_url = url::Url::parse(url).unwrap();
         assert_eq!(test_environment_url, expected_environment_url);
-        env::remove_var(ENDPOINT_BASE_URL);
+        env::remove_var(CF_API_BASE_URL);
 
         // Test #2
         // Tests that it fails with an invalid url
         let url = "thisisaninvalidurl";
 
-        env::set_var(ENDPOINT_BASE_URL, url);
+        env::set_var(CF_API_BASE_URL, url);
         let test_environment = get_environment();
 
         assert!(test_environment.is_err());
-        env::remove_var(ENDPOINT_BASE_URL);
+        env::remove_var(CF_API_BASE_URL);
 
         // Test #3
         // Tests that the API endpoint base URL is set to production if no environment variable is set
 
         // unset the environment variable
-        env::remove_var(ENDPOINT_BASE_URL);
+        env::remove_var(CF_API_BASE_URL);
         let test_environment_url = url::Url::from(&get_environment().unwrap());
 
         let expected_environment_url = url::Url::from(&Environment::Production);

--- a/src/http/cf.rs
+++ b/src/http/cf.rs
@@ -38,10 +38,7 @@ pub fn cf_v4_client(user: &GlobalUser) -> Result<HttpApiClient> {
         default_headers: headers(None),
     };
 
-    let environment = match get_environment() {
-        Ok(env) => env,
-        Err(err) => anyhow::bail!(err),
-    };
+    let environment = get_environment()?;
 
     HttpApiClient::new(Credentials::from(user.to_owned()), config, environment)
 }
@@ -52,10 +49,7 @@ pub fn cf_v4_api_client_async(user: &GlobalUser) -> Result<async_api::Client> {
         default_headers: headers(None),
     };
 
-    let environment = match get_environment() {
-        Ok(env) => env,
-        Err(err) => anyhow::bail!(err),
-    };
+    let environment = get_environment()?;
 
     async_api::Client::new(Credentials::from(user.to_owned()), config, environment)
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3,6 +3,6 @@ pub(crate) mod feature;
 pub(self) mod legacy;
 
 pub const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 60;
-pub use cf::{cf_v4_api_client_async, cf_v4_client, format_error};
+pub use cf::{cf_v4_api_client_async, cf_v4_client, format_error, get_environment};
 pub use feature::Feature;
 pub use legacy::{client, featured_legacy_auth_client, legacy_auth_client};

--- a/src/kv/bulk.rs
+++ b/src/kv/bulk.rs
@@ -30,10 +30,7 @@ fn bulk_api_client(user: &GlobalUser) -> Result<HttpApiClient> {
         default_headers: headers(None),
     };
 
-    let environment = match http::get_environment() {
-        Ok(env) => env,
-        Err(err) => anyhow::bail!(err),
-    };
+    let environment = http::get_environment()?;
 
     HttpApiClient::new(Credentials::from(user.to_owned()), config, environment)
 }


### PR DESCRIPTION
Adds the option to configure the API endpoint through an environment variable.
For example, `export ENDPOINT_BASE_URL=some_url`.