### PR TITLE
Fixes wrangler.toml being incorrectly inserted into existing directory

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -35,7 +35,7 @@ pub fn generate(
     log::info!("Generating a new worker project with name '{}'", new_name);
     run_generate(&new_name, template)?;
 
-    let config_path = PathBuf::from("./").join(&name);
+    let config_path = PathBuf::from("./").join(&new_name);
     // TODO: this is tightly coupled to our site template. Need to remove once
     // we refine our generate logic.
     let generated_site = if site {

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -32,6 +32,30 @@ fn it_generates_with_arguments() {
     cleanup(name);
 }
 
+#[test]
+fn it_generates_toml_file_in_correct_directory() {
+    let name = "collision-example";
+    let expected_name = "collision-example-1";
+    let template = "https://github.com/cloudflare/rustwasm-worker-template";
+    let project_type = "webpack";
+    fs::create_dir_all(Path::new(name)).unwrap();
+
+    generate(Some(name), Some(template), Some(project_type));
+    assert_eq!(Path::new(expected_name).exists(), true);
+
+    let wranglertoml_path = format!("{}/wrangler.toml", expected_name);
+    assert_eq!(Path::new(&wranglertoml_path).exists(), true);
+
+    let wranglertoml_text = fs::read_to_string(wranglertoml_path).unwrap();
+    assert!(wranglertoml_text.contains(expected_name));
+
+    let unexpected_wranglertoml_path = format!("{}/wrangler.toml", name);
+    assert_eq!(Path::new(&unexpected_wranglertoml_path).exists(), false);
+
+    cleanup(name);
+    cleanup(expected_name);
+}
+
 pub fn generate(name: Option<&str>, template: Option<&str>, project_type: Option<&str>) {
     let mut wrangler = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     if name.is_none() && template.is_none() && project_type.is_none() {


### PR DESCRIPTION
Fixes #2051 by passing new_name rather than name to config_path path