### PR TITLE
1.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,97 @@
 # Changelog
 
+## v1.19.5
+
+- ## Features
+
+  - **add \_\_STATIC_CONTENT_MANIFEST as a text module for modules workers - [g45t345rt], [pull/2126]**
+
+    The `__STATIC_CONTENT_MANIFEST` is not accessible when using modules workers `[sites]`
+
+    This pr makes it possible to import the content of manifest as text.
+
+    It is also in favor of storing the manifest in vars
+    https://github.com/cloudf
+    ... truncated
+
+    [g45t345rt]: https://github.com/g45t345rt
+    [pull/2126]: https://github.com/cloudflare/wrangler/pull/2126
+
+- ## Maintenance
+
+  - **Bump os-version to 0.2.0 - [a1ien], [pull/2122]**
+
+    In 0.2 `os-version` use new stable version of `plist`
+    In plist 1.2.2(which is not published yet) remove chrono dependency and use time 0.3 which fix part of #2117
+
+    [a1ien]: https://github.com/a1ien
+    [pull/2122]: https://github.com/cloudflare/wrangler/pull/2122
+
+  - **Fix missing fmt argument in error message - [dtolnay], [pull/2118]**
+
+    - The first commit fills in a missing argument to `{}` in config.rs. Without this, the error message would literally be 'Your token has status "{}"' with curly braces in it instead of the token status.
+
+    - The second commit closes an incon
+      ... truncated
+
+    [dtolnay]: https://github.com/dtolnay
+    [pull/2118]: https://github.com/cloudflare/wrangler/pull/2118
+
+  - **Fix some migration errors - [xortive], [pull/2127]**
+
+    - Don't include migrations in Target for preview/dev uploads
+
+    [xortive]: https://github.com/xortive
+    [pull/2127]: https://github.com/cloudflare/wrangler/pull/2127
+
+  - **Fixes wrangler.toml being incorrectly inserted into existing directory - [Scotsoo], [pull/2110]**
+
+    Fixes #2051 by passing new_name rather than name to config_path path
+
+    [scotsoo]: https://github.com/Scotsoo
+    [pull/2110]: https://github.com/cloudflare/wrangler/pull/2110
+
+  - **Remove serde-hjson transitive dependency - [a1ien], [pull/2123]**
+
+    serde-hjson crate is not maintained anymore
+    With removing this dependency we also remove duplicate of old serde
+    Also in new version of `config` crate hjson also removed
+
+    [a1ien]: https://github.com/a1ien
+    [pull/2123]: https://github.com/cloudflare/wrangler/pull/2123
+
+  - **Remove unneeded heartbeat logic with sketchy time addition - [nataliescottdavidson], [pull/2129]**
+
+    [nataliescottdavidson]: https://github.com/nataliescottdavidson
+    [pull/2129]: https://github.com/cloudflare/wrangler/pull/2129
+
+  - **Remove unused eventual dependency - [a1ien], [pull/2119]**
+
+    This also fix part of #2117
+
+    [a1ien]: https://github.com/a1ien
+    [pull/2119]: https://github.com/cloudflare/wrangler/pull/2119
+
+  - **Update hash comment to changed XxHash64 usage - [dcousens], [pull/2124]**
+
+    As introduced in https://github.com/cloudflare/wrangler/pull/1221
+
+    [dcousens]: https://github.com/dcousens
+    [pull/2124]: https://github.com/cloudflare/wrangler/pull/2124
+
+  - **use --openssl-legacy-provider flag when running node 17 - [caass], [pull/2116]**
+
+    Closes #2108
+
+    Node 17 uses openssl 3 by default, which is not
+    compatible with webpack 4. This change adds a check to see if
+    the user is running node 17, and if they are, we add the appropriate
+    flag to the call to node (https://github.com/no
+    ... truncated
+
+    [caass]: https://github.com/caass
+    [pull/2116]: https://github.com/cloudflare/wrangler/pull/2116
+
 ## v1.19.4
 
 - ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 dependencies = [
  "backtrace",
 ]
@@ -121,9 +121,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-tools"
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a909e4d93292cd8e9c42e189f61681eff9d67b6541f96b8a1a737f23737bd001"
+checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
 dependencies = [
  "bytes 1.1.0",
  "memchr",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3b8db7f3341ddef15786d250106334d4a6c4b0ae4a46cd77082777d9849b9"
+checksum = "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
 dependencies = [
  "curl-sys",
  "libc",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.49+curl-7.79.1"
+version = "0.4.50+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483"
+checksum = "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
 dependencies = [
  "cc",
  "libc",
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "globset"
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1178,9 +1178,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libflate"
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -1727,9 +1727,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1747,18 +1747,18 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "111.16.0+1.1.1l"
+version = "300.0.2+3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "parity-ws"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab8a461779bd022964cae2b4989fa9c99deb270bec162da2125ec03c09fcaa"
+checksum = "5983d3929ad50f12c3eb9a6743f19d691866ecd44da74c0a3308c3f8a56df0c6"
 dependencies = [
  "byteorder",
  "bytes 0.4.12",
@@ -1850,9 +1850,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "plist"
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
@@ -1956,9 +1956,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -2123,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c732d463dd300362ffb44b7b125f299c23d2990411a4253824630ebc7467fb"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64",
  "bytes 1.1.0",
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -2373,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
  "rustversion",
  "serde",
@@ -2384,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "sys-info"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fcecee49339531cf6bd84ecf3ed94f9c8ef4a7e700f2a1cac9cc1ca485383a"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
@@ -2719,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fbf2dd23e79c28ccfa2472d3e6b3b189866ffef1aeb91f17c2d968b6586378"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "text_io"
@@ -2780,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2795,9 +2795,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes 1.1.0",
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2857,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2883,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "wrangler"
-version = "1.19.4"
+version = "1.19.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrangler"
-version = "1.19.4"
+version = "1.19.5"
 authors = ["The Wrangler Team <wrangler@cloudflare.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/npm/npm-shrinkwrap.json
+++ b/npm/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/wrangler",
-      "version": "1.19.4",
+      "version": "1.19.5",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/wrangler",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "description": "Command-line interface for all things Cloudflare Workers",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
## v1.19.5

- ## Features

  - **add \_\_STATIC_CONTENT_MANIFEST as a text module for modules workers - [g45t345rt], [pull/2126]**

    The `__STATIC_CONTENT_MANIFEST` is not accessible when using modules workers `[sites]`

    This pr makes it possible to import the content of manifest as text.

    It is also in favor of storing the manifest in vars
    https://github.com/cloudf
    ... truncated

    [g45t345rt]: https://github.com/g45t345rt
    [pull/2126]: https://github.com/cloudflare/wrangler/pull/2126

- ## Maintenance

  - **Bump os-version to 0.2.0 - [a1ien], [pull/2122]**

    In 0.2 `os-version` use new stable version of `plist`
    In plist 1.2.2(which is not published yet) remove chrono dependency and use time 0.3 which fix part of #2117

    [a1ien]: https://github.com/a1ien
    [pull/2122]: https://github.com/cloudflare/wrangler/pull/2122

  - **Fix missing fmt argument in error message - [dtolnay], [pull/2118]**

    - The first commit fills in a missing argument to `{}` in config.rs. Without this, the error message would literally be 'Your token has status "{}"' with curly braces in it instead of the token status.

    - The second commit closes an incon
      ... truncated

    [dtolnay]: https://github.com/dtolnay
    [pull/2118]: https://github.com/cloudflare/wrangler/pull/2118

  - **Fix some migration errors - [xortive], [pull/2127]**

    - Don't include migrations in Target for preview/dev uploads

    [xortive]: https://github.com/xortive
    [pull/2127]: https://github.com/cloudflare/wrangler/pull/2127

  - **Fixes wrangler.toml being incorrectly inserted into existing directory - [Scotsoo], [pull/2110]**

    Fixes #2051 by passing new_name rather than name to config_path path

    [scotsoo]: https://github.com/Scotsoo
    [pull/2110]: https://github.com/cloudflare/wrangler/pull/2110

  - **Remove serde-hjson transitive dependency - [a1ien], [pull/2123]**

    serde-hjson crate is not maintained anymore
    With removing this dependency we also remove duplicate of old serde
    Also in new version of `config` crate hjson also removed

    [a1ien]: https://github.com/a1ien
    [pull/2123]: https://github.com/cloudflare/wrangler/pull/2123

  - **Remove unneeded heartbeat logic with sketchy time addition - [nataliescottdavidson], [pull/2129]**

    [nataliescottdavidson]: https://github.com/nataliescottdavidson
    [pull/2129]: https://github.com/cloudflare/wrangler/pull/2129

  - **Remove unused eventual dependency - [a1ien], [pull/2119]**

    This also fix part of #2117

    [a1ien]: https://github.com/a1ien
    [pull/2119]: https://github.com/cloudflare/wrangler/pull/2119

  - **Update hash comment to changed XxHash64 usage - [dcousens], [pull/2124]**

    As introduced in https://github.com/cloudflare/wrangler/pull/1221

    [dcousens]: https://github.com/dcousens
    [pull/2124]: https://github.com/cloudflare/wrangler/pull/2124

  - **use --openssl-legacy-provider flag when running node 17 - [caass], [pull/2116]**

    Closes #2108

    Node 17 uses openssl 3 by default, which is not
    compatible with webpack 4. This change adds a check to see if
    the user is running node 17, and if they are, we add the appropriate
    flag to the call to node (https://github.com/no
    ... truncated

    [caass]: https://github.com/caass
    [pull/2116]: https://github.com/cloudflare/wrangler/pull/2116