### PR TITLE
Generate `compatibility_date` in `wrangler init` and warn if it's missing

### DIFF
--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -181,7 +181,7 @@ impl Manifest {
         }
 
         config_template_doc["compatibility_date"] =
-            toml_edit::value(format!("{}", Utc::now().format("%F")));
+            toml_edit::value(Utc::now().format("%F").to_string());
 
         // TODO: https://github.com/cloudflare/wrangler/issues/773
 

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use config::{Config, File};
 
 use anyhow::{anyhow, Result};
+use chrono::Utc;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_with::rust::string_empty_as_none;
@@ -171,6 +172,9 @@ impl Manifest {
                 }
             }
         }
+
+        config_template_doc["compatibility_date"] =
+            toml_edit::value(format!("{}", Utc::now().format("%F")));
 
         // TODO: https://github.com/cloudflare/wrangler/issues/773
 

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -94,6 +94,13 @@ impl Manifest {
 
         check_for_duplicate_names(&manifest)?;
 
+        if manifest.compatibility_date.is_none() {
+            StdOut::warn(&format!(
+                "Your configuration file is missing compatibility_date, so a distant past date is assumed. To get the latest possibly-breaking bug fixes, add this line to your wrangler.toml:\n\n    compatibility_date = \"{}\"\n",
+                Utc::now().format("%F")));
+            StdOut::warn("For more information about compatibility dates, see: https://developers.cloudflare.com/workers/platform/compatibility-dates");
+        }
+
         Ok(manifest)
     }
 


### PR DESCRIPTION
We'd like everyone to specify a `compatibility_date` in their `wrangler.toml` going forward. This change both adds the date automatically to newly-generated `wrangler.toml` files, and warns when parsing old ones that are missing it.

See also the documentation change: https://github.com/cloudflare/cloudflare-docs/pull/2289