### PR TITLE
fix: incomplete binary with npm installation

### DIFF
--- a/npm/binary-install.js
+++ b/npm/binary-install.js
@@ -92,7 +92,21 @@ class Binary {
 
         return axios({ url: this.url, responseType: "stream" })
             .then(res => {
-                res.data.pipe(tar.x({ strip: 1, C: this.binaryDirectory }));
+                const writer = tar.x({ strip: 1, C: this.binaryDirectory });
+
+                return new Promise((resolve, reject) => {
+                    res.data.pipe(writer);
+                    let error = null;
+                    writer.on('error', err => {
+                      error = err;
+                      reject(err);
+                    });
+                    writer.on('close', () => {
+                      if (!error) {
+                        resolve(true);
+                      }
+                    });
+                })
             })
             .then(() => {
                 console.log(


### PR DESCRIPTION
 Closes #2148.
This PR modifies binary-install.js ([reference](https://stackoverflow.com/questions/55374755/node-js-axios-download-file-stream-and-writefile)) to make sure the file stream is complete before the program finishes.
I'm not an experienced JS developer (also a new OSS developer), so thank you for checking this PR. (If I screwed things up, just close this PR and use it as a reference)