### PR TITLE
Update Rust toolchain to 1.57

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.54"
+channel = "1.57"
 components = ["rustfmt", "clippy"]

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -388,7 +388,7 @@ mod tests {
         .unwrap();
 
         let tmp_dir = tempdir().unwrap();
-        let tmp_config_path = test_config_dir(&tmp_dir, Some(user.clone())).unwrap();
+        let tmp_config_path = test_config_dir(&tmp_dir, Some(user)).unwrap();
 
         let mut temp_file = fs::OpenOptions::new()
             .append(true)
@@ -412,7 +412,7 @@ mod tests {
         let user_extra_toml = "refresh_token: \"thisisarefreshtoken\"";
 
         let tmp_dir = tempdir().unwrap();
-        let tmp_config_path = test_config_dir(&tmp_dir, Some(user.clone())).unwrap();
+        let tmp_config_path = test_config_dir(&tmp_dir, Some(user)).unwrap();
 
         let mut temp_file = fs::OpenOptions::new()
             .append(true)
@@ -442,7 +442,7 @@ mod tests {
         .unwrap();
 
         let tmp_dir = tempdir().unwrap();
-        let tmp_config_path = test_config_dir(&tmp_dir, Some(user.clone())).unwrap();
+        let tmp_config_path = test_config_dir(&tmp_dir, Some(user)).unwrap();
 
         let mut temp_file = fs::OpenOptions::new()
             .append(true)
@@ -467,7 +467,7 @@ mod tests {
         let user_extra_toml = "refresh_token: \"thisisarefreshtoken\"";
 
         let tmp_dir = tempdir().unwrap();
-        let tmp_config_path = test_config_dir(&tmp_dir, Some(user.clone())).unwrap();
+        let tmp_config_path = test_config_dir(&tmp_dir, Some(user)).unwrap();
 
         let mut temp_file = fs::OpenOptions::new()
             .append(true)

--- a/src/upload/package.rs
+++ b/src/upload/package.rs
@@ -11,8 +11,6 @@ const PACKAGE_JSON_KEY_ERROR_MODULE: &str = "The `module` key in your `package.j
 pub struct Package {
     #[serde(default)]
     main: PathBuf,
-    #[serde(default)]
-    module: PathBuf,
 }
 impl Package {
     pub fn main(&self, package_dir: &Path) -> Result<PathBuf> {


### PR DESCRIPTION
I originally updated my toolchain to 1.56.1 on a local branch, since afaict rust-analyzer wasn't able to work with derived StructOpt proc-macros in 1.54. Since 1.57 was released today, I figured I'd update it all the way in this pr.

followed example from #2017 

This commit can be replicated by updating rust-toolchain, then running
`cargo clippy --fix --allow-dirty`.