### PR TITLE
Update version of cargo-generate

### DIFF
--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.10.0";
-pub const GENERATE_VERSION: &str = "0.5.0";
+pub const GENERATE_VERSION: &str = "0.11.0";


### PR DESCRIPTION
This fixes generating projects based on templates with a default branch other than "master".

Fixes https://github.com/cloudflare/wrangler/issues/1704.

It might make sense to eventually support passing a branch other than the default, but this at least fixes the hard error you get if the repo doesn't have a master branch.