### PR TITLE
Revert "Don't look for background updates unless Wrangler finished successfully"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> Result<()> {
     }
     env_logger::init();
 
+    let latest_version_receiver = background_check_for_updates();
     if let Ok(me) = env::current_exe() {
         // If we're actually running as the installer then execute our
         // self-installation, otherwise just continue as usual.
@@ -35,7 +36,7 @@ fn main() -> Result<()> {
         }
     }
     run()?;
-    if let Ok(latest_version) = background_check_for_updates().try_recv() {
+    if let Ok(latest_version) = latest_version_receiver.try_recv() {
         let latest_version = styles::highlight(latest_version.to_string());
         let new_version_available = format!(
             "A new version of Wrangler ({}) is available!",


### PR DESCRIPTION
This reverts commit 45f5ab26383787ec1ac8f17fc78c1b8f4028d7da to avoid #2161.
It's unclear to me why that would have introduced a regression,
but this whole issue is actual Undefined Behavior according to the C
standard, so it's basically impossible to predict the behavior of the program from the source code. I unfortunately wasn't able to reproduce the regression locally so I'm not sure whether this helps or not.

cc @Electroid @threepointone