### PR TITLE
Update path-slash to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "path-slash"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ oauth2 = "4.1"
 once_cell = "1"
 openssl = { version = "0.10.35", optional = true }
 os-version = "0.2.0"
-path-slash = "0.1.4"
+path-slash = "0.2.1"
 percent-encoding = "2.1.0"
 predicates = "2.0.0"
 prettytable-rs = "0.8.0"

--- a/src/upload/form/project_assets.rs
+++ b/src/upload/form/project_assets.rs
@@ -185,7 +185,8 @@ impl ModuleConfig {
             .map(|p| {
                 let p = p.as_ref();
                 p.strip_prefix(upload_dir).map(|p_stripped_prefix| {
-                    let p_stripped_prefix: PathBuf = p_stripped_prefix.to_slash_lossy().into();
+                    let p_stripped_prefix: PathBuf =
+                        p_stripped_prefix.to_slash_lossy().into_owned().into();
                     // we convert the path used for matching and names to a slash path
                     // so globs are the same on all platforms
                     // to_slash_lossy() strips non-unicode characters in the path on windows


### PR DESCRIPTION
Hi, I'm author of path-slash crate.

I noticed this big project uses older version of path-slash so I created this PR to update the version. In path-slash v0.2, `to_slash_lossy` returns `Cow` and allocates memory only when it is necessary so this change may be able to save some heap allocations.