### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ All of the arguments and flags to this command are optional:
 
 All information regarding wrangler or Cloudflare Workers is located in the [Cloudflare Workers Developer Docs](https://developers.cloudflare.com/workers/). This includes:
 
-- Using wrangler [commands](https://developers.cloudflare.com/workers/tooling/wrangler/commands)
-- Wrangler [configuration](https://developers.cloudflare.com/workers/tooling/wrangler/configuration)
+- Using wrangler [commands](https://developers.cloudflare.com/workers/wrangler/commands/)
+- Wrangler [configuration](https://developers.cloudflare.com/workers/wrangler/configuration)
 - General documentation surrounding Workers development
 - All wrangler features such as Workers Sites and KV
 


### PR DESCRIPTION
There are two links in README.md seems deprecated.

* `https://developers.cloudflare.com/workers/tooling/wrangler/commands` will result in 404

![](https://user-images.githubusercontent.com/24852034/167645655-a13ed544-adc9-4555-9970-a7a97404b7a3.png)

* `https://developers.cloudflare.com/workers/tooling/wrangler/configuration` can successfully redirect to `https://developers.cloudflare.com/workers/wrangler/configuration/`

![](https://user-images.githubusercontent.com/24852034/167645660-b726c136-cbbf-4940-9159-9aa065fd6cbd.png)
