### PR TITLE
revert sites expiry stuff

### DIFF
--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::path::Path;
 
 use anyhow::Result;
-use cloudflare::endpoints::workerskv::write_bulk::KeyValuePair;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
@@ -11,7 +10,6 @@ use crate::build::build_target;
 use crate::deploy::{self, DeploymentSet};
 use crate::http::{self, Feature};
 use crate::kv::bulk;
-use crate::kv::key::get_value;
 use crate::settings::global_user::GlobalUser;
 use crate::settings::toml::migrations::{MigrationTag, Migrations};
 use crate::settings::toml::Target;
@@ -108,7 +106,7 @@ pub fn publish(
 
         run_deploy(target)?;
 
-        // Finally, mark any stale files for expiration
+        // Finally, remove any stale files
         if !to_delete.is_empty() {
             StdErr::info("Deleting stale files...");
 
@@ -122,35 +120,11 @@ pub fn publish(
                 None
             };
 
-            let account_id = target.account_id.load()?;
-
-            // create identical key:value pairs, except set them to expire in five minutes
-            // isn't this very slow? yes. can we do this in bulk? unfortunately as of now
-            // there isn't a KV endpoint for "bulk read".
-            // https://api.cloudflare.com/#workers-kv-namespace-properties
-            let five_minutes_from_now = chrono::Utc::now().timestamp() + (60 * 5);
-            let http_client = reqwest::blocking::Client::new();
-            let to_delete_pairs = to_delete
-                .into_iter()
-                .map(|key| {
-                    get_value(&key, &site_namespace.id, account_id, user, &http_client).map(
-                        // discard the timestamp to match wrangler2 implementation
-                        |(value, _)| KeyValuePair {
-                            key,
-                            value,
-                            expiration: Some(five_minutes_from_now),
-                            expiration_ttl: None,
-                            base64: None,
-                        },
-                    )
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            bulk::put(
+            bulk::delete(
                 target,
                 user,
                 &site_namespace.id,
-                to_delete_pairs,
+                to_delete,
                 &delete_progress_bar,
             )?;
 


### PR DESCRIPTION
After discussion with @threepointone  and @petebacondarwin  we've decided simply to revert back to the old behavior for workers-sites where we delete old assets, rather than marking them for expiration. This should resolve the issues our users were getting where their KV namespaces _exploded_ with files and caused deploys to hang (#2224)

- Revert "hotfix for expiring unused sites assets (#2226)"
- Revert "fix: expire unused assets on site upload (#2221)"
