### PR TITLE
Get the audit CI job passing

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+# See https://github.com/cloudflare/wrangler/issues/2117
+ignore = [
+    "RUSTSEC-2020-0159", # Potential segfault in `localtime_r` invocations
+    "RUSTSEC-2020-0071", # Potential segfault in the time crate
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".cargo/audit.toml"
       - "**/package-lock.json"
       - "**/npm-shrinkwrap.json"
   schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,9 +2795,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes 1.1.0",
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,7 +2993,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]


### PR DESCRIPTION
Note that I didn't say "fix the vulnerabilities" - this just ignores the `chrono` and `time` vulnerabilities because they're both very hard to fix and not very common in practice.

This uncovered a tokio vulnerability, which I've fixed by upgrading tokio.

cc https://github.com/cloudflare/wrangler/issues/2117