### PR TITLE
Add `wrangler1` as an alias

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,8 @@
     "postinstall": "node ./install-wrangler.js"
   },
   "bin": {
-    "wrangler": "./run-wrangler.js"
+    "wrangler": "./run-wrangler.js",
+    "wrangler1": "./run-wrangler.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So that when @cloudflare/wrangler is installed along wrangler2, they can each be referenced in npm run scripts.

See https://github.com/cloudflare/wrangler2/pull/40