### PR TITLE
Improve version checking for --openssl-legacy-provider

### DIFF
--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -328,7 +328,10 @@ fn use_legacy_openssl_if_necessary(command: &mut Command) -> Result<()> {
     let mut version_check_command = Command::new(&node);
     version_check_command.arg("--version");
     let result = version_check_command.output()?.stdout;
-    let need_legacy_openssl = String::from_utf8_lossy(&result)[1..3].parse::<i32>().unwrap() >= 17;
+    let need_legacy_openssl = String::from_utf8_lossy(&result)[1..3]
+        .parse::<i32>()
+        .unwrap()
+        >= 17;
 
     let mut option_exists_command = Command::new(&node);
     option_exists_command.arg("--help");

--- a/src/wranglerjs/mod.rs
+++ b/src/wranglerjs/mod.rs
@@ -315,11 +315,11 @@ fn random_chars(n: usize) -> String {
         .collect()
 }
 
-// If user is on Node 17, we may need legacy OpenSSL because Webpack 4 relies on
+// If user is on Node 17+, we may need legacy OpenSSL because Webpack 4 relies on
 // calls that were removed in OpenSSL 3. See:
 // https://github.com/cloudflare/wrangler/issues/2108
 // https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md#openssl-30
-// Node 17 can still be built against OpenSSL 1, in which case the option
+// Node 17+ can still be built against OpenSSL 1, in which case the option
 // doesn't exist. We need to check for that as well. See:
 // https://github.com/cloudflare/wrangler/issues/2155
 fn use_legacy_openssl_if_necessary(command: &mut Command) -> Result<()> {
@@ -328,7 +328,7 @@ fn use_legacy_openssl_if_necessary(command: &mut Command) -> Result<()> {
     let mut version_check_command = Command::new(&node);
     version_check_command.arg("--version");
     let result = version_check_command.output()?.stdout;
-    let need_legacy_openssl = String::from_utf8_lossy(&result).contains("v17");
+    let need_legacy_openssl = String::from_utf8_lossy(&result)[1..3].parse::<i32>().unwrap() >= 17;
 
     let mut option_exists_command = Command::new(&node);
     option_exists_command.arg("--help");


### PR DESCRIPTION
[Node v18 came out yesterday](https://nodejs.org/en/blog/announcements/v18-release-announce/) and I noticed that the [issue I reported last year](https://github.com/cloudflare/wrangler/issues/2108) returned. I quickly identified the problem and here is a patch for it. Instead of only checking for v17, it will now check for versions higher than that as well, ensuring the issue does not return again when Node v19 releases.

Note: This will stop working again when Node v100 releases. I expect Wrangler v1 to be fully replaced by v2 by that point.

If you approve of this fix, I would greatly appreciate a hotfix update as soon as you are able to release one.