### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -59,7 +59,7 @@ pub fn validate_credentials(user: &GlobalUser) -> Result<()> {
                 if success.result.status == "active" {
                     Ok(())
                 } else {
-                    anyhow::bail!("Authentication check failed. Your token has status \"{}\", not \"active\".\nTry rolling your token on the Cloudflare dashboard.")
+                    anyhow::bail!("Authentication check failed. Your token has status \"{}\", not \"active\".\nTry rolling your token on the Cloudflare dashboard.", success.result.status)
                 }
             }
             Err(e) => anyhow::bail!(

--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -44,7 +44,11 @@ pub fn run(
                 serde_json::from_str(&data);
             match keys_vec {
                 Ok(keys_vec) => keys_vec.iter().map(|kv| { kv.key.to_owned() }).collect(),
-                Err(_) => anyhow::bail!("Failed to decode JSON. Please make sure to follow the format, [{\"key\": \"test_key\", \"value\": \"test_value\"}, ...]")
+                Err(_) => {
+                    // Hide '{' in this error message from the formatting machinery in bail macro
+                    let msg = "Failed to decode JSON. Please make sure to follow the format, [{\"key\": \"test_key\", \"value\": \"test_value\"}, ...]";
+                    anyhow::bail!(msg);
+                }
             }
         }
         Ok(_) => anyhow::bail!("{} should be a JSON file, but is not", filename.display()),

--- a/src/commands/kv/bulk/delete.rs
+++ b/src/commands/kv/bulk/delete.rs
@@ -43,7 +43,7 @@ pub fn run(
             let keys_vec: Result<Vec<KeyValuePair>, serde_json::Error> =
                 serde_json::from_str(&data);
             match keys_vec {
-                Ok(keys_vec) => keys_vec.iter().map(|kv| { kv.key.to_owned() }).collect(),
+                Ok(keys_vec) => keys_vec.iter().map(|kv| kv.key.to_owned()).collect(),
                 Err(_) => {
                     // Hide '{' in this error message from the formatting machinery in bail macro
                     let msg = "Failed to decode JSON. Please make sure to follow the format, [{\"key\": \"test_key\", \"value\": \"test_value\"}, ...]";

--- a/src/commands/kv/bulk/put.rs
+++ b/src/commands/kv/bulk/put.rs
@@ -21,7 +21,11 @@ pub fn run(target: &Target, user: &GlobalUser, namespace_id: &str, filename: &Pa
             let data_vec = serde_json::from_str(&data);
             match data_vec {
                 Ok(data_vec) => Ok(data_vec),
-                Err(_) => Err(anyhow!("Failed to decode JSON. Please make sure to follow the format, [{{\"key\": \"test_key\", \"value\": \"test_value\"}}, ...]"))
+                Err(_) => {
+                    // Hide '{' in this error message from the formatting machinery in anyhow macro
+                    let msg = "Failed to decode JSON. Please make sure to follow the format, [{\"key\": \"test_key\", \"value\": \"test_value\"}, ...]";
+                    Err(anyhow!(msg))
+                }
             }
         }
         Ok(_) => Err(anyhow!(


### PR DESCRIPTION
- The first commit fills in a missing argument to `{}` in config.rs. Without this, the error message would literally be 'Your token has status "{}"' with curly braces in it instead of the token status.

- The second commit closes an inconsistency between how two places were doing bail macro args: the one in delete.rs used single `{` assuming the string would *not* get put into std::fmt, while the one in put.rs used double `{{` assuming that std::fmt *would* get applied to it. This change makes room for the bail macro to catch issues like this statically in a future version.

- The third commit is done by rustfmt; I am guessing the long line changed by the second commit previously made rustfmt fail out without formatting anything in the whole `match` expression.